### PR TITLE
Accessibility, shops directory enhancements, path fixes, trust docs, and SW cache bump

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -33,10 +33,11 @@
   
 </head>
 <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <!-- Nav + Breadcrumbs (injected by calculator.js) -->
   <div class="page-breadcrumbs"></div>
 
-  <main>
+  <main id="main-content">
     <!-- Hero -->
     <section class="calc-hero">
       <div class="calc-hero-inner">

--- a/countries/egypt/cities/cairo.html
+++ b/countries/egypt/cities/cairo.html
@@ -12,12 +12,12 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/egypt/cities/cairo.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../countries/country-page.css" />
-  <link rel="stylesheet" href="../../cities/city-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../countries/country-page.css" />
+  <link rel="stylesheet" href="../../../cities/city-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -61,11 +61,11 @@
 
     <section class="cp-section">
       <div class="cp-tools-row">
-        <a href="../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
-        <a href="../../tracker.html" class="related-tool-link">📈 Live Tracker</a>
-        <a href="../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
-        <a href="../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
-        <a href="../../countries/egypt.html" class="related-tool-link">🇪🇬 Egypt Gold Overview</a>
+        <a href="../../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
+        <a href="../../../tracker.html" class="related-tool-link">📈 Live Tracker</a>
+        <a href="../../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
+        <a href="../../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
+        <a href="../../../countries/egypt.html" class="related-tool-link">🇪🇬 Egypt Gold Overview</a>
       </div>
     </section>
 
@@ -84,7 +84,7 @@
         <h2>Key Gold Markets in Cairo</h2>
       </div>
       <div class="city-markets-grid">
-        <a href="../../markets/khan-el-khalili-cairo.html" class="city-market-card">
+        <a href="../markets/khan-el-khalili-cairo.html" class="city-market-card">
           <span class="city-market-card-tag">Historic Bazaar</span>
           <div class="city-market-card-name">Khan el-Khalili — Islamic Cairo</div>
           <div class="city-market-card-meta">Cairo's most famous bazaar, established in the 14th century. The gold section offers traditional Egyptian jewellery, antique designs, and contemporary pieces. Heavily tourist-visited but also serves local buyers. Negotiation is expected.</div>
@@ -149,7 +149,7 @@
         <li>Egyptian government regulation requires jewellery to be stamped with purity marks. Look for the official assay office stamp (طابع الحكومة) on any piece you buy.</li>
         <li>Making charges (أجرة الصنعة) are a significant cost component in Egypt and are typically negotiable, especially at traditional souks. For standard designs, making charges are lower than for intricate handmade pieces.</li>
         <li>For investment gold, the National Bank of Egypt and other major banks sell certified gold bars. This is generally safer than purchasing from unregulated bullion dealers.</li>
-        <li>Use our <a href="../../calculator.html">Gold Calculator</a> to verify the metal value by weight and karat before finalising any purchase.</li>
+        <li>Use our <a href="../../../calculator.html">Gold Calculator</a> to verify the metal value by weight and karat before finalising any purchase.</li>
       </ul>
     </section>
 
@@ -160,8 +160,8 @@
           <p>The EGP floats — monitor live rates before buying. Use the calculator to check exact metal value by weight.</p>
         </div>
         <div class="city-cta-buttons">
-          <a href="../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
-          <a href="../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
+          <a href="../../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
+          <a href="../../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
         </div>
       </div>
     </section>
@@ -173,11 +173,11 @@
           <h2>Related Markets</h2>
         </div>
         <div class="city-related-cities">
-          <a href="../../countries/egypt.html" class="city-related-link">🇪🇬 Egypt Overview</a>
-          <a href="../../markets/khan-el-khalili-cairo.html" class="city-related-link">🕌 Khan el-Khalili Market</a>
+          <a href="../../../countries/egypt.html" class="city-related-link">🇪🇬 Egypt Overview</a>
+          <a href="../markets/khan-el-khalili-cairo.html" class="city-related-link">🕌 Khan el-Khalili Market</a>
           <a href="../../uae/cities/dubai.html" class="city-related-link">🏙 Dubai Gold Price</a>
-          <a href="../../countries/jordan.html" class="city-related-link">🇯🇴 Jordan Gold Price</a>
-          <a href="../../shops.html?country=EG" class="city-related-link">🏪 Egypt Shops</a>
+          <a href="../../../countries/jordan.html" class="city-related-link">🇯🇴 Jordan Gold Price</a>
+          <a href="../../../shops.html?country=EG" class="city-related-link">🏪 Egypt Shops</a>
         </div>
       </div>
     </section>

--- a/countries/egypt/markets/khan-el-khalili-cairo.html
+++ b/countries/egypt/markets/khan-el-khalili-cairo.html
@@ -12,11 +12,11 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/egypt/markets/khan-el-khalili-cairo.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../markets/market-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../markets/market-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -83,11 +83,11 @@
     <section class="mkt-section" style="padding:1.2rem 1.5rem;">
       <div class="mkt-inner">
         <div class="mkt-links-row">
-          <a href="../../countries/egypt/cities/cairo.html" class="mkt-link-btn">🏙 Cairo Live Gold Price</a>
-          <a href="../../countries/egypt.html" class="mkt-link-btn">🇪🇬 Egypt Gold Overview</a>
-          <a href="../../calculator.html" class="mkt-link-btn mkt-link-btn-primary">🧮 Gold Calculator</a>
-          <a href="../../tracker.html" class="mkt-link-btn">📈 Live Tracker</a>
-          <a href="../../guides/buying-guide.html" class="mkt-link-btn">📖 Buying Guide</a>
+          <a href="../../../countries/egypt/cities/cairo.html" class="mkt-link-btn">🏙 Cairo Live Gold Price</a>
+          <a href="../../../countries/egypt.html" class="mkt-link-btn">🇪🇬 Egypt Gold Overview</a>
+          <a href="../../../calculator.html" class="mkt-link-btn mkt-link-btn-primary">🧮 Gold Calculator</a>
+          <a href="../../../tracker.html" class="mkt-link-btn">📈 Live Tracker</a>
+          <a href="../../../guides/buying-guide.html" class="mkt-link-btn">📖 Buying Guide</a>
         </div>
       </div>
     </section>
@@ -160,10 +160,10 @@
       <div class="mkt-inner">
         <h2 class="mkt-section-title">How Gold Pricing Works at Khan el-Khalili</h2>
         <div class="mkt-section-body">
-          <p><strong>The EGP gold rate:</strong> Egypt's gold price fluctuates with both global XAU/USD spot movements AND the EGP/USD exchange rate. Because the Egyptian Pound floats (it is not pegged), a weaker pound means higher EGP gold prices. Always check the current live EGP rate on our <a href="../../countries/egypt/cities/cairo.html">Cairo page</a> before you shop.</p>
+          <p><strong>The EGP gold rate:</strong> Egypt's gold price fluctuates with both global XAU/USD spot movements AND the EGP/USD exchange rate. Because the Egyptian Pound floats (it is not pegged), a weaker pound means higher EGP gold prices. Always check the current live EGP rate on our <a href="../../../countries/egypt/cities/cairo.html">Cairo page</a> before you shop.</p>
           <p><strong>Making charges (أجرة الصنعة):</strong> As in other Arab gold markets, the total price is the gold rate per gram multiplied by weight, plus a making charge for workmanship. At Khan el-Khalili, making charges are negotiable and can vary significantly between shops.</p>
           <p><strong>Tourist pricing:</strong> Khan el-Khalili is a major tourist destination, and initial asking prices for tourists can be substantially inflated. Local buyers typically negotiate to lower levels. Knowing the current EGP gold rate per gram (from our site or from the displayed rate boards) and the weight of any piece gives you the metal value floor, which is your negotiating anchor.</p>
-          <p><strong>The formula:</strong> Weight (grams) × 21K rate (EGP/gram) + Making charge (EGP) = Fair starting point. Use our <a href="../../calculator.html">Gold Calculator</a> to compute this before entering price discussions.</p>
+          <p><strong>The formula:</strong> Weight (grams) × 21K rate (EGP/gram) + Making charge (EGP) = Fair starting point. Use our <a href="../../../calculator.html">Gold Calculator</a> to compute this before entering price discussions.</p>
         </div>
         <div class="mkt-trust-note">
           ⚠ Egypt's EGP gold price can shift significantly due to currency movements. The gold rate on our site reflects the current live EGP/USD rate. Always verify the rate displayed at the shop matches market levels before completing a purchase.
@@ -176,7 +176,7 @@
       <div class="mkt-inner">
         <h2 class="mkt-section-title">Practical Tips for Khan el-Khalili</h2>
         <ul class="mkt-tips-list">
-          <li>Check the live EGP gold rate before you visit — it changes with both global spot and Egyptian Pound movements. Use our <a href="../../countries/egypt/cities/cairo.html">Cairo city page</a> for the current rate.</li>
+          <li>Check the live EGP gold rate before you visit — it changes with both global spot and Egyptian Pound movements. Use our <a href="../../../countries/egypt/cities/cairo.html">Cairo city page</a> for the current rate.</li>
           <li>Ask for the weight of any piece on calibrated scales before discussing price. Any legitimate retailer will weigh the piece. The weight multiplied by the gold rate gives you the metal floor value.</li>
           <li>Negotiate the making charge firmly, especially if you are buying a standard (non-custom) machine-made piece. The making charge for a simple chain or bangle can often be reduced significantly from the initial ask.</li>
           <li>Check the hallmark stamp on any piece. Egyptian law requires 21K gold to bear the official assay stamp. Look for the government karat mark — lack of a stamp is a warning sign.</li>
@@ -193,27 +193,27 @@
       <div class="mkt-inner">
         <h2 class="mkt-section-title">Related Markets & Resources</h2>
         <div class="mkt-related-grid">
-          <a href="../../countries/egypt/cities/cairo.html" class="mkt-related-card">
+          <a href="../../../countries/egypt/cities/cairo.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🏙 Cairo City Gold Guide</div>
             <div class="mkt-related-card-loc">Live EGP price + all Cairo gold market areas</div>
           </a>
-          <a href="../../countries/uae/markets/dubai-gold-souk.html" class="mkt-related-card">
+          <a href="../../../countries/uae/markets/dubai-gold-souk.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🪙 Dubai Gold Souk</div>
             <div class="mkt-related-card-loc">The world's most famous gold market guide</div>
           </a>
-          <a href="../../countries/egypt.html" class="mkt-related-card">
+          <a href="../../../countries/egypt.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🇪🇬 Egypt Gold Price</div>
             <div class="mkt-related-card-loc">Live EGP karat table for all of Egypt</div>
           </a>
-          <a href="../../guides/buying-guide.html" class="mkt-related-card">
+          <a href="../../../guides/buying-guide.html" class="mkt-related-card">
             <div class="mkt-related-card-name">📖 Complete Buying Guide</div>
             <div class="mkt-related-card-loc">How to buy gold — jewellery vs investment, karats, checklist</div>
           </a>
-          <a href="../../calculator.html" class="mkt-related-card">
+          <a href="../../../calculator.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🧮 Gold Calculator</div>
             <div class="mkt-related-card-loc">Calculate metal value by weight and karat</div>
           </a>
-          <a href="../../tracker.html" class="mkt-related-card">
+          <a href="../../../tracker.html" class="mkt-related-card">
             <div class="mkt-related-card-name">📈 Live Tracker</div>
             <div class="mkt-related-card-loc">Compare EGP, AED, SAR gold rates side by side</div>
           </a>

--- a/countries/qatar/cities/doha.html
+++ b/countries/qatar/cities/doha.html
@@ -12,12 +12,12 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/qatar/cities/doha.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../countries/country-page.css" />
-  <link rel="stylesheet" href="../../cities/city-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../countries/country-page.css" />
+  <link rel="stylesheet" href="../../../cities/city-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -61,11 +61,11 @@
 
     <section class="cp-section">
       <div class="cp-tools-row">
-        <a href="../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
-        <a href="../../tracker.html" class="related-tool-link">📈 Compare GCC Markets</a>
-        <a href="../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
-        <a href="../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
-        <a href="../../countries/qatar.html" class="related-tool-link">🇶🇦 Qatar Gold Overview</a>
+        <a href="../../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
+        <a href="../../../tracker.html" class="related-tool-link">📈 Compare GCC Markets</a>
+        <a href="../../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
+        <a href="../../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
+        <a href="../../../countries/qatar.html" class="related-tool-link">🇶🇦 Qatar Gold Overview</a>
       </div>
     </section>
 
@@ -148,7 +148,7 @@
         <li>Souq Waqif gold prices are negotiable, particularly on making charges. Retail chains have fixed prices. For large purchases, comparison shopping across both is worthwhile.</li>
         <li>Qatar's Consumer Protection Authority and the Ministry of Commerce regulate gold retail. Legitimate retailers are required to display calibrated scales and issue receipts showing weight, karat, and unit price.</li>
         <li>For investment gold, QNB and other licensed banks in Qatar are the most reliable route to certified bars with proper documentation.</li>
-        <li>Use our <a href="../../calculator.html">Gold Calculator</a> before any purchase to verify the metal value per gram at the current QAR rate.</li>
+        <li>Use our <a href="../../../calculator.html">Gold Calculator</a> before any purchase to verify the metal value per gram at the current QAR rate.</li>
       </ul>
     </section>
 
@@ -159,8 +159,8 @@
           <p>Live tracker shows side-by-side QAR, AED, SAR, and KWD gold rates in real time.</p>
         </div>
         <div class="city-cta-buttons">
-          <a href="../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
-          <a href="../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
+          <a href="../../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
+          <a href="../../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
         </div>
       </div>
     </section>
@@ -172,10 +172,10 @@
           <h2>Related GCC Markets</h2>
         </div>
         <div class="city-related-cities">
-          <a href="../../countries/qatar.html" class="city-related-link">🇶🇦 Qatar Overview</a>
+          <a href="../../../countries/qatar.html" class="city-related-link">🇶🇦 Qatar Overview</a>
           <a href="../../uae/cities/dubai.html" class="city-related-link">🏙 Dubai Gold Price</a>
           <a href="../../saudi-arabia/cities/riyadh.html" class="city-related-link">🏙 Riyadh Gold Price</a>
-          <a href="../../shops.html?country=QA" class="city-related-link">🏪 Qatar Shops</a>
+          <a href="../../../shops.html?country=QA" class="city-related-link">🏪 Qatar Shops</a>
         </div>
       </div>
     </section>

--- a/countries/saudi-arabia/cities/riyadh.html
+++ b/countries/saudi-arabia/cities/riyadh.html
@@ -12,12 +12,12 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/saudi-arabia/cities/riyadh.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../countries/country-page.css" />
-  <link rel="stylesheet" href="../../cities/city-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../countries/country-page.css" />
+  <link rel="stylesheet" href="../../../cities/city-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -61,11 +61,11 @@
 
     <section class="cp-section">
       <div class="cp-tools-row">
-        <a href="../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
-        <a href="../../tracker.html" class="related-tool-link">📈 Compare GCC Markets</a>
-        <a href="../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
-        <a href="../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
-        <a href="../../countries/saudi-arabia.html" class="related-tool-link">🇸🇦 Saudi Arabia Overview</a>
+        <a href="../../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
+        <a href="../../../tracker.html" class="related-tool-link">📈 Compare GCC Markets</a>
+        <a href="../../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
+        <a href="../../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
+        <a href="../../../countries/saudi-arabia.html" class="related-tool-link">🇸🇦 Saudi Arabia Overview</a>
       </div>
     </section>
 
@@ -148,7 +148,7 @@
         <li>The 15% VAT that applies to most goods in Saudi Arabia has specific rules for gold: investment-grade gold (bullion, coins) is typically exempt; jewellery is taxable. Verify the VAT treatment at point of purchase.</li>
         <li>Making charges (ujrat al-sinaa) are negotiable at traditional souk retailers, especially for larger purchases or bridal sets. Branded chains typically use fixed making charges.</li>
         <li>For investment gold, Saudi banks and licensed dealers are the most reliable source. Always request a certificate of authenticity and weight certification.</li>
-        <li>Use our <a href="../../calculator.html">Gold Calculator</a> to calculate the metal value of a piece by weight and karat before entering negotiations.</li>
+        <li>Use our <a href="../../../calculator.html">Gold Calculator</a> to calculate the metal value of a piece by weight and karat before entering negotiations.</li>
       </ul>
     </section>
 
@@ -159,8 +159,8 @@
           <p>Live tracker shows side-by-side SAR, AED, QAR, and KWD gold rates. Calculate exact metal value for any piece.</p>
         </div>
         <div class="city-cta-buttons">
-          <a href="../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
-          <a href="../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
+          <a href="../../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
+          <a href="../../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
         </div>
       </div>
     </section>
@@ -172,10 +172,10 @@
           <h2>Other Saudi Cities & Related Markets</h2>
         </div>
         <div class="city-related-cities">
-          <a href="../../countries/saudi-arabia.html" class="city-related-link">🇸🇦 Saudi Arabia Overview</a>
+          <a href="../../../countries/saudi-arabia.html" class="city-related-link">🇸🇦 Saudi Arabia Overview</a>
           <a href="../../uae/cities/dubai.html" class="city-related-link">🏙 Dubai Gold Price</a>
           <a href="../../qatar/cities/doha.html" class="city-related-link">🏙 Doha Gold Price</a>
-          <a href="../../shops.html?country=SA" class="city-related-link">🏪 Saudi Shops</a>
+          <a href="../../../shops.html?country=SA" class="city-related-link">🏪 Saudi Shops</a>
         </div>
       </div>
     </section>

--- a/countries/uae/cities/abu-dhabi.html
+++ b/countries/uae/cities/abu-dhabi.html
@@ -12,12 +12,12 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/uae/cities/abu-dhabi.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../countries/country-page.css" />
-  <link rel="stylesheet" href="../../cities/city-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../countries/country-page.css" />
+  <link rel="stylesheet" href="../../../cities/city-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -61,10 +61,10 @@
 
     <section class="cp-section">
       <div class="cp-tools-row">
-        <a href="../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
-        <a href="../../tracker.html" class="related-tool-link">📈 Compare All Countries</a>
-        <a href="../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
-        <a href="../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
+        <a href="../../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
+        <a href="../../../tracker.html" class="related-tool-link">📈 Compare All Countries</a>
+        <a href="../../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
+        <a href="../../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
         <a href="./dubai.html" class="related-tool-link">🏙 Dubai Gold Price</a>
       </div>
     </section>
@@ -139,7 +139,7 @@
         <li>The Madinat Zayed Gold Center is the best starting point for comparison shopping. Multiple retailers in a single complex make it easy to compare making charges.</li>
         <li>Investment gold bars purchased from regulated dealers in Abu Dhabi follow the same zero-VAT treatment as elsewhere in the UAE.</li>
         <li>Jewellery is subject to 5% UAE VAT. Keep your receipt for potential VAT refund at Abu Dhabi Airport (Abu Dhabi International Airport participates in the VAT Tourist Refund Scheme).</li>
-        <li>Use our <a href="../../calculator.html">Gold Calculator</a> to verify the metal value of any piece before paying.</li>
+        <li>Use our <a href="../../../calculator.html">Gold Calculator</a> to verify the metal value of any piece before paying.</li>
       </ul>
     </section>
 
@@ -150,8 +150,8 @@
           <p>Use the live tracker for real-time AED gold rates, or the calculator to check exact metal value by weight.</p>
         </div>
         <div class="city-cta-buttons">
-          <a href="../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
-          <a href="../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
+          <a href="../../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
+          <a href="../../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
         </div>
       </div>
     </section>
@@ -164,8 +164,8 @@
         </div>
         <div class="city-related-cities">
           <a href="./dubai.html" class="city-related-link">🏙 Dubai</a>
-          <a href="../../countries/uae.html" class="city-related-link">🇦🇪 UAE Overview</a>
-          <a href="../../shops.html?country=AE" class="city-related-link">🏪 UAE Shops</a>
+          <a href="../../../countries/uae.html" class="city-related-link">🇦🇪 UAE Overview</a>
+          <a href="../../../shops.html?country=AE" class="city-related-link">🏪 UAE Shops</a>
         </div>
       </div>
     </section>

--- a/countries/uae/cities/dubai.html
+++ b/countries/uae/cities/dubai.html
@@ -12,12 +12,12 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/uae/cities/dubai.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../countries/country-page.css" />
-  <link rel="stylesheet" href="../../cities/city-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../countries/country-page.css" />
+  <link rel="stylesheet" href="../../../cities/city-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -75,11 +75,11 @@
     <!-- Tools row -->
     <section class="cp-section">
       <div class="cp-tools-row">
-        <a href="../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
-        <a href="../../tracker.html" class="related-tool-link">📈 Compare All Countries</a>
-        <a href="../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
-        <a href="../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
-        <a href="../../countries/uae.html" class="related-tool-link">🇦🇪 UAE Gold Overview</a>
+        <a href="../../../calculator.html" class="related-tool-link">🧮 Gold Calculator</a>
+        <a href="../../../tracker.html" class="related-tool-link">📈 Compare All Countries</a>
+        <a href="../../../shops.html" class="related-tool-link">🏪 Find Gold Shops</a>
+        <a href="../../../guides/buying-guide.html" class="related-tool-link">📖 Buying Guide</a>
+        <a href="../../../countries/uae.html" class="related-tool-link">🇦🇪 UAE Gold Overview</a>
       </div>
     </section>
 
@@ -100,7 +100,7 @@
         <p>Dubai's gold trade is spread across traditional souks, purpose-built gold centres, and mall-based retailers.</p>
       </div>
       <div class="city-markets-grid">
-        <a href="../../markets/dubai-gold-souk.html" class="city-market-card">
+        <a href="../markets/dubai-gold-souk.html" class="city-market-card">
           <span class="city-market-card-tag">Iconic Souk</span>
           <div class="city-market-card-name">Dubai Gold Souk — Deira</div>
           <div class="city-market-card-meta">The most famous gold market in the Arab world. Hundreds of retailers across covered alleyways in Deira. Open daily; best visited in the evening. 22K jewellery, bullion, and coins available.</div>
@@ -165,7 +165,7 @@
       <ul class="city-tips-list">
         <li>Check the daily gold rate board displayed at most souk shops before negotiating — the rate is typically the 22K or 24K per-gram price in AED for that session.</li>
         <li>Understand making charges: the gold rate covers raw metal cost; making charges (craftwork fees, typically 3–25 AED/gram) are added on top. These are negotiable at traditional souk shops.</li>
-        <li>Use our <a href="../../calculator.html">Gold Calculator</a> before you shop to know the spot-based metal value of any piece by weight and karat.</li>
+        <li>Use our <a href="../../../calculator.html">Gold Calculator</a> before you shop to know the spot-based metal value of any piece by weight and karat.</li>
         <li>Dubai gold jewellery is hallmarked by the Dubai Central Laboratories. The UAE follows mandatory hallmarking — check for the hallmark stamp indicating karat purity.</li>
         <li>BIS or DMCC-certified bullion bars and coins sold in Dubai can be verified against international standards. Ask for certification documents when buying investment gold.</li>
         <li>VAT in the UAE is 5%, but gold bars and coins for investment purposes are zero-rated. Jewellery purchases are subject to 5% VAT. Factor this into your cost comparison.</li>
@@ -181,8 +181,8 @@
           <p>Use the live tracker to compare Dubai gold against other GCC markets, or calculate exact metal value by weight and karat.</p>
         </div>
         <div class="city-cta-buttons">
-          <a href="../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
-          <a href="../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
+          <a href="../../../tracker.html" class="city-cta-btn city-cta-btn-primary">📈 Live Tracker</a>
+          <a href="../../../calculator.html" class="city-cta-btn city-cta-btn-secondary">🧮 Calculator</a>
         </div>
       </div>
     </section>
@@ -196,9 +196,9 @@
         </div>
         <div class="city-related-cities">
           <a href="./abu-dhabi.html" class="city-related-link">🏙 Abu Dhabi</a>
-          <a href="../../countries/uae.html" class="city-related-link">🇦🇪 UAE Overview</a>
-          <a href="../../markets/dubai-gold-souk.html" class="city-related-link">🪙 Dubai Gold Souk</a>
-          <a href="../../shops.html?country=AE" class="city-related-link">🏪 UAE Shops Directory</a>
+          <a href="../../../countries/uae.html" class="city-related-link">🇦🇪 UAE Overview</a>
+          <a href="../markets/dubai-gold-souk.html" class="city-related-link">🪙 Dubai Gold Souk</a>
+          <a href="../../../shops.html?country=AE" class="city-related-link">🏪 UAE Shops Directory</a>
         </div>
       </div>
     </section>

--- a/countries/uae/markets/dubai-gold-souk.html
+++ b/countries/uae/markets/dubai-gold-souk.html
@@ -12,11 +12,11 @@
   <meta property="og:url" content="https://vctb12.github.io/Gold-Prices/countries/uae/markets/dubai-gold-souk.html" />
   <meta property="og:image" content="https://vctb12.github.io/Gold-Prices/assets/og-image.svg" />
   <meta name="twitter:card" content="summary" />
-  <link rel="manifest" href="../../manifest.json" />
+  <link rel="manifest" href="../../../manifest.json" />
   <meta name="theme-color" content="#d4a017" />
-  <link rel="stylesheet" href="../../style.css" />
-  <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="../../markets/market-page.css" />
+  <link rel="stylesheet" href="../../../style.css" />
+  <link rel="icon" href="../../../favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../../markets/market-page.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -83,12 +83,12 @@
     <section class="mkt-section" style="padding:1.2rem 1.5rem;">
       <div class="mkt-inner">
         <div class="mkt-links-row">
-          <a href="../../countries/uae/cities/dubai.html" class="mkt-link-btn">🏙 Dubai Live Gold Price</a>
-          <a href="../../countries/uae.html" class="mkt-link-btn">🇦🇪 UAE Gold Overview</a>
-          <a href="../../calculator.html" class="mkt-link-btn mkt-link-btn-primary">🧮 Gold Calculator</a>
-          <a href="../../tracker.html" class="mkt-link-btn">📈 Compare GCC Rates</a>
-          <a href="../../shops.html" class="mkt-link-btn">🏪 UAE Shops Directory</a>
-          <a href="../../guides/buying-guide.html" class="mkt-link-btn">📖 Buying Guide</a>
+          <a href="../../../countries/uae/cities/dubai.html" class="mkt-link-btn">🏙 Dubai Live Gold Price</a>
+          <a href="../../../countries/uae.html" class="mkt-link-btn">🇦🇪 UAE Gold Overview</a>
+          <a href="../../../calculator.html" class="mkt-link-btn mkt-link-btn-primary">🧮 Gold Calculator</a>
+          <a href="../../../tracker.html" class="mkt-link-btn">📈 Compare GCC Rates</a>
+          <a href="../../../shops.html" class="mkt-link-btn">🏪 UAE Shops Directory</a>
+          <a href="../../../guides/buying-guide.html" class="mkt-link-btn">📖 Buying Guide</a>
         </div>
       </div>
     </section>
@@ -167,7 +167,7 @@
           <p>Understanding how prices are structured will help you negotiate effectively and avoid overpaying.</p>
           <p><strong>Gold rate (سعر الذهب):</strong> This is the base metal price per gram, derived from the global XAU/USD spot rate converted at the UAE's fixed AED peg (3.6725). Most souk shops display this rate prominently at the front of their shop. It changes throughout the day as global markets move. This rate is essentially the same for all shops — the metal price is not negotiable.</p>
           <p><strong>Making charges (أجرة الصنعة):</strong> This is the workmanship fee added on top of the gold rate. It covers the cost of manufacturing the piece and the shop's margin. This is what IS negotiable in the souk. For simple machine-made chains, making charges might be as low as 3–5 AED/gram; for complex handmade pieces, they can be 25 AED/gram or more.</p>
-          <p><strong>Total price formula:</strong> Weight (grams) × Gold rate (AED/gram) + Making charge. Use our <a href="../../calculator.html">Gold Calculator</a> to compute the metal value for any piece by weight and karat, so you know what the raw gold is worth before negotiating.</p>
+          <p><strong>Total price formula:</strong> Weight (grams) × Gold rate (AED/gram) + Making charge. Use our <a href="../../../calculator.html">Gold Calculator</a> to compute the metal value for any piece by weight and karat, so you know what the raw gold is worth before negotiating.</p>
         </div>
         <div class="mkt-trust-note">
           ⚠ The gold prices shown on our site are spot-equivalent estimates. Actual souk prices will be higher than this by the making charge component. Always check the gold rate board at any shop and use it as your baseline before negotiating.
@@ -180,7 +180,7 @@
       <div class="mkt-inner">
         <h2 class="mkt-section-title">Practical Tips for Visiting the Dubai Gold Souk</h2>
         <ul class="mkt-tips-list">
-          <li>Check the live gold rate before you go — use our <a href="../../countries/uae/cities/dubai.html">Dubai live price page</a> or the rate board displayed at shop entrances. Knowing the current rate gives you a strong negotiating baseline.</li>
+          <li>Check the live gold rate before you go — use our <a href="../../../countries/uae/cities/dubai.html">Dubai live price page</a> or the rate board displayed at shop entrances. Knowing the current rate gives you a strong negotiating baseline.</li>
           <li>Calculate the metal value of any piece you're interested in using the gold rate and the piece's weight. Ask shops to weigh the piece for you on their calibrated scales — this is standard practice and any legitimate retailer will do it.</li>
           <li>Negotiate the making charge, not the gold rate. The metal price is standard; the craftsmanship fee is where you have room. For simple pieces, aim lower; for intricate handmade work, a higher making charge may be justified.</li>
           <li>Verify the hallmark stamp on any piece. UAE mandatory hallmarking requires a karat purity mark on all gold jewellery. Ask to see the hallmark and confirm it matches what you're being sold.</li>
@@ -197,27 +197,27 @@
       <div class="mkt-inner">
         <h2 class="mkt-section-title">Related Markets & Resources</h2>
         <div class="mkt-related-grid">
-          <a href="../../countries/uae/cities/dubai.html" class="mkt-related-card">
+          <a href="../../../countries/uae/cities/dubai.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🏙 Dubai City Gold Guide</div>
             <div class="mkt-related-card-loc">Live AED price + all Dubai gold market areas</div>
           </a>
-          <a href="../../countries/egypt/markets/khan-el-khalili-cairo.html" class="mkt-related-card">
+          <a href="../../../countries/egypt/markets/khan-el-khalili-cairo.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🕌 Khan el-Khalili, Cairo</div>
             <div class="mkt-related-card-loc">Cairo's historic bazaar gold market guide</div>
           </a>
-          <a href="../../countries/uae.html" class="mkt-related-card">
+          <a href="../../../countries/uae.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🇦🇪 UAE Gold Price</div>
             <div class="mkt-related-card-loc">Live AED karat table for all UAE</div>
           </a>
-          <a href="../../guides/buying-guide.html" class="mkt-related-card">
+          <a href="../../../guides/buying-guide.html" class="mkt-related-card">
             <div class="mkt-related-card-name">📖 Complete Buying Guide</div>
             <div class="mkt-related-card-loc">How to buy gold — jewellery vs investment, karats, checklist</div>
           </a>
-          <a href="../../tracker.html" class="mkt-related-card">
+          <a href="../../../tracker.html" class="mkt-related-card">
             <div class="mkt-related-card-name">📈 Live Tracker</div>
             <div class="mkt-related-card-loc">Compare real-time gold prices across all GCC markets</div>
           </a>
-          <a href="../../calculator.html" class="mkt-related-card">
+          <a href="../../../calculator.html" class="mkt-related-card">
             <div class="mkt-related-card-name">🧮 Gold Calculator</div>
             <div class="mkt-related-card-loc">Calculate metal value by weight and karat before buying</div>
           </a>

--- a/docs/product/PHASE0_GUARDRAILS.md
+++ b/docs/product/PHASE0_GUARDRAILS.md
@@ -1,0 +1,117 @@
+# Phase 0 — Product Guardrails (Must Land First)
+
+## Purpose
+
+Create non-negotiable product rules for trust language before any broad visual or UX revamp.
+
+This phase ensures the site remains explicit about what prices represent and what they do **not** represent.
+
+## Scope
+
+- Copy and labeling standards for all pages that show prices, rates, listings, or market comparisons.
+- Shared trust wording patterns for banners, cards, and detail panels.
+- Verification checklist for PR review.
+
+Out of scope:
+- Major layout redesigns
+- Framework migrations
+- Large structural rewrites
+
+---
+
+## Core Trust Rules
+
+1. **Always separate reference prices from retail outcomes.**
+   - Use “spot-linked reference estimate” for computed values.
+   - Never label computed values as “shop price” unless sourced from a real store feed.
+
+2. **Always label data freshness and source layer.**
+   - Every critical price surface must indicate one of:
+     - `Live`
+     - `Cached`
+     - `Fallback`
+     - `Derived estimate`
+
+3. **Always expose timing context.**
+   - Show timestamp/age where possible (e.g., “Updated 3 min ago”).
+   - If stale, show “Delayed” or “Stale” state explicitly.
+
+4. **Never imply store verification without evidence.**
+   - For market clusters or area listings, use wording such as:
+     - “Market-area listing”
+     - “Directory reference profile”
+
+5. **Always include user next-step guidance.**
+   - On shops/listings surfaces, include:
+     - “Confirm final prices, making charges, and VAT directly with seller.”
+
+---
+
+## Global Label Taxonomy
+
+Use these canonical labels across UI:
+
+- `Spot/reference estimate`
+- `Retail price (from seller)`
+- `Live data`
+- `Cached data`
+- `Fallback value`
+- `Derived value`
+- `Last reviewed`
+- `Methodology`
+
+Avoid ambiguous terms:
+
+- “accurate retail now”
+- “verified price” (unless provenance is explicit)
+- “official market price” (unless the source is named)
+
+---
+
+## Required Trust Elements by Page Type
+
+### Tracker pages
+
+Must include:
+- source-layer label (live/cached/fallback)
+- methodology link
+- spot-vs-retail distinction
+- timestamp or age indicator
+
+### Shops directory and listing detail modal
+
+Must include:
+- listing-type clarity (store vs market area)
+- details availability badge (full/partial/limited)
+- “confirm directly with seller” disclaimer
+- last reviewed date for directory content
+
+### Country/city/market guide pages
+
+Must include:
+- clear separation between benchmark prices and local retail variability
+- links to methodology and relevant tracker/shops pages
+
+---
+
+## Copy Pattern Rules
+
+- Use short, explicit sentences over marketing-heavy claims.
+- Prefer “estimate”, “reference”, “indicative”, “derived” where applicable.
+- Keep disclaimers informative and actionable.
+- Avoid fear language and avoid overconfidence claims.
+
+---
+
+## PR Review Checklist (Phase 0 Gate)
+
+For any PR touching pricing/listing UI, reviewers must confirm:
+
+- [ ] Spot/reference vs retail is explicit on the changed surface.
+- [ ] Live/cached/fallback/derived status is visible where relevant.
+- [ ] Timestamp or recency context is present or intentionally not applicable.
+- [ ] Trust disclaimer is present and not vague.
+- [ ] Methodology link remains discoverable.
+- [ ] No wording implies verification without supporting data.
+
+If any item fails, PR should not be marked complete.

--- a/docs/product/TRUST_SNIPPETS.md
+++ b/docs/product/TRUST_SNIPPETS.md
@@ -1,0 +1,44 @@
+# Trust Copy Snippets (Reusable)
+
+Use these snippets as defaults for banners, cards, and modals. Adapt wording to context without changing meaning.
+
+## A) Spot/reference estimate banner
+
+"These are spot-linked reference estimates, not final retail jewelry prices."
+
+## B) Retail variance helper
+
+"Final shop prices can include making charges, premiums, and local taxes."
+
+## C) Source-layer badges
+
+- Live: "Live source"
+- Cached: "Cached value"
+- Fallback: "Fallback value"
+- Derived: "Derived estimate"
+
+## D) Shops directory disclaimer
+
+"Directory listings may represent market areas or dealer clusters unless direct business details are shown."
+
+## E) Seller confirmation CTA
+
+"Before purchasing, confirm final price, making charges, and tax directly with the seller."
+
+## F) Freshness label
+
+"Last reviewed: {date}"
+
+## G) Staleness label
+
+"Data may be delayed. Check timestamp before relying on this value."
+
+## H) Method transparency link text
+
+"See methodology and data sources"
+
+## Usage notes
+
+- Keep one primary trust sentence near the top of each critical page.
+- Do not stack multiple long disclaimers above the fold.
+- For mobile, prefer concise labels + expandable detail text.

--- a/guides/buying-guide.html
+++ b/guides/buying-guide.html
@@ -218,7 +218,7 @@
           </div>
         </div>
 
-        <p>Use our <a href="../cities/dubai.html">city pages</a> and <a href="../markets/dubai-gold-souk.html">market guides</a> to find specific venues in your area.</p>
+        <p>Use our <a href="../countries/uae/cities/dubai.html">city pages</a> and <a href="../countries/uae/markets/dubai-gold-souk.html">market guides</a> to find specific venues in your area.</p>
       </section>
 
       <!-- Section 5 -->
@@ -328,12 +328,12 @@
             <div class="guide-journey-step-title">Gold Calculator</div>
             <div class="guide-journey-step-desc">Input weight and karat to calculate metal value before negotiating.</div>
           </a>
-          <a href="../cities/dubai.html" class="guide-journey-step" style="text-decoration:none; color:inherit;">
+          <a href="../countries/uae/cities/dubai.html" class="guide-journey-step" style="text-decoration:none; color:inherit;">
             <div class="guide-journey-step-icon">🏙</div>
             <div class="guide-journey-step-title">City Guides</div>
             <div class="guide-journey-step-desc">Detailed guides to Dubai, Cairo, Riyadh, Doha, Abu Dhabi gold markets with tips.</div>
           </a>
-          <a href="../markets/dubai-gold-souk.html" class="guide-journey-step" style="text-decoration:none; color:inherit;">
+          <a href="../countries/uae/markets/dubai-gold-souk.html" class="guide-journey-step" style="text-decoration:none; color:inherit;">
             <div class="guide-journey-step-icon">🪙</div>
             <div class="guide-journey-step-title">Market Guides</div>
             <div class="guide-journey-step-desc">Deep dives into famous gold markets (Dubai Gold Souk, Khan el-Khalili).</div>

--- a/index.html
+++ b/index.html
@@ -60,10 +60,11 @@
 
 </head>
 <body class="home-page">
+  <a class="skip-link" href="#main-content">Skip to main content</a>
 
   <!-- ═══════ NAV (injected by home.js) ═══════ -->
 
-  <main>
+  <main id="main-content">
 
     <!-- ═══════ HERO ═══════ -->
     <section class="hero" aria-labelledby="hero-headline">

--- a/insights.html
+++ b/insights.html
@@ -56,10 +56,11 @@
   
 </head>
 <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <!-- Nav + Breadcrumbs (injected by insights.js) -->
   <div class="page-breadcrumbs"></div>
 
-  <main>
+  <main id="main-content">
 
     <!-- Section 1: Page Hero -->
     <section class="insights-hero">

--- a/invest.css
+++ b/invest.css
@@ -973,4 +973,3 @@
     [dir="rtl"] .invest-mini-chip {
       text-align: center;
     }
-  </style>

--- a/invest.html
+++ b/invest.html
@@ -36,10 +36,11 @@
 </head>
 
 <body class="invest-page">
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <!-- Nav + Breadcrumbs (injected by inline script) -->
   <div class="page-breadcrumbs"></div>
 
-  <main class="invest-main">
+  <main id="main-content" class="invest-main">
     <section class="invest-hero" aria-labelledby="invest-title">
       <div class="invest-shell invest-hero-grid">
         <article class="invest-hero-copy">

--- a/learn.html
+++ b/learn.html
@@ -80,10 +80,11 @@
   
 </head>
 <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <!-- Nav + Breadcrumbs (injected by learn.js) -->
   <div class="page-breadcrumbs"></div>
 
-  <main>
+  <main id="main-content">
     <!-- Hero -->
     <section class="learn-hero">
       <div class="learn-hero-inner">

--- a/methodology.html
+++ b/methodology.html
@@ -40,10 +40,11 @@
   
 </head>
 <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <!-- Nav + Breadcrumbs (injected by methodology.js) -->
   <div class="page-breadcrumbs"></div>
 
-  <main>
+  <main id="main-content">
 
     <!-- Hero -->
     <section class="method-hero">

--- a/shops.css
+++ b/shops.css
@@ -274,7 +274,30 @@
   grid-column: span 2;
 }
 
-.shops-control input,
+.shops-control--checkbox {
+  justify-content: flex-end;
+}
+
+.shops-control--checkbox input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  min-height: 18px;
+  margin: 0;
+  accent-color: var(--color-gold, #d4a017);
+}
+
+.shops-control--checkbox input[type="checkbox"]:focus-visible {
+  outline: 2px solid rgba(212, 160, 23, 0.6);
+  outline-offset: 2px;
+}
+
+.shops-control-help {
+  font-size: 0.74rem;
+  color: var(--color-text-muted, #888);
+  line-height: 1.35;
+}
+
+.shops-control input:not([type="checkbox"]),
 .shops-control select {
   border: 1px solid var(--color-border, #2e2b24);
   border-radius: var(--radius-md);
@@ -304,14 +327,14 @@
   padding-left: 2.2rem;
 }
 
-.shops-control input:focus,
+.shops-control input:not([type="checkbox"]):focus,
 .shops-control select:focus {
   outline: none;
   border-color: var(--color-gold, #d4a017);
   box-shadow: 0 0 0 3px rgba(212, 160, 23, 0.14);
 }
 
-.shops-control input::placeholder {
+.shops-control input:not([type="checkbox"])::placeholder {
   color: var(--color-text-faint, #555);
 }
 
@@ -463,6 +486,14 @@
 .shops-active-filters {
   color: var(--color-text-muted, #888);
   font-size: 0.82rem;
+}
+
+.shops-results-disclaimer {
+  margin: 0.1rem 0 0;
+  color: var(--color-text-muted, #8e897b);
+  font-size: 0.78rem;
+  line-height: 1.45;
+  max-width: 680px;
 }
 
 #shops-count {
@@ -1132,6 +1163,30 @@
   border-top: 1px solid var(--color-border, #2e2b24);
   padding-top: 1.2rem;
   margin: 0;
+}
+
+.modal-foot {
+  margin-top: 1.2rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.modal-close-cta {
+  border: 1px solid var(--color-border, #2e2b24);
+  background: var(--color-bg, #131210);
+  color: var(--color-text, #e8e0cc);
+  border-radius: var(--radius-md);
+  min-height: 40px;
+  padding: 0.45rem 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.modal-close-cta:hover,
+.modal-close-cta:focus-visible {
+  border-color: var(--color-gold, #d4a017);
+  box-shadow: 0 0 0 3px rgba(212, 160, 23, 0.14);
+  outline: none;
 }
 
 /* ── RTL overrides ───────────────────────────────────────────────────────── */

--- a/shops.html
+++ b/shops.html
@@ -28,10 +28,11 @@
   </script>
 </head>
 <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <!-- Nav + Breadcrumbs (injected by shops.js) -->
   <div class="page-breadcrumbs"></div>
 
-  <main>
+  <main id="main-content">
     <section class="shops-hero" aria-labelledby="shops-title">
       <div class="shops-hero-inner">
         <p class="shops-kicker" id="shops-kicker">Shops by region</p>
@@ -40,7 +41,7 @@
 
         <div class="shops-trust-banner" aria-label="Data freshness">
           <span class="shops-trust-icon" aria-hidden="true">◈</span>
-          <span class="shops-trust-text">Directory updated regularly · <span id="shops-last-updated">Loading...</span></span>
+          <span class="shops-trust-text"><span id="shops-trust-label">Reference listings</span> · <span id="shops-last-updated">Loading...</span></span>
         </div>
 
         <div class="shops-hero-stats" aria-label="Directory overview">
@@ -121,6 +122,11 @@
           <span id="shops-specialty-label">Specialty</span>
           <select id="shops-specialty-filter"></select>
         </label>
+        <label class="shops-control shops-control--wide shops-control--checkbox" for="shops-verified-only">
+          <span id="shops-verified-label">Verified details</span>
+          <input id="shops-verified-only" type="checkbox" />
+          <span id="shops-verified-help" class="shops-control-help">Show listings with phone or website details only</span>
+        </label>
         </div><!-- /.shops-filter-panel -->
       </div>
     </section>
@@ -151,9 +157,10 @@
       <div class="shops-results-inner">
         <div class="shops-results-head">
           <div class="shops-results-head-left">
-            <h2 id="shops-results-title">Listed Shops</h2>
+            <h2 id="shops-results-title">Listings</h2>
             <div id="shops-filter-pills" class="shops-filter-pills"></div>
             <p id="shops-active-filters" class="shops-active-filters"></p>
+            <p id="shops-results-disclaimer" class="shops-results-disclaimer">Listings may represent market areas or dealer clusters unless direct contact details are shown.</p>
           </div>
           <p id="shops-count" aria-live="polite"></p>
         </div>
@@ -192,7 +199,7 @@
   <div id="shops-modal" class="shops-modal" hidden aria-labelledby="shops-modal-title" role="dialog" aria-modal="true">
     <div class="shops-modal-overlay"></div>
     <div class="shops-modal-content">
-      <button class="shops-modal-close" aria-label="Close details" type="button">×</button>
+      <button class="shops-modal-close" type="button" aria-label="Close modal">×</button>
       <div id="shops-modal-body"></div>
     </div>
   </div>

--- a/shops.js
+++ b/shops.js
@@ -15,8 +15,11 @@ const STATE = {
   country: 'all',
   city: 'all',
   specialty: 'all',
+  verifiedOnly: false,
   shortlist: [], // IDs of saved shops for quick comparison
 };
+
+const SHOPS_LAST_REVIEWED_ISO = '2026-04-05';
 
 // Load shortlist from localStorage on module init
 (function loadShortlist() {
@@ -38,7 +41,8 @@ const TXT = {
     kicker: 'Shops by region',
     title: 'Explore Gold Shops & Known Gold Markets',
     lead: 'Browse directory listings across countries covered on GoldPrices. Use filters to narrow by region, country, city, and specialty. Shop information is for reference, and business details are shown where available.',
-    trustBanner: 'Directory updated regularly · Updated {date}',
+    trustLabel: 'Directory reference listings',
+    trustDate: 'Last content review {date}',
     statListings: 'Listed markets',
     statCountries: 'Countries',
     statRegions: 'Regions',
@@ -49,14 +53,17 @@ const TXT = {
     country: 'Country',
     city: 'City',
     specialtyFilter: 'Specialty',
-    listed: 'Listed Markets',
+    listed: 'Listings (shops + market areas)',
     allRegions: 'All regions',
     allCountries: 'All countries',
     allCities: 'All cities',
     allSpecialties: 'All specialties',
+    verifiedOnly: 'Verified details only',
+    verifiedHelp: 'Show listings with phone or website details only',
     count: (n) => `${n} listing${n === 1 ? '' : 's'}`,
     activeFilters: (value) => `Filters: ${value}`,
     noFilters: 'Showing all listings',
+    verifiedFilterLabel: 'verified details only',
     emptyTitle: 'No listings match your filters',
     emptyText: 'Try clearing one filter or searching with a broader term.',
     clearFilters: 'Clear filters',
@@ -81,6 +88,7 @@ const TXT = {
     shareShop: 'Share',
     directions: 'Directions',
     callShop: 'Call',
+    closeDetails: 'Close details',
     viewCountryPage: 'View country page',
     infoTitle: 'How to use this directory',
     info1Title: 'Compare by market area',
@@ -89,6 +97,7 @@ const TXT = {
     info2Body: 'Cards indicate whether business details are limited or partially available so you know what to expect.',
     info3Title: 'Use as a shortlist',
     info3Body: 'This page is for reference and discovery. Always confirm current prices, charges, and product details directly with shops.',
+    resultsDisclaimer: 'Listings may represent market areas or dealer clusters unless direct contact details are shown.',
     quickActionsCalc: 'Calculate Value',
     quickActionsRates: 'Live Rates',
     quickActionsUAE: 'UAE Market',
@@ -97,7 +106,8 @@ const TXT = {
     kicker: 'محلات حسب المنطقة',
     title: 'استكشف محلات الذهب والأسواق المعروفة',
     lead: 'تصفح إدراجات الدليل ضمن الدول التي يغطيها GoldPrices. استخدم الفلاتر حسب المنطقة والدولة والمدينة والتخصص. معلومات المحلات مرجعية، وتظهر تفاصيل النشاط حيثما كانت متاحة.',
-    trustBanner: 'يتم تحديث الدليل بانتظام · تم التحديث {date}',
+    trustLabel: 'إدراجات مرجعية للدليل',
+    trustDate: 'آخر مراجعة للمحتوى {date}',
     statListings: 'الأسواق المدرجة',
     statCountries: 'الدول',
     statRegions: 'المناطق',
@@ -108,14 +118,17 @@ const TXT = {
     country: 'الدولة',
     city: 'المدينة',
     specialtyFilter: 'التخصص',
-    listed: 'الأسواق المدرجة',
+    listed: 'الإدراجات (محلات + مناطق سوق)',
     allRegions: 'كل المناطق',
     allCountries: 'كل الدول',
     allCities: 'كل المدن',
     allSpecialties: 'كل التخصصات',
+    verifiedOnly: 'تفاصيل موثقة فقط',
+    verifiedHelp: 'اعرض الإدراجات التي تتضمن هاتفاً أو موقعاً فقط',
     count: (n) => `${n} نتيجة`,
     activeFilters: (value) => `الفلاتر: ${value}`,
     noFilters: 'عرض جميع الإدراجات',
+    verifiedFilterLabel: 'تفاصيل موثقة فقط',
     emptyTitle: 'لا توجد إدراجات مطابقة',
     emptyText: 'جرّب إلغاء أحد الفلاتر أو استخدام كلمات أوسع في البحث.',
     clearFilters: 'مسح الفلاتر',
@@ -140,6 +153,7 @@ const TXT = {
     shareShop: 'مشاركة',
     directions: 'الاتجاهات',
     callShop: 'اتصال',
+    closeDetails: 'إغلاق التفاصيل',
     viewCountryPage: 'عرض صفحة الدولة',
     infoTitle: 'كيفية استخدام هذا الدليل',
     info1Title: 'قارن حسب منطقة السوق',
@@ -148,6 +162,7 @@ const TXT = {
     info2Body: 'توضح البطاقات مستوى توفر تفاصيل النشاط حتى تعرف المعلومات المتاحة قبل التواصل.',
     info3Title: 'استخدمه كقائمة مختصرة',
     info3Body: 'هذه الصفحة للاكتشاف والمرجعية. احرص على تأكيد الأسعار والرسوم والتفاصيل مباشرة مع المحلات.',
+    resultsDisclaimer: 'قد تمثل بعض الإدراجات مناطق سوق أو تجمعات تجار ما لم تُعرض بيانات اتصال مباشرة.',
     quickActionsCalc: 'احسب القيمة',
     quickActionsRates: 'الأسعار المباشرة',
     quickActionsUAE: 'سوق الإمارات',
@@ -292,6 +307,9 @@ function openModal(shop) {
     </div>
 
     ${contactHTML}
+    <div class="modal-foot">
+      <button class="modal-close-cta" type="button">${t('closeDetails')}</button>
+    </div>
   `;
 
   // Bind action button handlers
@@ -309,10 +327,21 @@ function openModal(shop) {
   }
 
   modal.hidden = false;
+  document.body.style.overflow = 'hidden';
 }
 
-function closeModal() {
-  document.getElementById('shops-modal').hidden = true;
+function closeModal({ clearShopParam = true } = {}) {
+  const modal = document.getElementById('shops-modal');
+  if (!modal) return;
+  modal.hidden = true;
+  document.body.style.overflow = '';
+
+  if (!clearShopParam) return;
+  const params = new URLSearchParams(location.search);
+  if (!params.has('shop')) return;
+  params.delete('shop');
+  const qs = params.toString();
+  history.replaceState(null, '', qs ? `${location.pathname}?${qs}` : location.pathname);
 }
 
 function applyStaticText() {
@@ -324,13 +353,15 @@ function applyStaticText() {
   document.getElementById('shops-lead').textContent = t('lead');
   
   // Trust banner with formatted date
-  const today = new Date();
-  const dateStr = STATE.lang === 'ar' 
-    ? today.toLocaleDateString('ar-EG', { year: 'numeric', month: 'short', day: 'numeric' })
-    : today.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+  const reviewedDate = new Date(`${SHOPS_LAST_REVIEWED_ISO}T00:00:00Z`);
+  const dateStr = STATE.lang === 'ar'
+    ? reviewedDate.toLocaleDateString('ar-EG', { year: 'numeric', month: 'short', day: 'numeric' })
+    : reviewedDate.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
   const trustEl = document.getElementById('shops-last-updated');
+  const trustLabelEl = document.getElementById('shops-trust-label');
+  if (trustLabelEl) trustLabelEl.textContent = t('trustLabel');
   if (trustEl) {
-    trustEl.textContent = t('trustBanner').replace('{date}', dateStr);
+    trustEl.textContent = t('trustDate').replace('{date}', dateStr);
   }
   
   document.getElementById('shops-popular-label').textContent = t('popularMarkets');
@@ -340,6 +371,8 @@ function applyStaticText() {
   document.getElementById('shops-country-label').textContent = t('country');
   document.getElementById('shops-city-label').textContent = t('city');
   document.getElementById('shops-specialty-label').textContent = t('specialtyFilter');
+  document.getElementById('shops-verified-label').textContent = t('verifiedOnly');
+  document.getElementById('shops-verified-help').textContent = t('verifiedHelp');
   document.getElementById('shops-results-title').textContent = t('listed');
   document.getElementById('shops-empty-title').textContent = t('emptyTitle');
   document.getElementById('shops-empty-text').textContent = t('emptyText');
@@ -354,6 +387,13 @@ function applyStaticText() {
   document.getElementById('shops-info-2-body').textContent = t('info2Body');
   document.getElementById('shops-info-3-title').textContent = t('info3Title');
   document.getElementById('shops-info-3-body').textContent = t('info3Body');
+  document.getElementById('shops-results-disclaimer').textContent = t('resultsDisclaimer');
+
+  const modalCloseBtn = document.querySelector('.shops-modal-close');
+  if (modalCloseBtn) {
+    modalCloseBtn.setAttribute('aria-label', t('closeDetails'));
+    modalCloseBtn.setAttribute('title', t('closeDetails'));
+  }
 }
 
 function shopsMatchingPrimaryFilters() {
@@ -473,6 +513,7 @@ function filterShops() {
     if (STATE.country !== 'all' && shop.countryCode !== STATE.country) return false;
     if (STATE.city !== 'all' && shop.city !== STATE.city) return false;
     if (STATE.specialty !== 'all' && !(shop.specialties || []).includes(STATE.specialty)) return false;
+    if (STATE.verifiedOnly && !(shop.phone || shop.website)) return false;
 
     if (!q) return true;
 
@@ -513,6 +554,7 @@ function activeFilterSummary() {
   }
   if (STATE.city !== 'all') labels.push(STATE.city);
   if (STATE.specialty !== 'all') labels.push(STATE.specialty);
+  if (STATE.verifiedOnly) labels.push(t('verifiedFilterLabel'));
   if (STATE.search.trim()) labels.push(`"${STATE.search.trim()}"`);
 
   document.getElementById('shops-active-filters').textContent =
@@ -706,6 +748,7 @@ function renderFilterPills() {
   }
   if (STATE.city !== 'all') pills.push({ type: 'city', value: STATE.city, label: STATE.city });
   if (STATE.specialty !== 'all') pills.push({ type: 'specialty', value: STATE.specialty, label: STATE.specialty });
+  if (STATE.verifiedOnly) pills.push({ type: 'verified', value: '1', label: t('verifiedFilterLabel') });
   if (STATE.search.trim()) {
     const q = STATE.search.trim();
     pills.push({ type: 'search', value: '', label: `"${esc(q)}"`, ariaLabel: `Remove "${q}" search filter` });
@@ -733,6 +776,11 @@ function renderFilterPills() {
       if (type === 'country') STATE.country = 'all';
       if (type === 'city') STATE.city = 'all';
       if (type === 'specialty') STATE.specialty = 'all';
+      if (type === 'verified') {
+        STATE.verifiedOnly = false;
+        const verifiedBox = document.getElementById('shops-verified-only');
+        if (verifiedBox) verifiedBox.checked = false;
+      }
       if (type === 'search') {
         STATE.search = '';
         document.getElementById('shops-search').value = '';
@@ -750,6 +798,8 @@ function syncUrlToState() {
   if (STATE.country !== 'all') p.set('country', STATE.country); else p.delete('country');
   if (STATE.city !== 'all') p.set('city', STATE.city); else p.delete('city');
   if (STATE.specialty !== 'all') p.set('specialty', STATE.specialty); else p.delete('specialty');
+  if (STATE.verifiedOnly) p.set('verified', '1'); else p.delete('verified');
+  if (STATE.lang === 'ar') p.set('lang', 'ar'); else p.delete('lang');
 
   const q = STATE.search.trim();
   if (q) { p.set('search', q); p.delete('q'); }
@@ -800,7 +850,10 @@ function resetFilters() {
   STATE.country = 'all';
   STATE.city = 'all';
   STATE.specialty = 'all';
+  STATE.verifiedOnly = false;
   document.getElementById('shops-search').value = '';
+  const verifiedBox = document.getElementById('shops-verified-only');
+  if (verifiedBox) verifiedBox.checked = false;
   buildFilters();
   render();
 }
@@ -840,20 +893,25 @@ function bindEvents() {
     render();
   });
 
+  document.getElementById('shops-verified-only').addEventListener('change', (event) => {
+    STATE.verifiedOnly = event.target.checked;
+    render();
+  });
+
   document.getElementById('shops-clear-filters').addEventListener('click', resetFilters);
 
   // Modal events
   const modal = document.getElementById('shops-modal');
-  const modalClose = document.getElementById('shops-modal-close') || modal.querySelector('.shops-modal-close');
-  const modalOverlay = modal.querySelector('.shops-modal-overlay');
-
-  if (modalClose) {
-    modalClose.addEventListener('click', closeModal);
-  }
-
-  if (modalOverlay) {
-    modalOverlay.addEventListener('click', closeModal);
-  }
+  if (!modal) return;
+  modal.addEventListener('click', (e) => {
+    if (
+      e.target.closest('.modal-close-cta') ||
+      e.target.closest('.shops-modal-close') ||
+      e.target.classList.contains('shops-modal-overlay')
+    ) {
+      closeModal();
+    }
+  });
 
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && !modal.hidden) closeModal();
@@ -896,12 +954,16 @@ function init() {
   const _pCity    =  _p.get('city')      || '';
   const _pSpec    =  _p.get('specialty') || '';
   const _pSearch  =  _p.get('search')    || _p.get('q') || '';
+  const _pVerified = (_p.get('verified') || '') === '1';
+  const _pLang = (_p.get('lang') || '').toLowerCase();
 
   if (_pRegion && Object.prototype.hasOwnProperty.call(REGIONS, _pRegion)) STATE.region = _pRegion;
   if (_pCountry)  STATE.country   = _pCountry;   // buildFilters() resets to 'all' if invalid
   if (_pCity)     STATE.city      = _pCity;
   if (_pSpec)     STATE.specialty = _pSpec;
   if (_pSearch)   STATE.search    = _pSearch;
+  if (_pVerified) STATE.verifiedOnly = true;
+  if (_pLang === 'ar' || _pLang === 'en') STATE.lang = _pLang;
 
   const navResult = injectNav(STATE.lang, 0);
   injectBreadcrumbs('shops');
@@ -941,16 +1003,13 @@ function init() {
     const el = document.getElementById('shops-search');
     if (el) el.value = STATE.search;
   }
+  const verifiedBox = document.getElementById('shops-verified-only');
+  if (verifiedBox) verifiedBox.checked = STATE.verifiedOnly;
   
-  // Handle direct shop link from URL (?shop=ID)
-  const _pShop = new URLSearchParams(location.search).get('shop');
-  if (_pShop) {
-    const shop = SHOPS.find((s) => s.id === _pShop);
-    if (shop) {
-      setTimeout(() => openModal(shop), 500);
-    }
-  }
-  
+  // Prevent modal auto-open on page load even if ?shop is present.
+  // Keep initial load stable and non-intrusive.
+  closeModal();
+
   updateLanguage();
 
   // Mobile filter toggle

--- a/style.css
+++ b/style.css
@@ -95,6 +95,32 @@ button, select, input { font-family: var(--font-main); }
 button { cursor: pointer; }
 img, svg { display: block; }
 
+/* Keyboard accessibility baseline */
+:focus-visible {
+  outline: 3px solid var(--color-gold);
+  outline-offset: 2px;
+}
+
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: -48px;
+  z-index: 10000;
+  background: #111;
+  color: #fff;
+  padding: 0.6rem 0.9rem;
+  border-radius: var(--radius-sm);
+  border: 2px solid var(--color-gold);
+  text-decoration: none;
+  font-weight: 700;
+  transition: top var(--transition);
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  top: 0.75rem;
+}
+
 /* ═══════════════════════════════════════════════
    Shared Navigation (injected via components/nav.js)
    ═══════════════════════════════════════════════ */

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
  * Strategy: cache-first for static assets, network-first for API calls.
  */
 
-const CACHE_NAME = 'goldprices-v2';
+const CACHE_NAME = 'goldprices-v3';
 const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 1 day
 
 // Static assets to pre-cache on install

--- a/tracker.html
+++ b/tracker.html
@@ -49,6 +49,7 @@
 </head>
 
 <body class="tracker-page tracker-pro-page">
+  <a class="skip-link" href="#tracker-app">Skip to main content</a>
   <!-- Shared nav/footer/ticker are injected by tracker-pro.js using components/nav.js, components/footer.js, components/ticker.js -->
 
   <main id="tracker-app" class="tracker-app">


### PR DESCRIPTION
### Motivation
- Improve keyboard accessibility by adding a skip-to-content link and focus-visible baseline across pages.
- Harden the shops directory UX and trust signals by surfacing review dates, a verified-details filter, clearer disclaimers, and safer modal behavior.
- Fix relative asset and page links across country/city/market pages so resources resolve correctly when nested.
- Introduce product guardrails and reusable trust copy to standardize wording around spot vs retail pricing.

### Description
- Added a global `.skip-link` and `:focus-visible` styles in `style.css`, and inserted `a.skip-link` + `id="main-content"` on many pages (home, tracker, shops, calculator, insights, methodology, learn, invest, etc.) to support keyboard navigation.
- Updated numerous city/market HTML files to correct relative paths to `manifest.json`, styles, icons and internal links (mostly `../../` -> `../../../`) so assets and cross-links work from nested folders.
- Shops directory: added verified-only filter and UI (`shops.html`, `shops.css`), introduced `STATE.verifiedOnly` and `SHOPS_LAST_REVIEWED_ISO` in `shops.js`, added filtering logic, URL sync for `verified` and `lang`, accessible checkbox styling, updated copy/i18n, added a results disclaimer, and adjusted modal behavior to prevent auto-open and to clear `?shop=` from the URL on close.
- Service worker cache name bumped to `goldprices-v3` in `sw.js` and precache list maintained.
- Added product docs `docs/product/PHASE0_GUARDRAILS.md` and `docs/product/TRUST_SNIPPETS.md` with canonical trust language and PR review checklist for pricing surfaces.
- Minor UX/content tweaks: updated headings and trust banner text for the shops page, adjusted several market/city link targets, and small modal/button attribute improvements for accessibility.

### Testing
- No automated tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2a6a201e88321b834810f82c0f25d)