### PR TITLE
PHASE 3B: Separate tracker state mode into view + activeTool axes

### DIFF
--- a/tracker-pro.js
+++ b/tracker-pro.js
@@ -6,6 +6,7 @@ import * as calc from './lib/price-calculator.js';
 import * as fmt from './lib/formatter.js';
 import * as alertsLib from './lib/alerts.js';
 import { createInitialState, persistState } from './tracker/state.js';
+import { applyUrlState } from './tracker/state.js';
 import { mountShell, updateShellTickerFromState } from './tracker/ui-shell.js';
 import { fetchWire, renderWire as renderWireModule } from './tracker/wire.js';
 import { getUnifiedHistory, filterByRange, getHistoryStats } from './lib/historical-data.js';
@@ -119,7 +120,8 @@ function bindCoreEvents() {
 
   // Reset view
   el.resetBtn?.addEventListener('click', () => {
-    state.mode = 'live';
+    state.view = 'live';
+    state.activeTool = null;
     state.selectedCurrency = 'AED';
     state.selectedKarat = '24';
     state.selectedUnit = 'gram';
@@ -407,6 +409,13 @@ async function init() {
   await refreshData(false);
   renderAll();
   if (state.autoRefresh) startAutoRefresh();
+
+  // Add hashchange listener for back/forward button support
+  window.addEventListener('hashchange', () => {
+    applyUrlState(state);
+    shellCtrl.updateTabsAndPanels();
+    renderAll();
+  });
 }
 
 async function refreshData(forceLive = true) {
@@ -1053,21 +1062,25 @@ function renderAll() {
 
   renderHero();
 
-  if (state.mode === 'live') {
+  // Render view content
+  if (state.view === 'live') {
     renderMiniStrip();
     renderChart();
     renderKaratTable();
     renderMarkets();
     renderWatchlist();
     renderDecisionCues();
-  } else if (state.mode === 'compare') {
+  } else if (state.view === 'compare') {
     renderMarkets();
-  } else if (state.mode === 'archive') {
+  } else if (state.view === 'archive') {
     renderArchive();
-  } else if (state.mode === 'alerts') {
+  }
+
+  // Render active tool overlay (if any)
+  if (state.activeTool === 'alerts') {
     renderAlerts();
     renderPresets();
-  } else if (state.mode === 'planner') {
+  } else if (state.activeTool === 'planner') {
     renderPlanners();
   }
 

--- a/tracker/state.js
+++ b/tracker/state.js
@@ -11,7 +11,8 @@ export const STORAGE_KEYS = {
 
 export const DEFAULT_STATE = {
   lang: 'en',
-  mode: 'live',
+  view: 'live',
+  activeTool: null,
   selectedCurrency: 'AED',
   selectedKarat: '24',
   selectedUnit: 'gram',
@@ -90,7 +91,8 @@ export function createInitialState() {
   // Tracker-specific saved state
   const saved = readLocal(STORAGE_KEYS.core, {});
   base.lang = saved.lang || readLanguagePref() || base.lang;
-  base.mode = saved.mode || base.mode;
+  base.view = saved.view || base.view;
+  base.activeTool = saved.activeTool || base.activeTool;
   base.selectedCurrency = saved.selectedCurrency || base.selectedCurrency;
   base.selectedKarat = saved.selectedKarat || base.selectedKarat;
   base.selectedUnit = saved.selectedUnit || base.selectedUnit;
@@ -117,7 +119,8 @@ export function createInitialState() {
 export function persistState(state) {
   const payload = {
     lang: state.lang,
-    mode: state.mode,
+    view: state.view,
+    activeTool: state.activeTool,
     selectedCurrency: state.selectedCurrency,
     selectedKarat: state.selectedKarat,
     selectedUnit: state.selectedUnit,
@@ -137,19 +140,39 @@ export function persistState(state) {
 
 export function syncUrlFromState(state) {
   const url = new URL(window.location.href);
-  url.hash = `mode=${state.mode}&cur=${state.selectedCurrency}&k=${state.selectedKarat}&u=${state.selectedUnit}&r=${state.range}&cmp=${state.compareCurrency}`;
+  let hash = `view=${state.view}&cur=${state.selectedCurrency}&k=${state.selectedKarat}&u=${state.selectedUnit}&range=${state.range}&cmp=${state.compareCurrency}`;
+  if (state.activeTool) {
+    hash += `&tool=${state.activeTool}`;
+  }
+  url.hash = hash;
   history.replaceState(null, '', url.toString());
 }
 
-function applyUrlState(state) {
+export function applyUrlState(state) {
   const hash = window.location.hash.slice(1);
   if (!hash) return;
   const params = new URLSearchParams(hash);
-  state.mode = params.get('mode') || state.mode;
+
+  // Handle both new format (view/tool) and old format (mode) for backward compat
+  const viewOrMode = params.get('view') || params.get('mode');
+  if (viewOrMode) {
+    // Map old mode values to new view/tool split
+    if (viewOrMode === 'alerts') {
+      state.view = 'live';
+      state.activeTool = 'alerts';
+    } else if (viewOrMode === 'planner') {
+      state.view = 'live';
+      state.activeTool = 'planner';
+    } else {
+      state.view = viewOrMode;
+    }
+  }
+
+  state.activeTool = params.get('tool') || state.activeTool;
   state.selectedCurrency = params.get('cur') || state.selectedCurrency;
   state.selectedKarat = params.get('k') || state.selectedKarat;
   state.selectedUnit = params.get('u') || state.selectedUnit;
-  state.range = params.get('r') || state.range;
+  state.range = params.get('range') || params.get('r') || state.range;
   state.compareCurrency = params.get('cmp') || state.compareCurrency;
 }
 

--- a/tracker/ui-shell.js
+++ b/tracker/ui-shell.js
@@ -27,28 +27,71 @@ export function mountShell(state, els, onModeChange, onLangChange) {
   const tabs = Array.from(document.querySelectorAll('.tracker-mode-tab'));
   const panels = Array.from(document.querySelectorAll('.tracker-mode-panel'));
 
-  function setMode(mode) {
-    state.mode = mode;
-    tabs.forEach(tab => {
-      const active = tab.dataset.mode === mode;
-      tab.classList.toggle('is-active', active);
-      tab.setAttribute('aria-selected', active ? 'true' : 'false');
-    });
-    panels.forEach(panel => {
-      const active = panel.dataset.modePanel === mode;
-      panel.hidden = !active;
-    });
+  function setView(view) {
+    state.view = view;
+    // When switching views, close any open tool
+    state.activeTool = null;
+    updateTabsAndPanels();
     persistState(state);
     syncUrlFromState(state);
-    if (typeof onModeChange === 'function') onModeChange(mode);
+    if (typeof onModeChange === 'function') onModeChange(`view:${view}`);
+  }
+
+  function setActiveTool(tool) {
+    // Toggle tool: clicking active tool closes it, clicking different tool switches to that tool
+    state.activeTool = state.activeTool === tool ? null : tool;
+    updateTabsAndPanels();
+    persistState(state);
+    syncUrlFromState(state);
+    if (typeof onModeChange === 'function') onModeChange(`tool:${state.activeTool}`);
+  }
+
+  function updateTabsAndPanels() {
+    tabs.forEach(tab => {
+      const modeValue = tab.dataset.mode;
+      const isViewTab = ['live', 'archive', 'compare'].includes(modeValue);
+      const isToolTab = ['alerts', 'planner'].includes(modeValue);
+
+      let isActive = false;
+      if (isViewTab && modeValue === state.view && !state.activeTool) {
+        isActive = true;
+      } else if (isToolTab && modeValue === state.activeTool) {
+        isActive = true;
+      }
+
+      tab.classList.toggle('is-active', isActive);
+      tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    });
+
+    panels.forEach(panel => {
+      const modeValue = panel.dataset.modePanel;
+      const isViewPanel = ['live', 'archive', 'compare'].includes(modeValue);
+      const isToolPanel = ['alerts', 'planner'].includes(modeValue);
+
+      let isActive = false;
+      if (isViewPanel && modeValue === state.view) {
+        isActive = true;
+      } else if (isToolPanel && modeValue === state.activeTool) {
+        isActive = true;
+      }
+
+      panel.hidden = !isActive;
+    });
   }
 
   tabs.forEach(tab => {
-    tab.addEventListener('click', () => setMode(tab.dataset.mode));
+    tab.addEventListener('click', () => {
+      const mode = tab.dataset.mode;
+      if (['live', 'archive', 'compare'].includes(mode)) {
+        setView(mode);
+      } else if (['alerts', 'planner'].includes(mode)) {
+        setActiveTool(mode);
+      }
+    });
   });
 
   // Initial mode selection
-  setMode(state.mode || 'live');
+  updateTabsAndPanels();
 
   // Keyboard shortcuts
   window.addEventListener('keydown', evt => {
@@ -57,21 +100,17 @@ export function mountShell(state, els, onModeChange, onLangChange) {
     if (key === 'r') {
       els.refreshBtn?.click();
     } else if (key === 'h') {
-      setMode('live');
+      setView('live');
     } else if (key === 'c') {
-      setMode('compare');
+      setView('compare');
     } else if (key === 'a') {
-      setMode('alerts');
+      setActiveTool('alerts');
     } else if (key === 'p') {
-      setMode('planner');
-    } else if (key === 'x') {
-      setMode('exports');
-    } else if (key === 'm') {
-      setMode('method');
+      setActiveTool('planner');
     }
   });
 
-  return { setMode };
+  return { setView, setActiveTool, updateTabsAndPanels };
 }
 
 export function updateShellTickerFromState(state, spot, priceFor) {


### PR DESCRIPTION
- Replace state.mode field with view (live|archive|compare) + activeTool (alerts|planner|null)
- Update DEFAULT_STATE in tracker/state.js with new field structure
- Refactor persistState() to save both view and activeTool fields
- Update applyUrlState() to read new hash format (view/tool) with backward-compat for old format
- Refactor syncUrlFromState() to encode view=X&tool=Y syntax (tool param optional)
- Create setView() and setActiveTool() functions in ui-shell.js to replace monolithic setMode()
- Update tab/panel rendering logic to handle orthogonal view + tool dimensions
- Refactor renderAll() in tracker-pro.js to render view content first, then conditionally render tool
- Remove keyboard shortcuts for non-existent modes ('x' and 'm')
- Add export for applyUrlState() in state.js
- Add hashchange event listener in tracker-pro.js init() for back/forward button support
- Fix reset button to set both view and activeTool fields
- Update exports from ui-shell to include new functions and updateTabsAndPanels

Benefits:
- Views (live/archive/compare) now orthogonal to tools (alerts/planner)
- Can combine any view with any tool
- Simpler URL encoding with clearer semantics
- Hash changes (back/forward) now properly update UI via hashchange listener

https://claude.ai/code/session_013rJZazAVJ2UTHiEadQEz97