### PR TITLE
Add basic/advanced workspace toggle and persist workspace level in tracker

### DIFF
--- a/tracker-pro.css
+++ b/tracker-pro.css
@@ -1717,6 +1717,14 @@ body.tracker-pro-page {
   outline-offset: 2px;
 }
 
+body.tracker-workspace-basic .tracker-advanced-only {
+  display: none !important;
+}
+
+body.tracker-workspace-basic .tracker-modes {
+  justify-content: flex-start;
+}
+
 @media (max-width: 640px) {
   .tracker-modes {
     gap: 0.3rem;

--- a/tracker-pro.js
+++ b/tracker-pro.js
@@ -18,6 +18,7 @@ function ui() {
     refreshBtn: document.getElementById('tp-refresh-btn'),
     shareBtn: document.getElementById('tp-share-btn'),
     resetBtn: document.getElementById('tp-reset-btn'),
+    workspaceToggle: document.getElementById('tp-workspace-toggle'),
     language: document.getElementById('tp-language'),
     currency: document.getElementById('tp-currency'),
     karat: document.getElementById('tp-karat'),

--- a/tracker.html
+++ b/tracker.html
@@ -91,8 +91,7 @@
 
           <h1 id="tp-hero-title">Gold Tracker Pro</h1>
           <p id="tp-hero-copy">
-            A live gold desk for GCC and Arab markets: spot-linked pricing, karat ladders, comparison board,
-            archive, alerts, planners, and exports — all inside your site shell.
+            First action sequence: refresh live reference prices, choose your market + karat, then read the chart before opening advanced tools.
           </p>
 
           <div class="tracker-hero-actions">
@@ -100,14 +99,15 @@
             <button class="btn btn-outline" id="tp-share-btn" type="button">Copy quick brief</button>
             <button class="btn btn-ghost" id="tp-reset-btn" type="button">Reset view</button>
             <a class="btn btn-ghost" href="#mode-live" id="tp-jump-chart">Jump to chart</a>
+            <button class="btn btn-ghost" id="tp-workspace-toggle" type="button" aria-pressed="false">Open advanced workspace</button>
           </div>
 
           <div class="tracker-onboarding-card" aria-label="How to use tracker quickly">
-            <h2>Start in 30 seconds</h2>
+            <h2>Start with one path</h2>
             <ol class="tracker-onboarding-steps">
-              <li>Check the source state first: <span class="tracker-source-badge tracker-source-badge--live">Live</span> or <span class="tracker-source-badge tracker-source-badge--cached">Cached/Fallback</span>.</li>
-              <li>Pick your market, currency, karat, and unit from the controls below.</li>
-              <li>Use Compare + Planner for decisions, then export with timestamps for records.</li>
+              <li>Press <strong>Refresh live data</strong> and confirm the source badge shows <span class="tracker-source-badge tracker-source-badge--live">Live</span> or <span class="tracker-source-badge tracker-source-badge--cached">Cached/Fallback</span>.</li>
+              <li>Pick your market, currency, karat, and unit in the live controls.</li>
+              <li>Read the chart trend and decision cues, then open advanced workspace only when needed.</li>
             </ol>
             <p class="tracker-onboarding-note">All figures here are spot-linked reference estimates, not final retail jewelry quotes.</p>
           </div>
@@ -152,7 +152,7 @@
           Live
         </button>
         <button
-          class="tracker-mode-tab"
+          class="tracker-mode-tab tracker-advanced-only"
           role="tab"
           aria-selected="false"
           aria-controls="mode-compare"
@@ -162,7 +162,7 @@
           Compare
         </button>
         <button
-          class="tracker-mode-tab"
+          class="tracker-mode-tab tracker-advanced-only"
           role="tab"
           aria-selected="false"
           aria-controls="mode-archive"
@@ -172,7 +172,7 @@
           Archive
         </button>
         <button
-          class="tracker-mode-tab tracker-overlay-btn"
+          class="tracker-mode-tab tracker-overlay-btn tracker-advanced-only"
           type="button"
           id="tab-alerts"
           data-overlay="alerts"
@@ -182,7 +182,7 @@
           Alerts
         </button>
         <button
-          class="tracker-mode-tab tracker-overlay-btn"
+          class="tracker-mode-tab tracker-overlay-btn tracker-advanced-only"
           type="button"
           id="tab-planner"
           data-overlay="planner"
@@ -192,7 +192,7 @@
           Planner
         </button>
         <button
-          class="tracker-mode-tab"
+          class="tracker-mode-tab tracker-advanced-only"
           role="tab"
           aria-selected="false"
           aria-controls="mode-exports"
@@ -202,7 +202,7 @@
           Exports
         </button>
         <button
-          class="tracker-mode-tab"
+          class="tracker-mode-tab tracker-advanced-only"
           role="tab"
           aria-selected="false"
           aria-controls="mode-method"
@@ -244,7 +244,7 @@
             <span>Unit</span>
             <select id="tp-unit"></select>
           </label>
-          <label class="tracker-field">
+          <label class="tracker-field tracker-advanced-only">
             <span>Compare market</span>
             <select id="tp-compare-country"></select>
           </label>
@@ -265,15 +265,15 @@
             <button type="button" class="tracker-chip" id="tp-auto-refresh">Auto refresh: on</button>
             <button type="button" class="tracker-chip is-active" data-metric="selected">Selected view</button>
             <button type="button" class="tracker-chip" data-metric="spot">Spot only</button>
-            <button type="button" class="tracker-chip" data-metric="compare">Compare market</button>
-            <button type="button" class="tracker-chip" data-toggle="wire">Wire headlines</button>
+            <button type="button" class="tracker-chip tracker-advanced-only" data-metric="compare">Compare market</button>
+            <button type="button" class="tracker-chip tracker-advanced-only" data-toggle="wire">Wire headlines</button>
             <button type="button" class="tracker-chip" data-toggle="favorites">Favorites only</button>
           </div>
         </div>
       </div>
 
       <!-- Market wire -->
-      <section class="tracker-wire-shell" aria-label="Market wire">
+      <section class="tracker-wire-shell tracker-advanced-only" aria-label="Market wire">
         <div class="tracker-wire-card">
           <div class="tracker-wire-label">Market wire</div>
           <div class="tracker-wire-meta" id="tp-wire-meta">
@@ -305,10 +305,10 @@
               </p>
             </div>
             <div class="tracker-head-actions">
-              <button type="button" class="btn btn-sm btn-outline" id="tp-export-chart">
+              <button type="button" class="btn btn-sm btn-outline tracker-advanced-only" id="tp-export-chart">
                 Export visible chart CSV
               </button>
-              <button type="button" class="btn btn-sm btn-ghost" id="tp-download-json">
+              <button type="button" class="btn btn-sm btn-ghost tracker-advanced-only" id="tp-download-json">
                 Download snapshot JSON
               </button>
             </div>
@@ -381,7 +381,7 @@
           <div class="tracker-watchlist-block" aria-label="Market watchlist">
             <div class="tracker-subpanel-head">
               <h3>Market watchlist</h3>
-              <button type="button" class="btn btn-sm btn-outline" id="tp-export-watchlist">
+              <button type="button" class="btn btn-sm btn-outline tracker-advanced-only" id="tp-export-watchlist">
                 Export watchlist CSV
               </button>
             </div>
@@ -400,7 +400,7 @@
 
     <!-- MODE: COMPARE -->
     <section
-      class="tracker-shell tracker-compare-shell tracker-mode-panel"
+      class="tracker-shell tracker-compare-shell tracker-mode-panel tracker-advanced-only"
       id="mode-compare"
       role="tabpanel"
       aria-labelledby="tab-compare"
@@ -457,7 +457,7 @@
 
     <!-- OVERLAY: ALERTS & PRESETS (slide-in panel, independent of main view) -->
     <div
-      class="tp-overlay"
+      class="tp-overlay tracker-advanced-only"
       id="tp-overlay-alerts"
       role="dialog"
       aria-modal="true"
@@ -536,7 +536,7 @@
 
     <!-- OVERLAY: PLANNER (slide-in panel, independent of main view) -->
     <div
-      class="tp-overlay"
+      class="tp-overlay tracker-advanced-only"
       id="tp-overlay-planner"
       role="dialog"
       aria-modal="true"
@@ -638,7 +638,7 @@
 
     <!-- MODE: ARCHIVE -->
     <section
-      class="tracker-shell tracker-archive-shell tracker-mode-panel"
+      class="tracker-shell tracker-archive-shell tracker-mode-panel tracker-advanced-only"
       id="mode-archive"
       role="tabpanel"
       aria-labelledby="tab-archive"
@@ -732,7 +732,7 @@
 
     <!-- MODE: EXPORTS -->
     <section
-      class="tracker-shell tracker-exports-shell tracker-mode-panel"
+      class="tracker-shell tracker-exports-shell tracker-mode-panel tracker-advanced-only"
       id="mode-exports"
       role="tabpanel"
       aria-labelledby="tab-exports"
@@ -798,7 +798,7 @@
 
     <!-- MODE: METHOD -->
     <section
-      class="tracker-shell tracker-method-shell tracker-mode-panel"
+      class="tracker-shell tracker-method-shell tracker-mode-panel tracker-advanced-only"
       id="mode-method"
       role="tabpanel"
       aria-labelledby="tab-method"

--- a/tracker/state.js
+++ b/tracker/state.js
@@ -16,6 +16,7 @@ export const VALID_PANELS = new Set(['alerts', 'planner']);
 export const DEFAULT_STATE = {
   lang: 'en',
   mode: 'live',
+  workspaceLevel: 'basic',
   selectedCurrency: 'AED',
   selectedKarat: '24',
   selectedUnit: 'gram',
@@ -95,6 +96,7 @@ export function createInitialState() {
   const saved = readLocal(STORAGE_KEYS.core, {});
   base.lang = saved.lang || readLanguagePref() || base.lang;
   base.mode = (VALID_MODES.has(saved.mode) ? saved.mode : null) || base.mode;
+  base.workspaceLevel = saved.workspaceLevel === 'advanced' ? 'advanced' : base.workspaceLevel;
   base.selectedCurrency = saved.selectedCurrency || base.selectedCurrency;
   base.selectedKarat = saved.selectedKarat || base.selectedKarat;
   base.selectedUnit = saved.selectedUnit || base.selectedUnit;
@@ -122,6 +124,7 @@ export function persistState(state) {
   const payload = {
     lang: state.lang,
     mode: state.mode,
+    workspaceLevel: state.workspaceLevel === 'advanced' ? 'advanced' : 'basic',
     selectedCurrency: state.selectedCurrency,
     selectedKarat: state.selectedKarat,
     selectedUnit: state.selectedUnit,

--- a/tracker/ui-shell.js
+++ b/tracker/ui-shell.js
@@ -29,8 +29,40 @@ export function mountShell(state, els, onModeChange, onLangChange) {
   // Wire main mode tabs (Live / Compare / Archive / Exports / Method only)
   const tabs = Array.from(document.querySelectorAll('.tracker-mode-tab[data-mode]'));
   const panels = Array.from(document.querySelectorAll('.tracker-mode-panel[data-mode-panel]'));
+  const workspaceToggle = els.workspaceToggle || document.getElementById('tp-workspace-toggle');
+  const isAdvancedMode = () => state.workspaceLevel === 'advanced';
+
+  function applyWorkspaceLevel() {
+    const advanced = isAdvancedMode();
+    document.body.classList.toggle('tracker-workspace-basic', !advanced);
+    document.body.classList.toggle('tracker-workspace-advanced', advanced);
+    if (workspaceToggle) {
+      workspaceToggle.textContent = advanced ? 'Use basic workspace' : 'Open advanced workspace';
+      workspaceToggle.setAttribute('aria-pressed', advanced ? 'true' : 'false');
+    }
+    if (!advanced && state.mode !== 'live') {
+      setMode('live');
+    }
+    if (!advanced && _openPanel) {
+      closeOverlay(_openPanel);
+    }
+  }
+
+  function setWorkspaceLevel(level = 'basic') {
+    state.workspaceLevel = level === 'advanced' ? 'advanced' : 'basic';
+    persistState(state);
+    applyWorkspaceLevel();
+    if (typeof onModeChange === 'function') onModeChange(state.mode);
+  }
+
+  function ensureAdvancedWorkspace() {
+    if (!isAdvancedMode()) {
+      setWorkspaceLevel('advanced');
+    }
+  }
 
   function setMode(mode) {
+    if (mode !== 'live') ensureAdvancedWorkspace();
     state.mode = mode;
     tabs.forEach(tab => {
       const active = tab.dataset.mode === mode;
@@ -57,6 +89,7 @@ export function mountShell(state, els, onModeChange, onLangChange) {
   };
 
   function openOverlay(name) {
+    ensureAdvancedWorkspace();
     if (_openPanel && _openPanel !== name) closeOverlay(_openPanel);
     const overlay = overlays[name];
     if (!overlay) return;
@@ -111,6 +144,9 @@ export function mountShell(state, els, onModeChange, onLangChange) {
 
   function applyModeAndPanelFromHash() {
     const { panel } = applyUrlState(state);
+    const needsAdvanced = state.mode !== 'live' || !!panel;
+    if (needsAdvanced) state.workspaceLevel = 'advanced';
+    applyWorkspaceLevel();
     const safeMode = BASE_MODES.includes(state.mode) ? state.mode : 'live';
     setMode(safeMode);
     if (panel && overlays[panel]) {
@@ -146,6 +182,10 @@ export function mountShell(state, els, onModeChange, onLangChange) {
     } else if (key === 'p') {
       toggleOverlay('planner');
     }
+  });
+
+  workspaceToggle?.addEventListener('click', () => {
+    setWorkspaceLevel(isAdvancedMode() ? 'basic' : 'advanced');
   });
 
   return { setMode, openOverlay, closeOverlay };


### PR DESCRIPTION
### Motivation
- Provide a simple first-visit "basic" workspace that surfaces only essential controls and one clear first action path. 
- Let users opt into the full feature set via a visible toggle so advanced UI complexity is discoverable but not overwhelming. 
- Persist the chosen complexity level across reloads so the workspace respects user preference.

### Description
- Introduced `workspaceLevel` (default `basic`) to tracker state and persisted it in `persistState`/`createInitialState` so the complexity preference is stored in localStorage (`tracker/state.js`).
- Added an `Open advanced workspace` toggle to the hero actions and updated hero onboarding copy to a single explicit first-action sequence (refresh → choose market/karat/unit → read chart) (`tracker.html`).
- Marked advanced UI elements with `tracker-advanced-only` and added CSS rules to hide them when in basic mode, covering compare/archive/exports/method tabs, overlays, market wire, compare controls, and export buttons (`tracker.html`, `tracker-pro.css`).
- Implemented workspace-level logic in the shell: body class toggling, toggle wiring, automatic upgrade to `advanced` when deep links or non-live modes/overlays are requested, and ensuring keyboard shortcuts/deep links continue to open the advanced workspace as needed (`tracker/ui-shell.js`, `tracker-pro.js`).

### Testing
- Checked modified JS for syntax errors with `node --check` on `tracker/ui-shell.js`, `tracker/state.js`, and `tracker-pro.js`, all succeeded. 
- Verified changes were staged and committed (`git add` + `git commit`) successfully. 
- Not verified in this run: interactive browser behavior, visual QA, or automated end-to-end screenshots since no browser automation was run in this environment. 
- Note: remote sync against `origin/main` was not possible here because the environment has no `origin` remote configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c82f6cd48321adabeb96dd1360df)