### PR TITLE
Tracker: add canonical panel hash param, map legacy hashes, and fix CTA deep links

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -38,8 +38,8 @@ export function injectFooter(lang = 'en', depth = 0) {
         <h4 class="footer-col-heading">${isAr ? 'الأسواق' : 'Markets'}</h4>
         <a href="${r('../tracker.html')}">${isAr ? 'تتبع مباشر' : 'Live Tracker'}</a>
         <a href="${r('../countries/uae.html')}">${isAr ? 'ذهب الإمارات اليوم' : 'UAE Gold Today'}</a>
-        <a href="${r('../tracker.html#section-countries')}">${isAr ? 'مقارنة دول الخليج' : 'GCC Compare'}</a>
-        <a href="${r('../tracker.html#section-chart')}">${isAr ? 'البيانات التاريخية' : 'History &amp; Data'}</a>
+        <a href="${r('../tracker.html#mode=compare')}">${isAr ? 'مقارنة دول الخليج' : 'GCC Compare'}</a>
+        <a href="${r('../tracker.html#mode=archive')}">${isAr ? 'البيانات التاريخية' : 'History &amp; Data'}</a>
         <a href="${r('../shops.html')}">${isAr ? 'دليل المحلات' : 'Shop Directory'}</a>
       </div>
 
@@ -47,8 +47,8 @@ export function injectFooter(lang = 'en', depth = 0) {
       <div class="footer-col footer-col--links">
         <h4 class="footer-col-heading">${isAr ? 'الأدوات' : 'Tools'}</h4>
         <a href="${r('../calculator.html')}">${isAr ? 'حاسبة الذهب' : 'Gold Calculator'}</a>
-        <a href="${r('../tracker.html#section-alerts')}">${isAr ? 'تنبيهات السعر' : 'Price Alerts'}</a>
-        <a href="${r('../tracker.html#section-chart')}">${isAr ? 'تنزيل البيانات' : 'Downloads'}</a>
+        <a href="${r('../tracker.html#mode=live&panel=alerts')}">${isAr ? 'تنبيهات السعر' : 'Price Alerts'}</a>
+        <a href="${r('../tracker.html#mode=exports')}">${isAr ? 'تنزيل البيانات' : 'Downloads'}</a>
       </div>
 
       <!-- GCC column -->

--- a/components/nav-data.js
+++ b/components/nav-data.js
@@ -23,7 +23,7 @@ export const NAV_DATA = {
         label: 'Tools',
         items: [
           { href: '../calculator.html',                label: 'Calculator'   },
-          { href: '../tracker.html#mode=alerts',         label: 'Alerts'       },
+          { href: '../tracker.html#mode=live&panel=alerts', label: 'Alerts'       },
           { href: '../tracker.html#mode=exports',        label: 'Downloads'    },
           { href: '../tracker.html#mode=archive',        label: 'Date Lookup'  },
           { href: '../tracker.html#mode=archive',        label: 'Archive'      },
@@ -96,7 +96,7 @@ export const NAV_DATA = {
         label: 'أدوات',
         items: [
           { href: '../calculator.html',                label: 'حاسبة'             },
-          { href: '../tracker.html#mode=alerts',         label: 'تنبيهات'           },
+          { href: '../tracker.html#mode=live&panel=alerts', label: 'تنبيهات'           },
           { href: '../tracker.html#mode=exports',        label: 'تنزيلات'           },
           { href: '../tracker.html#mode=archive',        label: 'البحث بالتاريخ'    },
           { href: '../tracker.html#mode=archive',        label: 'الأرشيف'           },

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
           <div class="hero-ctas-secondary">
             <a href="calculator.html" class="hero-secondary-link" id="hero-cta-calc">Calculator</a>
             <span class="hero-secondary-sep" aria-hidden="true">·</span>
-            <a href="tracker.html#section-alerts" class="hero-secondary-link" id="hero-cta-alert">Set Alert</a>
+            <a href="tracker.html#mode=live&panel=alerts" class="hero-secondary-link" id="hero-cta-alert">Set Alert</a>
             <span class="hero-secondary-sep" aria-hidden="true">·</span>
             <a href="methodology.html" class="hero-secondary-link" id="hero-cta-method">How it works</a>
           </div>
@@ -265,32 +265,32 @@
             <h2 id="history-section-title" class="home-section-title">Historical Gold Prices</h2>
             <p class="home-section-sub" id="history-section-sub">Explore daily, monthly &amp; annual data — download CSV, look up any date</p>
           </div>
-          <a href="tracker.html#section-chart" class="section-link" id="history-see-all">Open Full History →</a>
+          <a href="tracker.html#mode=archive" class="section-link" id="history-see-all">Open Full History →</a>
         </div>
         <div class="history-feature-grid">
           <div class="history-feat-card history-feat-card--chart">
             <div class="history-feat-icon">📈</div>
             <h3 id="hist-feat-1-t">Price Chart</h3>
             <p id="hist-feat-1-d">24H to 5Y range. Interactive chart with full gold price history across all karats and currencies.</p>
-            <a href="tracker.html#section-chart" class="history-feat-link" id="hist-feat-1-l">Open Chart →</a>
+            <a href="tracker.html#mode=archive" class="history-feat-link" id="hist-feat-1-l">Open Chart →</a>
           </div>
           <div class="history-feat-card">
             <div class="history-feat-icon">📅</div>
             <h3 id="hist-feat-2-t">Monthly Archive</h3>
             <p id="hist-feat-2-d">Browse historical gold prices month by month for any country or karat.</p>
-            <a href="tracker.html#section-chart" class="history-feat-link" id="hist-feat-2-l">Browse Archive →</a>
+            <a href="tracker.html#mode=archive" class="history-feat-link" id="hist-feat-2-l">Browse Archive →</a>
           </div>
           <div class="history-feat-card">
             <div class="history-feat-icon">⬇</div>
             <h3 id="hist-feat-3-t">Download CSV</h3>
             <p id="hist-feat-3-d">Export price data for any country or karat as a CSV file for offline analysis.</p>
-            <a href="tracker.html" class="history-feat-link" id="hist-feat-3-l">Go to Tracker →</a>
+            <a href="tracker.html#mode=exports" class="history-feat-link" id="hist-feat-3-l">Go to Tracker →</a>
           </div>
           <div class="history-feat-card">
             <div class="history-feat-icon">🔍</div>
             <h3 id="hist-feat-4-t">Date Lookup</h3>
             <p id="hist-feat-4-d">Look up exactly what gold was worth on any specific date in any currency.</p>
-            <a href="tracker.html#section-chart" class="history-feat-link" id="hist-feat-4-l">Lookup →</a>
+            <a href="tracker.html#mode=archive" class="history-feat-link" id="hist-feat-4-l">Lookup →</a>
           </div>
         </div>
       </div>
@@ -416,7 +416,7 @@
             <h2 id="alert-cta-title">Set a Price Alert</h2>
             <p id="alert-cta-desc">Get notified when UAE 24K crosses your target price. Free, stored locally — no account needed.</p>
           </div>
-          <a href="tracker.html#alerts" class="btn btn-primary btn-lg" id="alert-cta-btn">Set Alert</a>
+          <a href="tracker.html#mode=live&panel=alerts" class="btn btn-primary btn-lg" id="alert-cta-btn">Set Alert</a>
         </div>
       </div>
     </section>

--- a/tracker/state.js
+++ b/tracker/state.js
@@ -11,6 +11,7 @@ export const STORAGE_KEYS = {
 };
 
 export const VALID_MODES = new Set(['live', 'compare', 'archive', 'exports', 'method']);
+export const VALID_PANELS = new Set(['alerts', 'planner']);
 
 export const DEFAULT_STATE = {
   lang: 'en',
@@ -139,18 +140,56 @@ export function persistState(state) {
   writeLocal(STORAGE_KEYS.wire, state.wireItems.slice(0, 32));
 }
 
-export function syncUrlFromState(state) {
+export function syncUrlFromState(state, panel = null) {
   const url = new URL(window.location.href);
-  url.hash = `mode=${state.mode}&cur=${state.selectedCurrency}&k=${state.selectedKarat}&u=${state.selectedUnit}&r=${state.range}&cmp=${state.compareCurrency}&lang=${state.lang}`;
+  const safePanel = VALID_PANELS.has(panel) ? panel : null;
+  const hashParams = new URLSearchParams({
+    mode: state.mode,
+    cur: state.selectedCurrency,
+    k: state.selectedKarat,
+    u: state.selectedUnit,
+    r: state.range,
+    cmp: state.compareCurrency,
+    lang: state.lang,
+  });
+  if (safePanel) hashParams.set('panel', safePanel);
+  url.hash = hashParams.toString();
   history.replaceState(null, '', url.toString());
 }
 
 export function applyUrlState(state) {
   const hash = window.location.hash.slice(1);
-  if (!hash) return;
+  if (!hash) return { panel: null };
+
+  const legacyHash = hash.toLowerCase();
+  const legacyPanelMap = {
+    alerts: 'alerts',
+    'section-alerts': 'alerts',
+  };
+
   const params = new URLSearchParams(hash);
   const urlMode = params.get('mode');
-  if (urlMode && VALID_MODES.has(urlMode)) state.mode = urlMode;
+  let panel = params.get('panel');
+  let shouldCanonicalize = false;
+
+  if (legacyPanelMap[legacyHash]) {
+    panel = legacyPanelMap[legacyHash];
+    shouldCanonicalize = true;
+  }
+
+  if (urlMode && VALID_MODES.has(urlMode)) {
+    state.mode = urlMode;
+  } else if (urlMode && VALID_PANELS.has(urlMode)) {
+    panel = urlMode;
+    state.mode = 'live';
+    shouldCanonicalize = true;
+  }
+
+  if (panel && !VALID_PANELS.has(panel)) {
+    panel = null;
+    shouldCanonicalize = true;
+  }
+
   state.selectedCurrency = params.get('cur') || state.selectedCurrency;
   state.selectedKarat = params.get('k') || state.selectedKarat;
   state.selectedUnit = params.get('u') || state.selectedUnit;
@@ -158,6 +197,17 @@ export function applyUrlState(state) {
   state.compareCurrency = params.get('cmp') || state.compareCurrency;
   const urlLang = params.get('lang');
   if (urlLang === 'en' || urlLang === 'ar') state.lang = urlLang;
+
+  if (!VALID_MODES.has(state.mode)) {
+    state.mode = 'live';
+    shouldCanonicalize = true;
+  }
+
+  if (shouldCanonicalize) {
+    syncUrlFromState(state, panel);
+  }
+
+  return { panel };
 }
 
 function readLocal(key, fallback) {

--- a/tracker/ui-shell.js
+++ b/tracker/ui-shell.js
@@ -5,6 +5,7 @@ import { injectTicker, updateTicker, updateTickerLang } from '../components/tick
 import { syncUrlFromState, persistState, applyUrlState } from './state.js';
 
 let _openPanel = null;
+const BASE_MODES = ['live', 'compare', 'archive', 'exports', 'method'];
 
 export function mountShell(state, els, onModeChange, onLangChange) {
   // Mount shared shell
@@ -41,19 +42,13 @@ export function mountShell(state, els, onModeChange, onLangChange) {
       panel.hidden = !active;
     });
     persistState(state);
-    syncUrlFromState(state);
+    syncUrlFromState(state, _openPanel);
     if (typeof onModeChange === 'function') onModeChange(mode);
   }
 
   tabs.forEach(tab => {
     tab.addEventListener('click', () => setMode(tab.dataset.mode));
   });
-
-  // Initial mode selection (never allow alerts/planner as mode)
-  const safeMode = ['live', 'compare', 'archive', 'exports', 'method'].includes(state.mode)
-    ? state.mode
-    : 'live';
-  setMode(safeMode);
 
   // Overlay system for Alerts and Planner
   const overlays = {
@@ -75,7 +70,7 @@ export function mountShell(state, els, onModeChange, onLangChange) {
       btn.setAttribute('aria-expanded', 'true');
     });
     // Sync URL with panel open
-    syncUrlFromState(state);
+    syncUrlFromState(state, _openPanel);
   }
 
   function closeOverlay(name) {
@@ -89,7 +84,7 @@ export function mountShell(state, els, onModeChange, onLangChange) {
       btn.setAttribute('aria-expanded', 'false');
     });
     _openPanel = null;
-    syncUrlFromState(state);
+    syncUrlFromState(state, _openPanel);
   }
 
   function toggleOverlay(name) {
@@ -114,14 +109,23 @@ export function mountShell(state, els, onModeChange, onLangChange) {
     });
   });
 
+  function applyModeAndPanelFromHash() {
+    const { panel } = applyUrlState(state);
+    const safeMode = BASE_MODES.includes(state.mode) ? state.mode : 'live';
+    setMode(safeMode);
+    if (panel && overlays[panel]) {
+      openOverlay(panel);
+    } else if (_openPanel) {
+      closeOverlay(_openPanel);
+    }
+  }
+
+  // Initial mode/panel selection (never allow alerts/planner as mode)
+  applyModeAndPanelFromHash();
+
   // Sync back/forward navigation
   window.addEventListener('hashchange', () => {
-    applyUrlState(state);
-    const m = ['live', 'compare', 'archive', 'exports', 'method'].includes(state.mode)
-      ? state.mode
-      : 'live';
-    setMode(m);
-    if (typeof onModeChange === 'function') onModeChange(state.mode);
+    applyModeAndPanelFromHash();
   });
 
   // Keyboard shortcuts


### PR DESCRIPTION
### Motivation
- Support explicit overlay deep-linking (alerts/planner) while keeping the tracker `mode` constrained to a base tab, and preserve backwards compatibility with legacy hashes.  

### Description
- Extended `tracker/state.js` with `VALID_PANELS`, made `syncUrlFromState(state, panel)` write a `panel` param when present, and updated `applyUrlState(state)` to parse `panel`, map legacy hashes (`#alerts`, `#section-alerts`, `#mode=alerts`) to the canonical form, canonicalize invalid/legacy forms, and return `{ panel }`.  
- Updated `tracker/ui-shell.js` to apply URL state on initial mount and on `hashchange`, force mode onto a valid base tab (default `live`) and open/close overlays when a `panel` is present, and include the open panel when syncing the URL.  
- Replaced legacy/broken anchors in `index.html`, `components/footer.js`, and `components/nav-data.js` so CTAs now point to canonical tracker hashes (examples: `#mode=live&panel=alerts`, `#mode=archive`, `#mode=exports`, `#mode=compare`).  
- Added compatibility behavior so old hashes that used `mode=alerts` or raw `#alerts`/`#section-alerts` redirect to the canonical `panel`+`mode` form.

### Testing
- Ran syntax checks with `node --check tracker/state.js tracker/ui-shell.js components/footer.js components/nav-data.js`, which succeeded.  
- Verified updated deep links exist with `rg` (searched for `panel=alerts`, `mode=archive`, `mode=compare`, `mode=exports`) in `index.html`, `components/footer.js`, and `components/nav-data.js`, which matched the expected replacements.  
- No automated browser integration tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c0749f188321a5d05b29be47c275)