### PR TITLE
Shops phase: Add featured section, modal preview, and trust signals

### DIFF
--- a/shops.css
+++ b/shops.css
@@ -245,6 +245,125 @@
   color: var(--color-text-faint, #555);
 }
 
+/* ── Featured section ───────────────────────────────────────────────────── */
+.shops-featured {
+  padding: 1.25rem;
+}
+
+.shops-featured-title {
+  font-size: clamp(1.1rem, 2.2vw, 1.3rem);
+  font-weight: 700;
+  color: var(--color-text, #e8e0cc);
+  margin: 0 0 1rem;
+}
+
+.shops-featured-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.9rem;
+}
+
+.featured-card {
+  background: var(--color-surface, #1a1814);
+  border: 1px solid rgba(212, 160, 23, 0.28);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  display: grid;
+  gap: 0.55rem;
+  transition: transform 0.18s, box-shadow 0.18s, border-color 0.18s;
+  cursor: pointer;
+}
+
+.featured-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(212, 160, 23, 0.15), 0 2px 6px rgba(0, 0, 0, 0.2);
+  border-color: rgba(212, 160, 23, 0.45);
+}
+
+.featured-header {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.featured-header h3 {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--color-text, #e8e0cc);
+  margin: 0;
+  line-height: 1.25;
+}
+
+.featured-location {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #888);
+  font-weight: 500;
+}
+
+.featured-market {
+  font-size: 0.82rem;
+  color: var(--color-gold, #d4a017);
+  font-weight: 600;
+  margin: 0;
+}
+
+.featured-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.featured-tag {
+  font-size: 0.68rem;
+  padding: 0.15rem 0.5rem;
+  background: rgba(212, 160, 23, 0.08);
+  border: 1px solid rgba(212, 160, 23, 0.2);
+  border-radius: var(--radius-pill);
+  color: var(--color-text-muted, #888);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* ── Filter pills ────────────────────────────────────────────────────────── */
+.shops-filter-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.4rem;
+}
+
+.shops-filter-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.7rem;
+  background: rgba(212, 160, 23, 0.12);
+  border: 1px solid rgba(212, 160, 23, 0.28);
+  border-radius: var(--radius-pill);
+  color: var(--color-gold, #d4a017);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 32px;
+  transition: background 0.18s, border-color 0.18s;
+  font-family: var(--font-main, inherit);
+}
+
+.shops-filter-pill:hover {
+  background: rgba(212, 160, 23, 0.2);
+  border-color: rgba(212, 160, 23, 0.4);
+}
+
+.shops-filter-pill-remove {
+  font-size: 0.95rem;
+  font-weight: 700;
+  opacity: 0.7;
+  transition: opacity 0.18s;
+}
+
+.shops-filter-pill:hover .shops-filter-pill-remove {
+  opacity: 1;
+}
+
 /* ── Results header ──────────────────────────────────────────────────────── */
 .shops-results {
   padding-top: 1.25rem;
@@ -347,19 +466,40 @@
   gap: 0.65rem;
 }
 
+/* ── Card badges ─────────────────────────────────────────────────────────– */
+.shop-card-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.3rem;
+}
+
 .shop-card h3 {
   font-size: 0.98rem;
   font-weight: 700;
   color: var(--color-text, #e8e0cc);
   line-height: 1.3;
-  margin: 0 0 0.25rem;
+  margin: 0;
+}
+
+.shop-cluster-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.63rem;
+  font-weight: 700;
+  color: rgba(255, 248, 234, 0.75);
+  background: rgba(180, 100, 0, 0.18);
+  border: 1px solid rgba(180, 100, 0, 0.3);
+  border-radius: var(--radius-pill);
+  padding: 0.15rem 0.45rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
 }
 
 .shop-featured {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  margin-top: 0.2rem;
   font-size: 0.68rem;
   font-weight: 700;
   color: var(--color-gold-dark, #b8860b);
@@ -377,14 +517,37 @@
 
 .shop-signal {
   flex-shrink: 0;
-  font-size: 0.68rem;
-  font-weight: 600;
+  font-size: 0.65rem;
+  font-weight: 700;
   color: var(--color-text-muted, #888);
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid var(--color-border, #2e2b24);
   border-radius: var(--radius-pill);
   padding: 0.22rem 0.6rem;
   white-space: nowrap;
+  text-transform: capitalize;
+}
+
+.shop-signal--full {
+  color: rgba(76, 175, 80, 0.8);
+  background: rgba(76, 175, 80, 0.08);
+  border-color: rgba(76, 175, 80, 0.2);
+}
+
+.shop-signal--partial {
+  color: rgba(255, 193, 7, 0.8);
+  background: rgba(255, 193, 7, 0.08);
+  border-color: rgba(255, 193, 7, 0.2);
+}
+
+.shop-signal--limited {
+  color: rgba(244, 67, 54, 0.7);
+  background: rgba(244, 67, 54, 0.08);
+  border-color: rgba(244, 67, 54, 0.2);
+}
+
+.shop-card--cluster {
+  border-color: rgba(180, 100, 0, 0.22);
 }
 
 /* ── Card meta grid ──────────────────────────────────────────────────────── */
@@ -627,6 +790,16 @@
   .shops-stat-value {
     font-size: 1.1rem;
   }
+  .shops-featured {
+    padding: 0.85rem;
+  }
+  .shops-featured-grid {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  }
+  .shops-modal-content {
+    padding: 1.5rem;
+    max-height: 90vh;
+  }
 }
 
 @media (max-width: 540px) {
@@ -639,6 +812,256 @@
   .shops-hero-stats {
     grid-template-columns: 1fr;
   }
+  .shops-featured-grid {
+    grid-template-columns: 1fr;
+  }
+  .shops-modal {
+    padding: 0.5rem;
+  }
+  .shops-modal-content {
+    padding: 1.25rem;
+    border-radius: var(--radius-md);
+  }
+  .shops-modal-close {
+    top: 0.8rem;
+    right: 0.8rem;
+    font-size: 1.5rem;
+  }
+  #shops-modal-title {
+    font-size: 1.1rem;
+  }
+}
+
+/* ── Modal ───────────────────────────────────────────────────────────────── */
+.shops-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.shops-modal-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+  cursor: pointer;
+}
+
+.shops-modal-content {
+  position: relative;
+  z-index: 1001;
+  background: var(--color-surface, #1a1814);
+  border: 1px solid var(--color-border, #2e2b24);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  max-width: 600px;
+  width: 100%;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.5);
+}
+
+.shops-modal-close {
+  position: absolute;
+  top: 1.2rem;
+  right: 1.2rem;
+  background: none;
+  border: none;
+  font-size: 1.8rem;
+  color: var(--color-text-muted, #888);
+  cursor: pointer;
+  padding: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.18s;
+}
+
+.shops-modal-close:hover {
+  color: var(--color-text, #e8e0cc);
+}
+
+[dir="rtl"] .shops-modal-close {
+  right: auto;
+  left: 1.2rem;
+}
+
+#shops-modal-title {
+  font-size: 1.3rem;
+  font-weight: 800;
+  color: var(--color-text, #e8e0cc);
+  margin: 0 0 0.5rem;
+  line-height: 1.2;
+}
+
+.modal-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.2rem;
+}
+
+.modal-cluster-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: rgba(255, 248, 234, 0.75);
+  background: rgba(180, 100, 0, 0.18);
+  border: 1px solid rgba(180, 100, 0, 0.3);
+  border-radius: var(--radius-pill);
+  padding: 0.25rem 0.65rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.modal-details-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  border-radius: var(--radius-pill);
+  padding: 0.25rem 0.65rem;
+  letter-spacing: 0.03em;
+  text-transform: capitalize;
+}
+
+.modal-details-full {
+  color: rgba(76, 175, 80, 0.85);
+  background: rgba(76, 175, 80, 0.1);
+  border: 1px solid rgba(76, 175, 80, 0.25);
+}
+
+.modal-details-partial {
+  color: rgba(255, 193, 7, 0.85);
+  background: rgba(255, 193, 7, 0.1);
+  border: 1px solid rgba(255, 193, 7, 0.25);
+}
+
+.modal-details-limited {
+  color: rgba(244, 67, 54, 0.75);
+  background: rgba(244, 67, 54, 0.1);
+  border: 1px solid rgba(244, 67, 54, 0.25);
+}
+
+.modal-featured-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--color-gold-dark, #b8860b);
+  background: rgba(212, 160, 23, 0.12);
+  border: 1px solid rgba(212, 160, 23, 0.28);
+  border-radius: var(--radius-pill);
+  padding: 0.25rem 0.65rem;
+  letter-spacing: 0.03em;
+}
+
+.modal-meta {
+  display: grid;
+  gap: 0.8rem;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--color-border, #2e2b24);
+  border-radius: var(--radius-md);
+}
+
+.modal-meta-item {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.modal-meta-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-faint, #555);
+}
+
+.modal-meta-value {
+  font-size: 0.95rem;
+  color: var(--color-text, #e8e0cc);
+  line-height: 1.4;
+}
+
+.modal-tags {
+  margin-bottom: 1.5rem;
+}
+
+.modal-tags-label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-faint, #555);
+  margin-bottom: 0.5rem;
+}
+
+.modal-tags-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.modal-tags-wrap .shop-tag {
+  font-size: 0.75rem;
+}
+
+.modal-notes {
+  font-size: 0.95rem;
+  color: var(--color-text-muted, #888);
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+.modal-notes p {
+  margin: 0;
+}
+
+.modal-contact {
+  border-top: 1px solid var(--color-border, #2e2b24);
+  padding-top: 1.2rem;
+}
+
+.modal-contact p {
+  font-size: 0.9rem;
+  color: var(--color-text, #e8e0cc);
+  margin: 0 0 0.5rem;
+}
+
+.modal-contact p:last-child {
+  margin: 0;
+}
+
+.modal-contact .shop-site-link {
+  color: var(--color-gold, #d4a017);
+  font-weight: 700;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.modal-contact .shop-site-link:hover {
+  text-decoration: underline;
+}
+
+.modal-no-contact {
+  font-size: 0.88rem;
+  color: var(--color-text-muted, #888);
+  border-top: 1px solid var(--color-border, #2e2b24);
+  padding-top: 1.2rem;
+  margin: 0;
 }
 
 /* ── RTL overrides ───────────────────────────────────────────────────────── */

--- a/shops.html
+++ b/shops.html
@@ -71,11 +71,19 @@
       </div>
     </section>
 
+    <section id="shops-featured" class="shops-featured" aria-labelledby="shops-featured-title" hidden>
+      <div class="shops-results-inner">
+        <h2 id="shops-featured-title" class="shops-featured-title">Featured Markets</h2>
+        <div id="shops-featured-grid" class="shops-featured-grid"></div>
+      </div>
+    </section>
+
     <section class="shops-results" aria-labelledby="shops-results-title">
       <div class="shops-results-inner">
         <div class="shops-results-head">
           <div class="shops-results-head-left">
             <h2 id="shops-results-title">Listed Shops</h2>
+            <div id="shops-filter-pills" class="shops-filter-pills"></div>
             <p id="shops-active-filters" class="shops-active-filters"></p>
           </div>
           <p id="shops-count" aria-live="polite"></p>
@@ -111,6 +119,14 @@
       </div>
     </section>
   </main>
+
+  <div id="shops-modal" class="shops-modal" hidden aria-labelledby="shops-modal-title" role="dialog" aria-modal="true">
+    <div class="shops-modal-overlay"></div>
+    <div class="shops-modal-content">
+      <button class="shops-modal-close" aria-label="Close details" type="button">×</button>
+      <div id="shops-modal-body"></div>
+    </div>
+  </div>
 
   <script type="module" src="./shops.js"></script>
 </body>

--- a/shops.js
+++ b/shops.js
@@ -62,6 +62,7 @@ const TXT = {
     noContact: 'Business details where available',
     visitWebsite: 'Visit website',
     featured: 'Featured market',
+    marketCluster: 'Market area cluster',
     infoTitle: 'How to use this directory',
     info1Title: 'Compare by market area',
     info1Body: 'Start with a country or city filter, then compare listed markets and specialties side by side.',
@@ -108,6 +109,7 @@ const TXT = {
     noContact: 'تفاصيل النشاط متاحة عند توفرها',
     visitWebsite: 'زيارة الموقع',
     featured: 'سوق مميز',
+    marketCluster: 'مجموعة متاجر بسوق',
     infoTitle: 'كيفية استخدام هذا الدليل',
     info1Title: 'قارن حسب منطقة السوق',
     info1Body: 'ابدأ بفلتر الدولة أو المدينة، ثم قارن الأسواق المدرجة والتخصصات بسهولة.',
@@ -138,6 +140,74 @@ function detailsAvailabilityLabel(value) {
   if (value === 'full') return t('detailsFull');
   if (value === 'partial') return t('detailsPartial');
   return t('detailsLimited');
+}
+
+function isMarketCluster(shop) {
+  // Market clusters typically have "cluster", "shops", "dealers", "area", or "market" in notes
+  // and empty phone/website
+  return !shop.phone && !shop.website &&
+         (shop.notes?.toLowerCase().includes('cluster') ||
+          shop.notes?.toLowerCase().includes('concentration') ||
+          shop.notes?.toLowerCase().includes('area'));
+}
+
+function openModal(shop) {
+  const modal = document.getElementById('shops-modal');
+  const country = countryByCode(shop.countryCode);
+  const specialties = (shop.specialties || []).map((item) => `<span class="shop-tag">${item}</span>`).join('');
+
+  const contactHTML = shop.phone || shop.website ?
+    `<div class="modal-contact">
+      ${shop.phone ? `<p><strong>${t('phone')}:</strong> ${shop.phone}</p>` : ''}
+      ${shop.website ? `<p><a href="${shop.website}" target="_blank" rel="noopener" class="shop-site-link">${t('visitWebsite')} →</a></p>` : ''}
+    </div>` :
+    `<p class="modal-no-contact">${t('noContact')}</p>`;
+
+  const clusterBadge = isMarketCluster(shop) ?
+    `<span class="modal-cluster-badge">${t('marketCluster')}</span>` : '';
+
+  document.getElementById('shops-modal-body').innerHTML = `
+    <div class="modal-head">
+      <h2 id="shops-modal-title">${shop.name}</h2>
+      <div class="modal-badges">
+        ${clusterBadge}
+        <span class="modal-details-badge modal-details-${shop.detailsAvailability}">${t('detailsSignal')}: ${detailsAvailabilityLabel(shop.detailsAvailability)}</span>
+        ${shop.featured ? `<span class="modal-featured-badge">★ ${t('featured')}</span>` : ''}
+      </div>
+    </div>
+
+    <div class="modal-meta">
+      <div class="modal-meta-item">
+        <span class="modal-meta-label">${t('location')}</span>
+        <span class="modal-meta-value">${shop.city}, ${countryName(country)} · ${regionName(country.group)}</span>
+      </div>
+      <div class="modal-meta-item">
+        <span class="modal-meta-label">${t('market')}</span>
+        <span class="modal-meta-value">${shop.market}</span>
+      </div>
+      <div class="modal-meta-item">
+        <span class="modal-meta-label">${t('category')}</span>
+        <span class="modal-meta-value">${shop.category}</span>
+      </div>
+    </div>
+
+    ${specialties ? `<div class="modal-tags">
+      <span class="modal-tags-label">${t('specialties')}</span>
+      <div class="modal-tags-wrap">${specialties}</div>
+    </div>` : ''}
+
+    <div class="modal-notes">
+      <p>${shop.notes}</p>
+    </div>
+
+    ${contactHTML}
+  `;
+
+  modal.hidden = false;
+}
+
+function closeModal() {
+  document.getElementById('shops-modal').hidden = true;
 }
 
 function applyStaticText() {
@@ -329,9 +399,11 @@ function activeFilterSummary() {
 
 function renderCards(shops) {
   const grid = document.getElementById('shops-grid');
-  grid.innerHTML = shops.map((shop) => {
+  grid.innerHTML = shops.map((shop, idx) => {
     const country = countryByCode(shop.countryCode);
     const specialties = (shop.specialties || []).map((item) => `<span class="shop-tag">${item}</span>`).join('');
+    const isCluster = isMarketCluster(shop);
+    const clusterBadge = isCluster ? `<span class="shop-cluster-badge">${t('marketCluster')}</span>` : '';
 
     const contactParts = [];
     if (shop.phone) contactParts.push(`${t('phone')}: ${shop.phone}`);
@@ -340,13 +412,16 @@ function renderCards(shops) {
     }
 
     return `
-      <article class="shop-card${shop.featured ? ' shop-card--featured' : ''}">
+      <article class="shop-card${shop.featured ? ' shop-card--featured' : ''}${isCluster ? ' shop-card--cluster' : ''}" data-shop-id="${shop.id}" style="cursor: pointer;">
         <header class="shop-card-head">
           <div>
             <h3>${shop.name}</h3>
-            ${shop.featured ? `<span class="shop-featured">${t('featured')}</span>` : ''}
+            <div class="shop-card-badges">
+              ${clusterBadge}
+              ${shop.featured ? `<span class="shop-featured">${t('featured')}</span>` : ''}
+            </div>
           </div>
-          <span class="shop-signal">${t('detailsSignal')}: ${detailsAvailabilityLabel(shop.detailsAvailability)}</span>
+          <span class="shop-signal shop-signal--${shop.detailsAvailability}">${detailsAvailabilityLabel(shop.detailsAvailability)}</span>
         </header>
 
         <div class="shop-meta-grid">
@@ -365,14 +440,98 @@ function renderCards(shops) {
       </article>
     `;
   }).join('');
+
+  // Bind click handlers to open modal
+  grid.querySelectorAll('.shop-card').forEach((card) => {
+    card.addEventListener('click', () => {
+      const shopId = card.dataset.shopId;
+      const shop = SHOPS.find((s) => s.id === shopId);
+      if (shop) openModal(shop);
+    });
+  });
+}
+
+function renderFeaturedSection() {
+  const featuredSection = document.getElementById('shops-featured');
+  const featuredGrid = document.getElementById('shops-featured-grid');
+  const featured = SHOPS.filter((shop) => shop.featured);
+
+  if (!featured.length) {
+    featuredSection.hidden = true;
+    return;
+  }
+
+  featuredSection.hidden = false;
+  featuredGrid.innerHTML = featured.map((shop) => {
+    const country = countryByCode(shop.countryCode);
+    const specialties = (shop.specialties || []).slice(0, 2).map((item) => `<span class="featured-tag">${item}</span>`).join('');
+    return `
+      <article class="featured-card" data-shop-id="${shop.id}" style="cursor: pointer;">
+        <div class="featured-header">
+          <h3>${shop.name}</h3>
+          <span class="featured-location">${shop.city} · ${countryName(country)}</span>
+        </div>
+        <p class="featured-market">${shop.market}</p>
+        <div class="featured-tags">${specialties}</div>
+      </article>
+    `;
+  }).join('');
+
+  // Bind click handlers
+  featuredGrid.querySelectorAll('.featured-card').forEach((card) => {
+    card.addEventListener('click', () => {
+      const shopId = card.dataset.shopId;
+      const shop = SHOPS.find((s) => s.id === shopId);
+      if (shop) openModal(shop);
+    });
+  });
+}
+
+function renderFilterPills() {
+  const pillsContainer = document.getElementById('shops-filter-pills');
+  const pills = [];
+
+  if (STATE.region !== 'all') pills.push({ type: 'region', value: STATE.region, label: regionName(STATE.region) });
+  if (STATE.country !== 'all') {
+    const country = countryByCode(STATE.country);
+    if (country) pills.push({ type: 'country', value: STATE.country, label: countryName(country) });
+  }
+  if (STATE.city !== 'all') pills.push({ type: 'city', value: STATE.city, label: STATE.city });
+  if (STATE.specialty !== 'all') pills.push({ type: 'specialty', value: STATE.specialty, label: STATE.specialty });
+
+  if (!pills.length) {
+    pillsContainer.innerHTML = '';
+    return;
+  }
+
+  pillsContainer.innerHTML = pills.map((pill) => `
+    <button class="shops-filter-pill" data-type="${pill.type}" data-value="${pill.value}" type="button">
+      ${pill.label}
+      <span class="shops-filter-pill-remove">×</span>
+    </button>
+  `).join('');
+
+  pillsContainer.querySelectorAll('.shops-filter-pill').forEach((pill) => {
+    pill.addEventListener('click', () => {
+      const type = pill.dataset.type;
+      if (type === 'region') STATE.region = 'all';
+      if (type === 'country') STATE.country = 'all';
+      if (type === 'city') STATE.city = 'all';
+      if (type === 'specialty') STATE.specialty = 'all';
+      buildFilters();
+      render();
+    });
+  });
 }
 
 function render() {
   const shops = filterShops();
   const empty = document.getElementById('shops-empty');
   const count = document.getElementById('shops-count');
-if (count) count.textContent = t('count')(shops.length);
+  if (count) count.textContent = t('count')(shops.length);
   activeFilterSummary();
+  renderFilterPills();
+  renderFeaturedSection();
 
   if (!shops.length) {
     document.getElementById('shops-grid').innerHTML = '';
@@ -431,6 +590,23 @@ function bindEvents() {
   });
 
   document.getElementById('shops-clear-filters').addEventListener('click', resetFilters);
+
+  // Modal events
+  const modal = document.getElementById('shops-modal');
+  const modalClose = document.getElementById('shops-modal-close') || modal.querySelector('.shops-modal-close');
+  const modalOverlay = modal.querySelector('.shops-modal-overlay');
+
+  if (modalClose) {
+    modalClose.addEventListener('click', closeModal);
+  }
+
+  if (modalOverlay) {
+    modalOverlay.addEventListener('click', closeModal);
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !modal.hidden) closeModal();
+  });
 }
 
 function updateLanguage() {


### PR DESCRIPTION
High-impact discovery improvements:
- Featured Markets section above results with clickable cards
- Quick preview modal: click any shop card to see full details
- Market-area cluster badges to distinguish clusters from shops
- Active filter pills (removable) above results
- Color-coded trust signals (limited/partial/full) on cards and modal
- Better card visual hierarchy with badges
- Responsive featured grid and modal

These changes transform shops.html from a static directory into a genuine listings/discovery page that encourages exploration and increases trust through clear information hierarchy and interaction patterns.

No data changes - all listings remain accurate and unpadded.

https://claude.ai/code/session_014tHAn2j4BCVTRTTCF4zz5J