### PR TITLE
Phase 2: UX honesty — disable stubs, fix nav, remove fake legend

### DIFF
--- a/components/nav-data.js
+++ b/components/nav-data.js
@@ -13,9 +13,9 @@ export const NAV_DATA = {
         items: [
           { href: '../tracker.html',                   label: 'Live Tracker'   },
           { href: '../countries/uae.html',             label: 'UAE Gold Today' },
-          { href: '../tracker.html#section-countries', label: 'GCC Compare'    },
-          { href: '../tracker.html#section-countries', label: 'Country Pages'  },
-          { href: '../tracker.html#section-chart',     label: 'History & Data' },
+          { href: '../tracker.html#mode=compare',        label: 'GCC Compare'    },
+          { href: '../tracker.html#mode=compare',        label: 'Country Pages'  },
+          { href: '../tracker.html#mode=archive',        label: 'History & Data' },
         ],
       },
       {
@@ -23,10 +23,10 @@ export const NAV_DATA = {
         label: 'Tools',
         items: [
           { href: '../calculator.html',                label: 'Calculator'   },
-          { href: '../tracker.html#section-alerts',    label: 'Alerts'       },
-          { href: '../tracker.html#section-chart',     label: 'Downloads'    },
-          { href: '../tracker.html#section-chart',     label: 'Date Lookup'  },
-          { href: '../tracker.html#section-chart',     label: 'Archive'      },
+          { href: '../tracker.html#mode=alerts',         label: 'Alerts'       },
+          { href: '../tracker.html#mode=exports',        label: 'Downloads'    },
+          { href: '../tracker.html#mode=archive',        label: 'Date Lookup'  },
+          { href: '../tracker.html#mode=archive',        label: 'Archive'      },
         ],
       },
       {
@@ -86,9 +86,9 @@ export const NAV_DATA = {
         items: [
           { href: '../tracker.html',                   label: 'تتبع مباشر'          },
           { href: '../countries/uae.html',             label: 'ذهب الإمارات'        },
-          { href: '../tracker.html#section-countries', label: 'مقارنة دول الخليج'   },
-          { href: '../tracker.html#section-countries', label: 'صفحات الدول'         },
-          { href: '../tracker.html#section-chart',     label: 'البيانات التاريخية'   },
+          { href: '../tracker.html#mode=compare',        label: 'مقارنة دول الخليج'   },
+          { href: '../tracker.html#mode=compare',        label: 'صفحات الدول'         },
+          { href: '../tracker.html#mode=archive',        label: 'البيانات التاريخية'   },
         ],
       },
       {
@@ -96,10 +96,10 @@ export const NAV_DATA = {
         label: 'أدوات',
         items: [
           { href: '../calculator.html',                label: 'حاسبة'             },
-          { href: '../tracker.html#section-alerts',    label: 'تنبيهات'           },
-          { href: '../tracker.html#section-chart',     label: 'تنزيلات'           },
-          { href: '../tracker.html#section-chart',     label: 'البحث بالتاريخ'    },
-          { href: '../tracker.html#section-chart',     label: 'الأرشيف'           },
+          { href: '../tracker.html#mode=alerts',         label: 'تنبيهات'           },
+          { href: '../tracker.html#mode=exports',        label: 'تنزيلات'           },
+          { href: '../tracker.html#mode=archive',        label: 'البحث بالتاريخ'    },
+          { href: '../tracker.html#mode=archive',        label: 'الأرشيف'           },
         ],
       },
       {

--- a/style.css
+++ b/style.css
@@ -1627,6 +1627,7 @@ main {
 .btn-ghost:hover { background: var(--color-surface-2); color: var(--color-text); }
 .btn-sm { padding: 0.4rem 1rem; font-size: 0.82rem; min-height: 34px; }
 .btn-lg { padding: 0.75rem 1.9rem; font-size: 0.98rem; min-height: 50px; }
+.btn:disabled { opacity: 0.45; cursor: not-allowed; pointer-events: none; }
 
 /* ═══════════════════════════════════════════════
    FAQ (global — used on home, learn, country pages)

--- a/tracker.html
+++ b/tracker.html
@@ -294,7 +294,7 @@
               </p>
             </div>
             <div class="tracker-head-actions">
-              <button type="button" class="btn btn-sm btn-outline" id="tp-export-chart">
+              <button type="button" class="btn btn-sm btn-outline" id="tp-export-chart" disabled title="Not yet available">
                 Export visible chart CSV
               </button>
               <button type="button" class="btn btn-sm btn-ghost" id="tp-download-json">
@@ -308,10 +308,6 @@
               <span class="tracker-legend-item">
                 <span class="tracker-legend-dot"></span>
                 <span id="tp-legend-main">Selected series</span>
-              </span>
-              <span class="tracker-legend-item">
-                <span class="tracker-legend-dot compare"></span>
-                <span id="tp-legend-compare">Compare series</span>
               </span>
             </div>
             <div class="tracker-mini-strip" id="tp-mini-strip"></div>
@@ -374,7 +370,7 @@
           <div class="tracker-watchlist-block" aria-label="Market watchlist">
             <div class="tracker-subpanel-head">
               <h3>Market watchlist</h3>
-              <button type="button" class="btn btn-sm btn-outline" id="tp-export-watchlist">
+              <button type="button" class="btn btn-sm btn-outline" id="tp-export-watchlist" disabled title="Not yet available">
                 Export watchlist CSV
               </button>
             </div>
@@ -771,7 +767,7 @@
           <article class="tracker-subpanel">
             <div class="tracker-subpanel-head"><h3>Visible chart CSV</h3></div>
             <p>Exports only the currently visible chart slice with range, mode, and source-layer annotations.</p>
-            <button class="btn btn-outline" id="tp-export-chart-2" type="button">
+            <button class="btn btn-outline" id="tp-export-chart-2" type="button" disabled title="Not yet available">
               Export visible chart CSV
             </button>
           </article>
@@ -779,7 +775,7 @@
           <article class="tracker-subpanel">
             <div class="tracker-subpanel-head"><h3>Current view CSV</h3></div>
             <p>Snapshot of the current currency/karat/unit across markets, matching the compare board ordering.</p>
-            <button class="btn btn-outline" id="tp-export-current" type="button">
+            <button class="btn btn-outline" id="tp-export-current" type="button" disabled title="Not yet available">
               Download current view CSV
             </button>
           </article>
@@ -808,7 +804,7 @@
           <article class="tracker-subpanel">
             <div class="tracker-subpanel-head"><h3>Market brief text</h3></div>
             <p>Export the current market brief as plain text, suitable for email or note-taking.</p>
-            <button class="btn btn-outline" id="tp-download-brief" type="button">
+            <button class="btn btn-outline" id="tp-download-brief" type="button" disabled title="Not yet available">
               Download brief
             </button>
           </article>

--- a/tracker/events.js
+++ b/tracker/events.js
@@ -190,8 +190,7 @@ export function bindCoreEvents() {
   _el.exportHistory2?.addEventListener('click', () => _cb.exportHistoryData());
   _el.downloadJson?.addEventListener('click', () => _cb.exportJsonData());
   _el.downloadJson2?.addEventListener('click', () => _cb.exportJsonData());
-  [_el.exportChart, _el.exportChart2, _el.exportCurrent, _el.exportWatchlist, _el.downloadBrief]
-    .forEach(btn => btn?.addEventListener('click', () => _cb.showToast('Export not available for this section yet.')));
+  // exportChart, exportChart2, exportCurrent, exportWatchlist, downloadBrief are disabled in HTML until implemented
 
   // Alert list: delete button delegation
   _el.alertList?.addEventListener('click', (e) => {


### PR DESCRIPTION
- Disable 5 unimplemented export buttons (chart CSV, watchlist CSV, current view CSV, brief) with disabled attr + title="Not yet available" instead of showing a "not available" toast on click
- Add .btn:disabled CSS rule (opacity 0.45, cursor not-allowed)
- Remove compare chart legend entry that implied a second data series on the chart which does not exist
- Fix nav dropdown links: replace dead #section-* anchors with working #mode=X hash params that actually switch the tracker tab (compare, archive, alerts, exports)

https://claude.ai/code/session_014pCS4oc4XHVrhmoSuAASvU