### PR TITLE
Phase 3: Fix chart distortion on mobile

### DIFF
--- a/tracker-pro.js
+++ b/tracker-pro.js
@@ -7,7 +7,7 @@ import { createInitialState, persistState } from './tracker/state.js';
 import { mountShell } from './tracker/ui-shell.js';
 import { fetchWire, renderWire as renderWireModule } from './tracker/wire.js';
 import { getUnifiedHistory } from './lib/historical-data.js';
-import { initRender, renderAll, renderMarkets, renderAlerts, renderPresets, renderPlanners, renderArchive } from './tracker/render.js';
+import { initRender, renderAll, renderChart, renderMarkets, renderAlerts, renderPresets, renderPlanners, renderArchive } from './tracker/render.js';
 import { initEvents, bindCoreEvents } from './tracker/events.js';
 
 const state = createInitialState();
@@ -343,6 +343,15 @@ async function init() {
   await refreshData(false);
   renderAll();
   if (state.autoRefresh) startAutoRefresh();
+
+  // Redraw chart on resize so viewBox stays in sync with container dimensions
+  let _resizeTimer = null;
+  window.addEventListener('resize', () => {
+    clearTimeout(_resizeTimer);
+    _resizeTimer = setTimeout(() => {
+      if (state.mode === 'live') renderChart();
+    }, 150);
+  });
 }
 
 init();

--- a/tracker.html
+++ b/tracker.html
@@ -314,7 +314,7 @@
           </div>
 
           <div class="tracker-chart-wrap" aria-label="Gold price chart" role="group">
-            <svg id="tp-chart" viewBox="0 0 1200 430" preserveAspectRatio="none"></svg>
+            <svg id="tp-chart" viewBox="0 0 1200 430"></svg>
             <div class="tracker-tooltip" id="tp-tooltip" role="status" aria-live="polite"></div>
             <div class="tracker-chart-empty" id="tp-chart-empty" hidden>
               <p>Waiting for live and history data…</p>

--- a/tracker/render.js
+++ b/tracker/render.js
@@ -82,7 +82,9 @@ export function renderChart() {
   const prices = rows.map(r => r.spot);
   const min = Math.min(...prices) * 0.998;
   const max = Math.max(...prices) * 1.002;
-  const W = 1200, H = 430;
+  const W = (_el.chartWrap?.clientWidth || 1200);
+  const H = (_el.chartWrap?.clientHeight || 430);
+  _el.chart.setAttribute('viewBox', `0 0 ${W} ${H}`);
   const pts = rows.map((r, i) => {
     const x = (i / (rows.length - 1)) * W;
     const y = H - ((r.spot - min) / (max - min)) * (H - 40) - 20;


### PR DESCRIPTION
- Remove preserveAspectRatio="none" from SVG element; it caused the chart to stretch/squish the data into whatever the container shape was
- renderChart() now reads actual container dimensions (clientWidth/Height) and sets the SVG viewBox to match, so data points always fill the available space at the correct proportions
- Add debounced resize listener (150ms) to redraw the chart when the window resizes (covers orientation change on mobile)
- Import renderChart in tracker-pro.js for use by the resize handler

Fallback: if container reports 0 dimensions (e.g. tab not visible), W/H default to 1200/430 as before.

https://claude.ai/code/session_014pCS4oc4XHVrhmoSuAASvU