### PR TITLE
Fix 3 bugs and improve shops trust language

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -15,5 +15,6 @@ export const CONSTANTS = {
     dayOpen: 'gold_day_open',
     history: 'gold_price_history',
     userPrefs: 'user_prefs',
+    alerts: 'gold_price_alerts',
   },
 };

--- a/config/countries.js
+++ b/config/countries.js
@@ -1,38 +1,38 @@
 export const COUNTRIES = [
   // GCC
   {
-    code: 'AE', nameEn: 'United Arab Emirates', nameAr: 'الإمارات العربية المتحدة',
+    code: 'AE', slug: 'uae', nameEn: 'United Arab Emirates', nameAr: 'الإمارات العربية المتحدة',
     currency: 'AED', flag: '🇦🇪', group: 'gcc', decimals: 2, fixedPeg: true,
     searchAliases: ['uae', 'emirates', 'aed', 'الإمارات', 'امارات', 'إمارات'],
   },
   {
-    code: 'SA', nameEn: 'Saudi Arabia', nameAr: 'المملكة العربية السعودية',
+    code: 'SA', slug: 'saudi-arabia', nameEn: 'Saudi Arabia', nameAr: 'المملكة العربية السعودية',
     currency: 'SAR', flag: '🇸🇦', group: 'gcc', decimals: 2, fixedPeg: false,
     searchAliases: ['saudi', 'sa', 'sar', 'السعودية', 'سعودية', 'المملكة'],
   },
   {
-    code: 'KW', nameEn: 'Kuwait', nameAr: 'الكويت',
+    code: 'KW', slug: 'kuwait', nameEn: 'Kuwait', nameAr: 'الكويت',
     currency: 'KWD', flag: '🇰🇼', group: 'gcc', decimals: 3, fixedPeg: false,
     searchAliases: ['kuwait', 'kw', 'kwd', 'الكويت', 'كويت'],
   },
   {
-    code: 'QA', nameEn: 'Qatar', nameAr: 'قطر',
+    code: 'QA', slug: 'qatar', nameEn: 'Qatar', nameAr: 'قطر',
     currency: 'QAR', flag: '🇶🇦', group: 'gcc', decimals: 2, fixedPeg: false,
     searchAliases: ['qatar', 'qa', 'qar', 'قطر'],
   },
   {
-    code: 'BH', nameEn: 'Bahrain', nameAr: 'البحرين',
+    code: 'BH', slug: 'bahrain', nameEn: 'Bahrain', nameAr: 'البحرين',
     currency: 'BHD', flag: '🇧🇭', group: 'gcc', decimals: 3, fixedPeg: false,
     searchAliases: ['bahrain', 'bh', 'bhd', 'البحرين', 'بحرين'],
   },
   {
-    code: 'OM', nameEn: 'Oman', nameAr: 'عُمان',
+    code: 'OM', slug: 'oman', nameEn: 'Oman', nameAr: 'عُمان',
     currency: 'OMR', flag: '🇴🇲', group: 'gcc', decimals: 3, fixedPeg: false,
     searchAliases: ['oman', 'om', 'omr', 'عمان', 'عُمان'],
   },
   // Levant
   {
-    code: 'JO', nameEn: 'Jordan', nameAr: 'الأردن',
+    code: 'JO', slug: 'jordan', nameEn: 'Jordan', nameAr: 'الأردن',
     currency: 'JOD', flag: '🇯🇴', group: 'levant', decimals: 3, fixedPeg: false,
     searchAliases: ['jordan', 'jo', 'jod', 'الأردن', 'أردن'],
   },
@@ -53,7 +53,7 @@ export const COUNTRIES = [
   },
   // North & East Africa
   {
-    code: 'EG', nameEn: 'Egypt', nameAr: 'مصر',
+    code: 'EG', slug: 'egypt', nameEn: 'Egypt', nameAr: 'مصر',
     currency: 'EGP', flag: '🇪🇬', group: 'africa', decimals: 2, fixedPeg: false,
     searchAliases: ['egypt', 'eg', 'egp', 'مصر'],
   },
@@ -73,7 +73,7 @@ export const COUNTRIES = [
     searchAliases: ['algeria', 'dz', 'dzd', 'الجزائر', 'جزائر'],
   },
   {
-    code: 'MA', nameEn: 'Morocco', nameAr: 'المغرب',
+    code: 'MA', slug: 'morocco', nameEn: 'Morocco', nameAr: 'المغرب',
     currency: 'MAD', flag: '🇲🇦', group: 'africa', decimals: 2, fixedPeg: false,
     searchAliases: ['morocco', 'ma', 'mad', 'المغرب', 'مغرب'],
   },
@@ -119,7 +119,7 @@ export const COUNTRIES = [
     searchAliases: ['europe', 'eu', 'eur', 'eurozone', 'منطقة اليورو', 'يورو', 'أوروبا'],
   },
   {
-    code: 'IN', nameEn: 'India', nameAr: 'الهند',
+    code: 'IN', slug: 'india', nameEn: 'India', nameAr: 'الهند',
     currency: 'INR', flag: '🇮🇳', group: 'global', decimals: 2, fixedPeg: false,
     searchAliases: ['india', 'in', 'inr', 'الهند', 'هند'],
   },

--- a/shops.html
+++ b/shops.html
@@ -46,7 +46,7 @@
         <div class="shops-hero-stats" aria-label="Directory overview">
           <div class="shops-stat">
             <span class="shops-stat-value" id="shops-stat-listings">0</span>
-            <span class="shops-stat-label" id="shops-stat-listings-label">Listed shops</span>
+            <span class="shops-stat-label" id="shops-stat-listings-label">Listed markets</span>
           </div>
           <div class="shops-stat">
             <span class="shops-stat-value" id="shops-stat-countries">0</span>

--- a/shops.js
+++ b/shops.js
@@ -39,7 +39,7 @@ const TXT = {
     title: 'Explore Gold Shops & Known Gold Markets',
     lead: 'Browse directory listings across countries covered on GoldPrices. Use filters to narrow by region, country, city, and specialty. Shop information is for reference, and business details are shown where available.',
     trustBanner: 'Directory updated regularly · Updated {date}',
-    statListings: 'Listed shops',
+    statListings: 'Listed markets',
     statCountries: 'Countries',
     statRegions: 'Regions',
     popularMarkets: 'Popular markets',
@@ -49,7 +49,7 @@ const TXT = {
     country: 'Country',
     city: 'City',
     specialtyFilter: 'Specialty',
-    listed: 'Listed Shops',
+    listed: 'Listed Markets',
     allRegions: 'All regions',
     allCountries: 'All countries',
     allCities: 'All cities',
@@ -70,7 +70,7 @@ const TXT = {
     detailsPartial: 'Partially available',
     detailsLimited: 'Limited',
     detailsFull: 'Available',
-    noContact: 'Business details where available',
+    noContact: 'Contact details not yet listed',
     visitWebsite: 'Visit website',
     featured: 'Featured market',
     marketCluster: 'Market area cluster',
@@ -98,7 +98,7 @@ const TXT = {
     title: 'استكشف محلات الذهب والأسواق المعروفة',
     lead: 'تصفح إدراجات الدليل ضمن الدول التي يغطيها GoldPrices. استخدم الفلاتر حسب المنطقة والدولة والمدينة والتخصص. معلومات المحلات مرجعية، وتظهر تفاصيل النشاط حيثما كانت متاحة.',
     trustBanner: 'يتم تحديث الدليل بانتظام · تم التحديث {date}',
-    statListings: 'المحلات المدرجة',
+    statListings: 'الأسواق المدرجة',
     statCountries: 'الدول',
     statRegions: 'المناطق',
     popularMarkets: 'أسواق شائعة',
@@ -108,7 +108,7 @@ const TXT = {
     country: 'الدولة',
     city: 'المدينة',
     specialtyFilter: 'التخصص',
-    listed: 'المحلات المدرجة',
+    listed: 'الأسواق المدرجة',
     allRegions: 'كل المناطق',
     allCountries: 'كل الدول',
     allCities: 'كل المدن',
@@ -129,7 +129,7 @@ const TXT = {
     detailsPartial: 'متوفرة جزئياً',
     detailsLimited: 'محدودة',
     detailsFull: 'متوفرة',
-    noContact: 'تفاصيل النشاط متاحة عند توفرها',
+    noContact: 'بيانات الاتصال غير مدرجة بعد',
     visitWebsite: 'زيارة الموقع',
     featured: 'سوق مميز',
     marketCluster: 'مجموعة متاجر بسوق',
@@ -587,7 +587,7 @@ function renderCards(shops) {
             <span class="shop-action-icon">📞</span>
             <span class="shop-action-label">${t('callShop')}</span>
           </a>` : ''}
-          ${country ? `<a href="countries/${country.code}.html" class="shop-action-btn shop-action-btn--country" aria-label="${t('viewCountryPage')}: ${countryName(country)}">
+          ${country?.slug ? `<a href="countries/${country.slug}.html" class="shop-action-btn shop-action-btn--country" aria-label="${t('viewCountryPage')}: ${countryName(country)}">
             <span class="shop-action-icon">📄</span>
             <span class="shop-action-label">${countryName(country)}</span>
           </a>` : ''}

--- a/tracker/state.js
+++ b/tracker/state.js
@@ -132,6 +132,7 @@ export function persistState(state) {
     activeRegion: state.activeRegion,
   };
   writeLocal(STORAGE_KEYS.core, payload);
+  writeLocal(CONSTANTS.CACHE_KEYS.alerts, state.alerts.slice(0, 50));
   writeLocal(STORAGE_KEYS.presets, state.presets.slice(0, 20));
   writeLocal(STORAGE_KEYS.watchlist, state.favorites.slice(0, 32));
   writeLocal(STORAGE_KEYS.wire, state.wireItems.slice(0, 32));

--- a/tracker/ui-shell.js
+++ b/tracker/ui-shell.js
@@ -60,6 +60,7 @@ export function mountShell(state, els, onModeChange, onLangChange) {
   // Keyboard shortcuts
   window.addEventListener('keydown', evt => {
     if (evt.altKey || evt.metaKey || evt.ctrlKey) return;
+    if (['INPUT', 'TEXTAREA', 'SELECT'].includes(evt.target.tagName)) return;
     const key = evt.key.toLowerCase();
     if (key === 'r') {
       els.refreshBtn?.click();


### PR DESCRIPTION
Bug fixes:
- Fix broken country-page links in shops directory (used country code instead of URL slug, e.g. countries/AE.html → countries/uae.html)
- Fix tracker alerts silently lost on page reload (alerts were read from localStorage but never written back in persistState)
- Fix keyboard shortcuts firing inside text inputs on tracker page

Trust language:
- Change "Listed shops" to "Listed markets" (listings are market-area clusters, not individual stores)
- Change "Business details where available" to "Contact details not yet listed" (no listings have phone/website data)
- Update Arabic translations to match

https://claude.ai/code/session_014pCS4oc4XHVrhmoSuAASvU