### PR TITLE
Fix relative paths for assets and internal links on city/market pages

### DIFF
--- a/countries/egypt/cities/cairo.html
+++ b/countries/egypt/cities/cairo.html
@@ -12,12 +12,12 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/egypt/cities/cairo.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../countries/country-page.css" />
-  <link rel="stylesheet" href="../../cities/city-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../countries/country-page.css" />
+  <link rel="stylesheet" href="../../../cities/city-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -61,11 +61,11 @@
 
     <section class="cp-section">
       <div class="cp-tools-row">
-        <a href="../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
-        <a href="../../tracker.html" class="related-tool-link">📈 Live Tracker</a>
-        <a href="../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
-        <a href="../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
-        <a href="../../countries/egypt.html" class="related-tool-link">🇪🇬 Egypt Gold Overview</a>
+        <a href="../../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
+        <a href="../../../tracker.html" class="related-tool-link">📈 Live Tracker</a>
+        <a href="../../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
+        <a href="../../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
+        <a href="../../../countries/egypt.html" class="related-tool-link">🇪🇬 Egypt Gold Overview</a>
       </div>
     </section>
 
@@ -84,7 +84,7 @@
         <h2>Key Gold Markets in Cairo</h2>
       </div>
       <div class="city-markets-grid">
-        <a href="../../markets/khan-el-khalili-cairo.html" class="city-market-card">
+        <a href="../markets/khan-el-khalili-cairo.html" class="city-market-card">
           <span class="city-market-card-tag">Historic Bazaar</span>
           <div class="city-market-card-name">Khan el-Khalili — Islamic Cairo</div>
           <div class="city-market-card-meta">Cairo's most famous bazaar, established in the 14th century. The gold section offers traditional Egyptian jewellery, antique designs, and contemporary pieces. Heavily tourist-visited but also serves local buyers. Negotiation is expected.</div>
@@ -149,7 +149,7 @@
         <li>Egyptian government regulation requires jewellery to be stamped with purity marks. Look for the official assay office stamp (طابع الحكومة) on any piece you buy.</li>
         <li>Making charges (أجرة الصنعة) are a significant cost component in Egypt and are typically negotiable, especially at traditional souks. For standard designs, making charges are lower than for intricate handmade pieces.</li>
         <li>For investment gold, the National Bank of Egypt and other major banks sell certified gold bars. This is generally safer than purchasing from unregulated bullion dealers.</li>
-        <li>Use our <a href="../../calculator.html">Gold Calculator</a> to verify the metal value by weight and karat before finalising any purchase.</li>
+        <li>Use our <a href="../../../calculator.html">Gold Calculator</a> to verify the metal value by weight and karat before finalising any purchase.</li>
       </ul>
     </section>
 
@@ -160,8 +160,8 @@
           <p>The EGP floats — monitor live rates before buying. Use the calculator to check exact metal value by weight.</p>
         </div>
         <div class="city-cta-buttons">
-          <a href="../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
-          <a href="../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
+          <a href="../../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
+          <a href="../../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
         </div>
       </div>
     </section>
@@ -173,11 +173,11 @@
           <h2>Related Markets</h2>
         </div>
         <div class="city-related-cities">
-          <a href="../../countries/egypt.html" class="city-related-link">🇪🇬 Egypt Overview</a>
-          <a href="../../markets/khan-el-khalili-cairo.html" class="city-related-link">🕌 Khan el-Khalili Market</a>
+          <a href="../../../countries/egypt.html" class="city-related-link">🇪🇬 Egypt Overview</a>
+          <a href="../markets/khan-el-khalili-cairo.html" class="city-related-link">🕌 Khan el-Khalili Market</a>
           <a href="../../uae/cities/dubai.html" class="city-related-link">🏙 Dubai Gold Price</a>
-          <a href="../../countries/jordan.html" class="city-related-link">🇯🇴 Jordan Gold Price</a>
-          <a href="../../shops.html?country=EG" class="city-related-link">🏪 Egypt Shops</a>
+          <a href="../../../countries/jordan.html" class="city-related-link">🇯🇴 Jordan Gold Price</a>
+          <a href="../../../shops.html?country=EG" class="city-related-link">🏪 Egypt Shops</a>
         </div>
       </div>
     </section>

--- a/countries/egypt/markets/khan-el-khalili-cairo.html
+++ b/countries/egypt/markets/khan-el-khalili-cairo.html
@@ -12,11 +12,11 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/egypt/markets/khan-el-khalili-cairo.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../markets/market-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../markets/market-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -83,11 +83,11 @@
     <section class="mkt-section" style="padding:1.2rem 1.5rem;">
       <div class="mkt-inner">
         <div class="mkt-links-row">
-          <a href="../../countries/egypt/cities/cairo.html" class="mkt-link-btn">🏙 Cairo Live Gold Price</a>
-          <a href="../../countries/egypt.html" class="mkt-link-btn">🇪🇬 Egypt Gold Overview</a>
-          <a href="../../calculator.html" class="mkt-link-btn mkt-link-btn-primary">🧮 Gold Calculator</a>
-          <a href="../../tracker.html" class="mkt-link-btn">📈 Live Tracker</a>
-          <a href="../../guides/buying-guide.html" class="mkt-link-btn">📖 Buying Guide</a>
+          <a href="../../../countries/egypt/cities/cairo.html" class="mkt-link-btn">🏙 Cairo Live Gold Price</a>
+          <a href="../../../countries/egypt.html" class="mkt-link-btn">🇪🇬 Egypt Gold Overview</a>
+          <a href="../../../calculator.html" class="mkt-link-btn mkt-link-btn-primary">🧮 Gold Calculator</a>
+          <a href="../../../tracker.html" class="mkt-link-btn">📈 Live Tracker</a>
+          <a href="../../../guides/buying-guide.html" class="mkt-link-btn">📖 Buying Guide</a>
         </div>
       </div>
     </section>
@@ -160,10 +160,10 @@
       <div class="mkt-inner">
         <h2 class="mkt-section-title">How Gold Pricing Works at Khan el-Khalili</h2>
         <div class="mkt-section-body">
-          <p><strong>The EGP gold rate:</strong> Egypt's gold price fluctuates with both global XAU/USD spot movements AND the EGP/USD exchange rate. Because the Egyptian Pound floats (it is not pegged), a weaker pound means higher EGP gold prices. Always check the current live EGP rate on our <a href="../../countries/egypt/cities/cairo.html">Cairo page</a> before you shop.</p>
+          <p><strong>The EGP gold rate:</strong> Egypt's gold price fluctuates with both global XAU/USD spot movements AND the EGP/USD exchange rate. Because the Egyptian Pound floats (it is not pegged), a weaker pound means higher EGP gold prices. Always check the current live EGP rate on our <a href="../../../countries/egypt/cities/cairo.html">Cairo page</a> before you shop.</p>
           <p><strong>Making charges (أجرة الصنعة):</strong> As in other Arab gold markets, the total price is the gold rate per gram multiplied by weight, plus a making charge for workmanship. At Khan el-Khalili, making charges are negotiable and can vary significantly between shops.</p>
           <p><strong>Tourist pricing:</strong> Khan el-Khalili is a major tourist destination, and initial asking prices for tourists can be substantially inflated. Local buyers typically negotiate to lower levels. Knowing the current EGP gold rate per gram (from our site or from the displayed rate boards) and the weight of any piece gives you the metal value floor, which is your negotiating anchor.</p>
-          <p><strong>The formula:</strong> Weight (grams) × 21K rate (EGP/gram) + Making charge (EGP) = Fair starting point. Use our <a href="../../calculator.html">Gold Calculator</a> to compute this before entering price discussions.</p>
+          <p><strong>The formula:</strong> Weight (grams) × 21K rate (EGP/gram) + Making charge (EGP) = Fair starting point. Use our <a href="../../../calculator.html">Gold Calculator</a> to compute this before entering price discussions.</p>
         </div>
         <div class="mkt-trust-note">
           ⚠ Egypt's EGP gold price can shift significantly due to currency movements. The gold rate on our site reflects the current live EGP/USD rate. Always verify the rate displayed at the shop matches market levels before completing a purchase.
@@ -176,7 +176,7 @@
       <div class="mkt-inner">
         <h2 class="mkt-section-title">Practical Tips for Khan el-Khalili</h2>
         <ul class="mkt-tips-list">
-          <li>Check the live EGP gold rate before you visit — it changes with both global spot and Egyptian Pound movements. Use our <a href="../../countries/egypt/cities/cairo.html">Cairo city page</a> for the current rate.</li>
+          <li>Check the live EGP gold rate before you visit — it changes with both global spot and Egyptian Pound movements. Use our <a href="../../../countries/egypt/cities/cairo.html">Cairo city page</a> for the current rate.</li>
           <li>Ask for the weight of any piece on calibrated scales before discussing price. Any legitimate retailer will weigh the piece. The weight multiplied by the gold rate gives you the metal floor value.</li>
           <li>Negotiate the making charge firmly, especially if you are buying a standard (non-custom) machine-made piece. The making charge for a simple chain or bangle can often be reduced significantly from the initial ask.</li>
           <li>Check the hallmark stamp on any piece. Egyptian law requires 21K gold to bear the official assay stamp. Look for the government karat mark — lack of a stamp is a warning sign.</li>
@@ -193,27 +193,27 @@
       <div class="mkt-inner">
         <h2 class="mkt-section-title">Related Markets & Resources</h2>
         <div class="mkt-related-grid">
-          <a href="../../countries/egypt/cities/cairo.html" class="mkt-related-card">
+          <a href="../../../countries/egypt/cities/cairo.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🏙 Cairo City Gold Guide</div>
             <div class="mkt-related-card-loc">Live EGP price + all Cairo gold market areas</div>
           </a>
-          <a href="../../countries/uae/markets/dubai-gold-souk.html" class="mkt-related-card">
+          <a href="../../../countries/uae/markets/dubai-gold-souk.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🪙 Dubai Gold Souk</div>
             <div class="mkt-related-card-loc">The world's most famous gold market guide</div>
           </a>
-          <a href="../../countries/egypt.html" class="mkt-related-card">
+          <a href="../../../countries/egypt.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🇪🇬 Egypt Gold Price</div>
             <div class="mkt-related-card-loc">Live EGP karat table for all of Egypt</div>
           </a>
-          <a href="../../guides/buying-guide.html" class="mkt-related-card">
+          <a href="../../../guides/buying-guide.html" class="mkt-related-card">
             <div class="mkt-related-card-name">📖 Complete Buying Guide</div>
             <div class="mkt-related-card-loc">How to buy gold — jewellery vs investment, karats, checklist</div>
           </a>
-          <a href="../../calculator.html" class="mkt-related-card">
+          <a href="../../../calculator.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🧮 Gold Calculator</div>
             <div class="mkt-related-card-loc">Calculate metal value by weight and karat</div>
           </a>
-          <a href="../../tracker.html" class="mkt-related-card">
+          <a href="../../../tracker.html" class="mkt-related-card">
             <div class="mkt-related-card-name">📈 Live Tracker</div>
             <div class="mkt-related-card-loc">Compare EGP, AED, SAR gold rates side by side</div>
           </a>

--- a/countries/qatar/cities/doha.html
+++ b/countries/qatar/cities/doha.html
@@ -12,12 +12,12 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/qatar/cities/doha.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../countries/country-page.css" />
-  <link rel="stylesheet" href="../../cities/city-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../countries/country-page.css" />
+  <link rel="stylesheet" href="../../../cities/city-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -61,11 +61,11 @@
 
     <section class="cp-section">
       <div class="cp-tools-row">
-        <a href="../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
-        <a href="../../tracker.html" class="related-tool-link">📈 Compare GCC Markets</a>
-        <a href="../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
-        <a href="../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
-        <a href="../../countries/qatar.html" class="related-tool-link">🇶🇦 Qatar Gold Overview</a>
+        <a href="../../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
+        <a href="../../../tracker.html" class="related-tool-link">📈 Compare GCC Markets</a>
+        <a href="../../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
+        <a href="../../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
+        <a href="../../../countries/qatar.html" class="related-tool-link">🇶🇦 Qatar Gold Overview</a>
       </div>
     </section>
 
@@ -148,7 +148,7 @@
         <li>Souq Waqif gold prices are negotiable, particularly on making charges. Retail chains have fixed prices. For large purchases, comparison shopping across both is worthwhile.</li>
         <li>Qatar's Consumer Protection Authority and the Ministry of Commerce regulate gold retail. Legitimate retailers are required to display calibrated scales and issue receipts showing weight, karat, and unit price.</li>
         <li>For investment gold, QNB and other licensed banks in Qatar are the most reliable route to certified bars with proper documentation.</li>
-        <li>Use our <a href="../../calculator.html">Gold Calculator</a> before any purchase to verify the metal value per gram at the current QAR rate.</li>
+        <li>Use our <a href="../../../calculator.html">Gold Calculator</a> before any purchase to verify the metal value per gram at the current QAR rate.</li>
       </ul>
     </section>
 
@@ -159,8 +159,8 @@
           <p>Live tracker shows side-by-side QAR, AED, SAR, and KWD gold rates in real time.</p>
         </div>
         <div class="city-cta-buttons">
-          <a href="../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
-          <a href="../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
+          <a href="../../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
+          <a href="../../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
         </div>
       </div>
     </section>
@@ -172,10 +172,10 @@
           <h2>Related GCC Markets</h2>
         </div>
         <div class="city-related-cities">
-          <a href="../../countries/qatar.html" class="city-related-link">🇶🇦 Qatar Overview</a>
+          <a href="../../../countries/qatar.html" class="city-related-link">🇶🇦 Qatar Overview</a>
           <a href="../../uae/cities/dubai.html" class="city-related-link">🏙 Dubai Gold Price</a>
           <a href="../../saudi-arabia/cities/riyadh.html" class="city-related-link">🏙 Riyadh Gold Price</a>
-          <a href="../../shops.html?country=QA" class="city-related-link">🏪 Qatar Shops</a>
+          <a href="../../../shops.html?country=QA" class="city-related-link">🏪 Qatar Shops</a>
         </div>
       </div>
     </section>

--- a/countries/saudi-arabia/cities/riyadh.html
+++ b/countries/saudi-arabia/cities/riyadh.html
@@ -12,12 +12,12 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/saudi-arabia/cities/riyadh.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../countries/country-page.css" />
-  <link rel="stylesheet" href="../../cities/city-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../countries/country-page.css" />
+  <link rel="stylesheet" href="../../../cities/city-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -61,11 +61,11 @@
 
     <section class="cp-section">
       <div class="cp-tools-row">
-        <a href="../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
-        <a href="../../tracker.html" class="related-tool-link">📈 Compare GCC Markets</a>
-        <a href="../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
-        <a href="../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
-        <a href="../../countries/saudi-arabia.html" class="related-tool-link">🇸🇦 Saudi Arabia Overview</a>
+        <a href="../../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
+        <a href="../../../tracker.html" class="related-tool-link">📈 Compare GCC Markets</a>
+        <a href="../../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
+        <a href="../../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
+        <a href="../../../countries/saudi-arabia.html" class="related-tool-link">🇸🇦 Saudi Arabia Overview</a>
       </div>
     </section>
 
@@ -148,7 +148,7 @@
         <li>The 15% VAT that applies to most goods in Saudi Arabia has specific rules for gold: investment-grade gold (bullion, coins) is typically exempt; jewellery is taxable. Verify the VAT treatment at point of purchase.</li>
         <li>Making charges (ujrat al-sinaa) are negotiable at traditional souk retailers, especially for larger purchases or bridal sets. Branded chains typically use fixed making charges.</li>
         <li>For investment gold, Saudi banks and licensed dealers are the most reliable source. Always request a certificate of authenticity and weight certification.</li>
-        <li>Use our <a href="../../calculator.html">Gold Calculator</a> to calculate the metal value of a piece by weight and karat before entering negotiations.</li>
+        <li>Use our <a href="../../../calculator.html">Gold Calculator</a> to calculate the metal value of a piece by weight and karat before entering negotiations.</li>
       </ul>
     </section>
 
@@ -159,8 +159,8 @@
           <p>Live tracker shows side-by-side SAR, AED, QAR, and KWD gold rates. Calculate exact metal value for any piece.</p>
         </div>
         <div class="city-cta-buttons">
-          <a href="../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
-          <a href="../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
+          <a href="../../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
+          <a href="../../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
         </div>
       </div>
     </section>
@@ -172,10 +172,10 @@
           <h2>Other Saudi Cities & Related Markets</h2>
         </div>
         <div class="city-related-cities">
-          <a href="../../countries/saudi-arabia.html" class="city-related-link">🇸🇦 Saudi Arabia Overview</a>
+          <a href="../../../countries/saudi-arabia.html" class="city-related-link">🇸🇦 Saudi Arabia Overview</a>
           <a href="../../uae/cities/dubai.html" class="city-related-link">🏙 Dubai Gold Price</a>
           <a href="../../qatar/cities/doha.html" class="city-related-link">🏙 Doha Gold Price</a>
-          <a href="../../shops.html?country=SA" class="city-related-link">🏪 Saudi Shops</a>
+          <a href="../../../shops.html?country=SA" class="city-related-link">🏪 Saudi Shops</a>
         </div>
       </div>
     </section>

--- a/countries/uae/cities/abu-dhabi.html
+++ b/countries/uae/cities/abu-dhabi.html
@@ -12,12 +12,12 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/uae/cities/abu-dhabi.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../countries/country-page.css" />
-  <link rel="stylesheet" href="../../cities/city-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../countries/country-page.css" />
+  <link rel="stylesheet" href="../../../cities/city-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -61,10 +61,10 @@
 
     <section class="cp-section">
       <div class="cp-tools-row">
-        <a href="../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
-        <a href="../../tracker.html" class="related-tool-link">📈 Compare All Countries</a>
-        <a href="../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
-        <a href="../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
+        <a href="../../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
+        <a href="../../../tracker.html" class="related-tool-link">📈 Compare All Countries</a>
+        <a href="../../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
+        <a href="../../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
         <a href="./dubai.html" class="related-tool-link">🏙 Dubai Gold Price</a>
       </div>
     </section>
@@ -139,7 +139,7 @@
         <li>The Madinat Zayed Gold Center is the best starting point for comparison shopping. Multiple retailers in a single complex make it easy to compare making charges.</li>
         <li>Investment gold bars purchased from regulated dealers in Abu Dhabi follow the same zero-VAT treatment as elsewhere in the UAE.</li>
         <li>Jewellery is subject to 5% UAE VAT. Keep your receipt for potential VAT refund at Abu Dhabi Airport (Abu Dhabi International Airport participates in the VAT Tourist Refund Scheme).</li>
-        <li>Use our <a href="../../calculator.html">Gold Calculator</a> to verify the metal value of any piece before paying.</li>
+        <li>Use our <a href="../../../calculator.html">Gold Calculator</a> to verify the metal value of any piece before paying.</li>
       </ul>
     </section>
 
@@ -150,8 +150,8 @@
           <p>Use the live tracker for real-time AED gold rates, or the calculator to check exact metal value by weight.</p>
         </div>
         <div class="city-cta-buttons">
-          <a href="../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
-          <a href="../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
+          <a href="../../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
+          <a href="../../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
         </div>
       </div>
     </section>
@@ -164,8 +164,8 @@
         </div>
         <div class="city-related-cities">
           <a href="./dubai.html" class="city-related-link">🏙 Dubai</a>
-          <a href="../../countries/uae.html" class="city-related-link">🇦🇪 UAE Overview</a>
-          <a href="../../shops.html?country=AE" class="city-related-link">🏪 UAE Shops</a>
+          <a href="../../../countries/uae.html" class="city-related-link">🇦🇪 UAE Overview</a>
+          <a href="../../../shops.html?country=AE" class="city-related-link">🏪 UAE Shops</a>
         </div>
       </div>
     </section>

--- a/countries/uae/cities/dubai.html
+++ b/countries/uae/cities/dubai.html
@@ -12,12 +12,12 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/uae/cities/dubai.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../countries/country-page.css" />
-  <link rel="stylesheet" href="../../cities/city-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../countries/country-page.css" />
+  <link rel="stylesheet" href="../../../cities/city-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -75,11 +75,11 @@
     <!-- Tools row -->
     <section class="cp-section">
       <div class="cp-tools-row">
-        <a href="../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
-        <a href="../../tracker.html" class="related-tool-link">📈 Compare All Countries</a>
-        <a href="../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
-        <a href="../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
-        <a href="../../countries/uae.html" class="related-tool-link">🇦🇪 UAE Gold Overview</a>
+        <a href="../../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
+        <a href="../../../tracker.html" class="related-tool-link">📈 Compare All Countries</a>
+        <a href="../../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
+        <a href="../../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
+        <a href="../../../countries/uae.html" class="related-tool-link">🇦🇪 UAE Gold Overview</a>
       </div>
     </section>
 
@@ -100,7 +100,7 @@
         <p>Dubai's gold trade is spread across traditional souks, purpose-built gold centres, and mall-based retailers.</p>
       </div>
       <div class="city-markets-grid">
-        <a href="../../markets/dubai-gold-souk.html" class="city-market-card">
+        <a href="../markets/dubai-gold-souk.html" class="city-market-card">
           <span class="city-market-card-tag">Iconic Souk</span>
           <div class="city-market-card-name">Dubai Gold Souk — Deira</div>
           <div class="city-market-card-meta">The most famous gold market in the Arab world. Hundreds of retailers across covered alleyways in Deira. Open daily; best visited in the evening. 22K jewellery, bullion, and coins available.</div>
@@ -165,7 +165,7 @@
       <ul class="city-tips-list">
         <li>Check the daily gold rate board displayed at most souk shops before negotiating — the rate is typically the 22K or 24K per-gram price in AED for that session.</li>
         <li>Understand making charges: the gold rate covers raw metal cost; making charges (craftwork fees, typically 3–25 AED/gram) are added on top. These are negotiable at traditional souk shops.</li>
-        <li>Use our <a href="../../calculator.html">Gold Calculator</a> before you shop to know the spot-based metal value of any piece by weight and karat.</li>
+        <li>Use our <a href="../../../calculator.html">Gold Calculator</a> before you shop to know the spot-based metal value of any piece by weight and karat.</li>
         <li>Dubai gold jewellery is hallmarked by the Dubai Central Laboratories. The UAE follows mandatory hallmarking — check for the hallmark stamp indicating karat purity.</li>
         <li>BIS or DMCC-certified bullion bars and coins sold in Dubai can be verified against international standards. Ask for certification documents when buying investment gold.</li>
         <li>VAT in the UAE is 5%, but gold bars and coins for investment purposes are zero-rated. Jewellery purchases are subject to 5% VAT. Factor this into your cost comparison.</li>
@@ -181,8 +181,8 @@
           <p>Use the live tracker to compare Dubai gold against other GCC markets, or calculate exact metal value by weight and karat.</p>
         </div>
         <div class="city-cta-buttons">
-          <a href="../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
-          <a href="../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
+          <a href="../../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
+          <a href="../../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
         </div>
       </div>
     </section>
@@ -196,9 +196,9 @@
         </div>
         <div class="city-related-cities">
           <a href="./abu-dhabi.html" class="city-related-link">🏙 Abu Dhabi</a>
-          <a href="../../countries/uae.html" class="city-related-link">🇦🇪 UAE Overview</a>
-          <a href="../../markets/dubai-gold-souk.html" class="city-related-link">🪙 Dubai Gold Souk</a>
-          <a href="../../shops.html?country=AE" class="city-related-link">🏪 UAE Shops Directory</a>
+          <a href="../../../countries/uae.html" class="city-related-link">🇦🇪 UAE Overview</a>
+          <a href="../markets/dubai-gold-souk.html" class="city-related-link">🪙 Dubai Gold Souk</a>
+          <a href="../../../shops.html?country=AE" class="city-related-link">🏪 UAE Shops Directory</a>
         </div>
       </div>
     </section>

--- a/countries/uae/markets/dubai-gold-souk.html
+++ b/countries/uae/markets/dubai-gold-souk.html
@@ -12,11 +12,11 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/uae/markets/dubai-gold-souk.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../markets/market-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../markets/market-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -83,12 +83,12 @@
     <section class="mkt-section" style="padding:1.2rem 1.5rem;">
       <div class="mkt-inner">
         <div class="mkt-links-row">
-          <a href="../../countries/uae/cities/dubai.html" class="mkt-link-btn">🏙 Dubai Live Gold Price</a>
-          <a href="../../countries/uae.html" class="mkt-link-btn">🇦🇪 UAE Gold Overview</a>
-          <a href="../../calculator.html" class="mkt-link-btn mkt-link-btn-primary">🧮 Gold Calculator</a>
-          <a href="../../tracker.html" class="mkt-link-btn">📈 Compare GCC Rates</a>
-          <a href="../../shops.html" class="mkt-link-btn">🏪 UAE Shops Directory</a>
-          <a href="../../guides/buying-guide.html" class="mkt-link-btn">📖 Buying Guide</a>
+          <a href="../../../countries/uae/cities/dubai.html" class="mkt-link-btn">🏙 Dubai Live Gold Price</a>
+          <a href="../../../countries/uae.html" class="mkt-link-btn">🇦🇪 UAE Gold Overview</a>
+          <a href="../../../calculator.html" class="mkt-link-btn mkt-link-btn-primary">🧮 Gold Calculator</a>
+          <a href="../../../tracker.html" class="mkt-link-btn">📈 Compare GCC Rates</a>
+          <a href="../../../shops.html" class="mkt-link-btn">🏪 UAE Shops Directory</a>
+          <a href="../../../guides/buying-guide.html" class="mkt-link-btn">📖 Buying Guide</a>
         </div>
       </div>
     </section>
@@ -167,7 +167,7 @@
           <p>Understanding how prices are structured will help you negotiate effectively and avoid overpaying.</p>
           <p><strong>Gold rate (سعر الذهب):</strong> This is the base metal price per gram, derived from the global XAU/USD spot rate converted at the UAE's fixed AED peg (3.6725). Most souk shops display this rate prominently at the front of their shop. It changes throughout the day as global markets move. This rate is essentially the same for all shops — the metal price is not negotiable.</p>
           <p><strong>Making charges (أجرة الصنعة):</strong> This is the workmanship fee added on top of the gold rate. It covers the cost of manufacturing the piece and the shop's margin. This is what IS negotiable in the souk. For simple machine-made chains, making charges might be as low as 3–5 AED/gram; for complex handmade pieces, they can be 25 AED/gram or more.</p>
-          <p><strong>Total price formula:</strong> Weight (grams) × Gold rate (AED/gram) + Making charge. Use our <a href="../../calculator.html">Gold Calculator</a> to compute the metal value for any piece by weight and karat, so you know what the raw gold is worth before negotiating.</p>
+          <p><strong>Total price formula:</strong> Weight (grams) × Gold rate (AED/gram) + Making charge. Use our <a href="../../../calculator.html">Gold Calculator</a> to compute the metal value for any piece by weight and karat, so you know what the raw gold is worth before negotiating.</p>
         </div>
         <div class="mkt-trust-note">
           ⚠ The gold prices shown on our site are spot-equivalent estimates. Actual souk prices will be higher than this by the making charge component. Always check the gold rate board at any shop and use it as your baseline before negotiating.
@@ -180,7 +180,7 @@
       <div class="mkt-inner">
         <h2 class="mkt-section-title">Practical Tips for Visiting the Dubai Gold Souk</h2>
         <ul class="mkt-tips-list">
-          <li>Check the live gold rate before you go — use our <a href="../../countries/uae/cities/dubai.html">Dubai live price page</a> or the rate board displayed at shop entrances. Knowing the current rate gives you a strong negotiating baseline.</li>
+          <li>Check the live gold rate before you go — use our <a href="../../../countries/uae/cities/dubai.html">Dubai live price page</a> or the rate board displayed at shop entrances. Knowing the current rate gives you a strong negotiating baseline.</li>
           <li>Calculate the metal value of any piece you're interested in using the gold rate and the piece's weight. Ask shops to weigh the piece for you on their calibrated scales — this is standard practice and any legitimate retailer will do it.</li>
           <li>Negotiate the making charge, not the gold rate. The metal price is standard; the craftsmanship fee is where you have room. For simple pieces, aim lower; for intricate handmade work, a higher making charge may be justified.</li>
           <li>Verify the hallmark stamp on any piece. UAE mandatory hallmarking requires a karat purity mark on all gold jewellery. Ask to see the hallmark and confirm it matches what you're being sold.</li>
@@ -197,27 +197,27 @@
       <div class="mkt-inner">
         <h2 class="mkt-section-title">Related Markets & Resources</h2>
         <div class="mkt-related-grid">
-          <a href="../../countries/uae/cities/dubai.html" class="mkt-related-card">
+          <a href="../../../countries/uae/cities/dubai.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🏙 Dubai City Gold Guide</div>
             <div class="mkt-related-card-loc">Live AED price + all Dubai gold market areas</div>
           </a>
-          <a href="../../countries/egypt/markets/khan-el-khalili-cairo.html" class="mkt-related-card">
+          <a href="../../../countries/egypt/markets/khan-el-khalili-cairo.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🕌 Khan el-Khalili, Cairo</div>
             <div class="mkt-related-card-loc">Cairo's historic bazaar gold market guide</div>
           </a>
-          <a href="../../countries/uae.html" class="mkt-related-card">
+          <a href="../../../countries/uae.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🇦🇪 UAE Gold Price</div>
             <div class="mkt-related-card-loc">Live AED karat table for all UAE</div>
           </a>
-          <a href="../../guides/buying-guide.html" class="mkt-related-card">
+          <a href="../../../guides/buying-guide.html" class="mkt-related-card">
             <div class="mkt-related-card-name">📖 Complete Buying Guide</div>
             <div class="mkt-related-card-loc">How to buy gold — jewellery vs investment, karats, checklist</div>
           </a>
-          <a href="../../tracker.html" class="mkt-related-card">
+          <a href="../../../tracker.html" class="mkt-related-card">
             <div class="mkt-related-card-name">📈 Live Tracker</div>
             <div class="mkt-related-card-loc">Compare real-time gold prices across all GCC markets</div>
           </a>
-          <a href="../../calculator.html" class="mkt-related-card">
+          <a href="../../../calculator.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🧮 Gold Calculator</div>
             <div class="mkt-related-card-loc">Calculate metal value by weight and karat before buying</div>
           </a>

--- a/guides/buying-guide.html
+++ b/guides/buying-guide.html
@@ -218,7 +218,7 @@
           </div>
         </div>
 
-        <p>Use our <a href="../cities/dubai.html">city pages</a> and <a href="../markets/dubai-gold-souk.html">market guides</a> to find specific venues in your area.</p>
+        <p>Use our <a href="../countries/uae/cities/dubai.html">city pages</a> and <a href="../countries/uae/markets/dubai-gold-souk.html">market guides</a> to find specific venues in your area.</p>
       </section>
 
       <!-- Section 5 -->
@@ -328,12 +328,12 @@
             <div class="guide-journey-step-title">Gold Calculator</div>
             <div class="guide-journey-step-desc">Input weight and karat to calculate metal value before negotiating.</div>
           </a>
-          <a href="../cities/dubai.html" class="guide-journey-step" style="text-decoration:none; color:inherit;">
+          <a href="../countries/uae/cities/dubai.html" class="guide-journey-step" style="text-decoration:none; color:inherit;">
             <div class="guide-journey-step-icon">🏙</div>
             <div class="guide-journey-step-title">City Guides</div>
             <div class="guide-journey-step-desc">Detailed guides to Dubai, Cairo, Riyadh, Doha, Abu Dhabi gold markets with tips.</div>
           </a>
-          <a href="../markets/dubai-gold-souk.html" class="guide-journey-step" style="text-decoration:none; color:inherit;">
+          <a href="../countries/uae/markets/dubai-gold-souk.html" class="guide-journey-step" style="text-decoration:none; color:inherit;">
             <div class="guide-journey-step-icon">🪙</div>
             <div class="guide-journey-step-title">Market Guides</div>
             <div class="guide-journey-step-desc">Deep dives into famous gold markets (Dubai Gold Souk, Khan el-Khalili).</div>

--- a/invest.css
+++ b/invest.css
@@ -973,4 +973,3 @@
     [dir="rtl"] .invest-mini-chip {
       text-align: center;
     }
-  </style>


### PR DESCRIPTION
### Motivation
- Ensure assets (manifest, stylesheets, favicon) and internal navigation resolve correctly from deeper nested city/market HTML files by fixing incorrect relative paths.

### Description
- Updated manifest, stylesheet, favicon and CSS hrefs from `../../...` to `../../../...` across multiple city and market pages (Cairo, Doha, Riyadh, Abu Dhabi, Dubai, Khan el-Khalili, etc.).
- Corrected internal tool and navigation links for `calculator.html`, `tracker.html`, `shops.html`, `guides/*` and country overview pages from `../../...` to `../../../...` (and adjusted market link parents from `../../markets/...` to `../markets/...`) so anchors point to the proper locations.
- Fixed several related references in `guides/buying-guide.html` to use `countries/uae/...` paths for city and market guide links.
- Removed an extraneous `</style>` closing tag at the end of `invest.css`.

### Testing
- Built the static site with `npm run build` and the build completed without errors.
- Ran a link-checker with `npm run check-links` to validate updated relative URLs and it reported no broken links.
- No unit tests were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2a6a201e88321b834810f82c0f25d)