### PR TITLE
Refine nav/home CTA intent and add countries index destination

### DIFF
--- a/components/nav-data.js
+++ b/components/nav-data.js
@@ -14,7 +14,7 @@ export const NAV_DATA = {
           { href: '../tracker.html',                   label: 'Live Tracker'   },
           { href: '../countries/uae.html',             label: 'UAE Gold Today' },
           { href: '../tracker.html#mode=compare',        label: 'GCC Compare'    },
-          { href: '../tracker.html#mode=compare',        label: 'Country Pages'  },
+          { href: '../countries/index.html',            label: 'Country Pages'  },
           { href: '../tracker.html#mode=archive',        label: 'History & Data' },
         ],
       },
@@ -26,7 +26,6 @@ export const NAV_DATA = {
           { href: '../tracker.html#mode=live&panel=alerts', label: 'Alerts'       },
           { href: '../tracker.html#mode=exports',        label: 'Downloads'    },
           { href: '../tracker.html#mode=archive',        label: 'Date Lookup'  },
-          { href: '../tracker.html#mode=archive',        label: 'Archive'      },
         ],
       },
       {
@@ -87,7 +86,7 @@ export const NAV_DATA = {
           { href: '../tracker.html',                   label: 'تتبع مباشر'          },
           { href: '../countries/uae.html',             label: 'ذهب الإمارات'        },
           { href: '../tracker.html#mode=compare',        label: 'مقارنة دول الخليج'   },
-          { href: '../tracker.html#mode=compare',        label: 'صفحات الدول'         },
+          { href: '../countries/index.html',            label: 'صفحات الدول'         },
           { href: '../tracker.html#mode=archive',        label: 'البيانات التاريخية'   },
         ],
       },
@@ -99,7 +98,6 @@ export const NAV_DATA = {
           { href: '../tracker.html#mode=live&panel=alerts', label: 'تنبيهات'           },
           { href: '../tracker.html#mode=exports',        label: 'تنزيلات'           },
           { href: '../tracker.html#mode=archive',        label: 'البحث بالتاريخ'    },
-          { href: '../tracker.html#mode=archive',        label: 'الأرشيف'           },
         ],
       },
       {

--- a/countries/index.html
+++ b/countries/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gold Price by Country — GCC & Arab World | GoldPrices</title>
+  <meta name="description" content="Browse country gold price pages across GCC, Levant, Africa, and India. Live spot-linked estimates by country with local currency context." />
+  <link rel="canonical" href="https://vctb12.github.io/Gold-Prices/countries/index.html" />
+  <link rel="stylesheet" href="../style.css" />
+  <link rel="stylesheet" href="../home.css" />
+  <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
+  <style>
+    .countries-trust-note {
+      background: rgba(212, 160, 23, 0.12);
+      border: 1px solid rgba(212, 160, 23, 0.3);
+      border-radius: 12px;
+      padding: 0.85rem 1rem;
+      margin-bottom: 1rem;
+      color: var(--text-color, #2b2b2b);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
+  <main id="main-content">
+    <section class="home-section" aria-labelledby="countries-index-title" style="padding-top:2rem;">
+      <div class="home-section-inner">
+        <div class="section-intro">
+          <div>
+            <h1 id="countries-index-title" class="home-section-title">Country Gold Price Pages</h1>
+            <p class="home-section-sub">Choose a country page for local spot-linked estimates, currency context, and market notes.</p>
+          </div>
+          <a href="../tracker.html" class="section-link">Open Live Tracker →</a>
+        </div>
+
+        <div class="countries-trust-note">
+          ⚠ These are <strong>spot-linked bullion estimates</strong>, not retail jewelry prices. Store prices may include making charges and local premiums.
+        </div>
+
+        <div class="country-tiles">
+          <a href="uae.html" class="country-tile"><span>🇦🇪</span><span>UAE</span></a>
+          <a href="saudi-arabia.html" class="country-tile"><span>🇸🇦</span><span>Saudi Arabia</span></a>
+          <a href="kuwait.html" class="country-tile"><span>🇰🇼</span><span>Kuwait</span></a>
+          <a href="qatar.html" class="country-tile"><span>🇶🇦</span><span>Qatar</span></a>
+          <a href="bahrain.html" class="country-tile"><span>🇧🇭</span><span>Bahrain</span></a>
+          <a href="oman.html" class="country-tile"><span>🇴🇲</span><span>Oman</span></a>
+          <a href="egypt.html" class="country-tile"><span>🇪🇬</span><span>Egypt</span></a>
+          <a href="jordan.html" class="country-tile"><span>🇯🇴</span><span>Jordan</span></a>
+          <a href="morocco.html" class="country-tile"><span>🇲🇦</span><span>Morocco</span></a>
+          <a href="india.html" class="country-tile"><span>🇮🇳</span><span>India</span></a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script type="module">
+    import { injectNav } from '../components/nav.js';
+    import { injectFooter } from '../components/footer.js';
+
+    injectNav('en', 1);
+    injectFooter('en', 1);
+  </script>
+</body>
+</html>

--- a/home.js
+++ b/home.js
@@ -64,11 +64,9 @@ const T = {
     heroSub: 'UAE, GCC & Arab World',
     heroLead: 'Live spot-linked gold estimates across 24+ countries in 7 karats — in local currencies. Free, transparent, updated every 90 seconds.',
     heroCta1: 'View Live Tracker',
-    heroCta2: 'UAE Gold Today',
+    heroCta2: 'Browse Countries',
     heroCta3: 'Calculator',
-    heroCta4: 'Set Alert',
-    heroCta5: 'Find Gold Shops',
-    heroCta5Sub: '26 listings across UAE, Saudi Arabia, India & more — filterable by city and specialty.',
+    heroCta4: 'Find Gold Shops',
     spotTitle: 'Gold Spot Price',
     perOz: 'per troy ounce',
     lbl24aed: '24K / gram (AED)',
@@ -122,7 +120,7 @@ const T = {
     why2t: 'Genuinely Live',   why2d: 'Gold spot price refreshes every 90 seconds via gold-api.com. FX rates update daily. Countdown shown. Cached locally so it works offline too.',
     why3t: 'Full Bilingual',   why3d: 'Every label, badge, unit, and country name is available in English and Arabic. Full RTL layout switch — not just a font change.',
     why4t: '7 Karats, 24+ Countries', why4d: 'From pure 24K investment gold to 14K jewelry. All 7 standard karats × 24+ countries = a complete price matrix in any unit.',
-    countries: { UAE:'UAE', SA:'Saudi Arabia', KW:'Kuwait', QA:'Qatar', BH:'Bahrain', OM:'Oman', EG:'Egypt', JO:'Jordan', MA:'Morocco', IN:'India', more:'More countries →' },
+    countries: { UAE:'UAE', SA:'Saudi Arabia', KW:'Kuwait', QA:'Qatar', BH:'Bahrain', OM:'Oman', EG:'Egypt', JO:'Jordan', MA:'Morocco', IN:'India', more:'See all countries →' },
     tools: {
       trackerT:'Live Tracker', trackerD:'Full price matrix — 24+ countries, 7 karats, per gram & per ounce. Refreshed every 90 seconds.', trackerC:'Open Tracker →',
       calcT:'Gold Calculator', calcD:'Gold value, scrap, Zakat, buying power and unit conversion — all in one tool.', calcC:'Open Calculator →',
@@ -152,11 +150,9 @@ const T = {
     heroSub: 'الإمارات والخليج والعالم العربي',
     heroLead: 'تقديرات الذهب الفورية عبر 24+ دولة وبـ 7 عيارات — بالعملات المحلية. مجاني وشفاف ويتحدث كل 90 ثانية.',
     heroCta1: 'عرض التتبع المباشر',
-    heroCta2: 'ذهب الإمارات اليوم',
+    heroCta2: 'تصفح الدول',
     heroCta3: 'الحاسبة',
-    heroCta4: 'اضبط تنبيهاً',
-    heroCta5: 'ابحث عن محلات الذهب',
-    heroCta5Sub: '26 إدراجاً في الإمارات والسعودية والهند وأكثر — مع إمكانية التصفية حسب المدينة والتخصص.',
+    heroCta4: 'ابحث عن محلات الذهب',
     spotTitle: 'السعر الفوري للذهب',
     perOz: 'لكل أوقية تروي',
     lbl24aed: 'عيار 24 / غرام (AED)',
@@ -210,7 +206,7 @@ const T = {
     why2t: 'مباشر فعلًا', why2d: 'يتحدث السعر الفوري للذهب كل 90 ثانية. أسعار الصرف تتجدد يوميًا. يعمل دون اتصال بالإنترنت أيضًا.',
     why3t: 'ثنائي اللغة الكامل', why3d: 'كل تسمية وشارة ووحدة واسم بلد متاح بالعربية والإنجليزية. تبديل كامل للاتجاه RTL.',
     why4t: '7 عيارات، 24+ دولة', why4d: 'من ذهب الاستثمار 24 عيارًا إلى مجوهرات 14 عيارًا. جميع العيارات السبعة × 24+ دولة = مصفوفة أسعار كاملة.',
-    countries: { UAE:'الإمارات', SA:'السعودية', KW:'الكويت', QA:'قطر', BH:'البحرين', OM:'عُمان', EG:'مصر', JO:'الأردن', MA:'المغرب', IN:'الهند', more:'المزيد من الدول ←' },
+    countries: { UAE:'الإمارات', SA:'السعودية', KW:'الكويت', QA:'قطر', BH:'البحرين', OM:'عُمان', EG:'مصر', JO:'الأردن', MA:'المغرب', IN:'الهند', more:'عرض كل الدول ←' },
     tools: {
       trackerT:'تتبع مباشر', trackerD:'مصفوفة أسعار كاملة — 24+ دولة، 7 عيارات، لكل غرام وأوقية. يتجدد كل 90 ثانية.', trackerC:'افتح المتتبع ←',
       calcT:'حاسبة الذهب', calcD:'قيمة الذهب، الخردة، الزكاة، القوة الشرائية، وتحويل الوحدات — في أداة واحدة.', calcC:'افتح الحاسبة ←',
@@ -359,11 +355,9 @@ function applyLangToPage() {
   set('hero-title-sub',  tx('heroSub'));
   set('hero-lead',       tx('heroLead'));
   set('hero-cta-tracker',  tx('heroCta1'));
-  set('hero-cta-uae',      tx('heroCta2'));
+  set('hero-cta-countries', tx('heroCta2'));
   set('hero-cta-calc',     tx('heroCta3'));
-  set('hero-cta-alert',    tx('heroCta4'));
-  set('hero-cta-shops',    tx('heroCta5'));
-  set('hero-cta-shops-sub', tx('heroCta5Sub'));
+  set('hero-cta-shops',    tx('heroCta4'));
   set('hlc-tracker-link',  tx('trackerLink'));
   set('hlc-title',  tx('spotTitle'));
   set('hlc-sub',    tx('perOz'));
@@ -428,10 +422,10 @@ function applyLangToPage() {
   if (ht) {
     set('history-section-title', ht.title);
     set('history-section-sub',   ht.sub);
-    set('hist-feat-1-t', ht.feat1T); set('hist-feat-1-d', ht.feat1D); set('hist-feat-1-l', ht.feat1L);
-    set('hist-feat-2-t', ht.feat2T); set('hist-feat-2-d', ht.feat2D); set('hist-feat-2-l', ht.feat2L);
-    set('hist-feat-3-t', ht.feat3T); set('hist-feat-3-d', ht.feat3D); set('hist-feat-3-l', ht.feat3L);
-    set('hist-feat-4-t', ht.feat4T); set('hist-feat-4-d', ht.feat4D); set('hist-feat-4-l', ht.feat4L);
+    set('hist-feat-1-t', ht.feat1T); set('hist-feat-1-d', ht.feat1D);
+    set('hist-feat-2-t', ht.feat2T); set('hist-feat-2-d', ht.feat2D);
+    set('hist-feat-3-t', ht.feat3T); set('hist-feat-3-d', ht.feat3D);
+    set('hist-feat-4-t', ht.feat4T); set('hist-feat-4-d', ht.feat4D);
   }
 
   // Insights banner

--- a/index.html
+++ b/index.html
@@ -83,18 +83,13 @@
           </p>
           <div class="hero-ctas">
             <a href="tracker.html" class="btn btn-primary" id="hero-cta-tracker">View Live Tracker</a>
-            <a href="countries/uae.html" class="btn btn-outline-light" id="hero-cta-uae">UAE Gold Today</a>
-          </div>
-          <div class="hero-shop-cta" aria-label="Buy gold shop directory">
-            <a href="./shops.html" class="btn btn-buy-gold" id="hero-cta-shops">Buy Gold Here</a>
-            <p class="hero-shop-cta-sub" id="hero-cta-shops-sub">Browse listed shops by region, country, and city.</p>
           </div>
           <div class="hero-ctas-secondary">
+            <a href="countries/index.html" class="hero-secondary-link" id="hero-cta-countries">Browse Countries</a>
+            <span class="hero-secondary-sep" aria-hidden="true">·</span>
             <a href="calculator.html" class="hero-secondary-link" id="hero-cta-calc">Calculator</a>
             <span class="hero-secondary-sep" aria-hidden="true">·</span>
-            <a href="tracker.html#mode=live&panel=alerts" class="hero-secondary-link" id="hero-cta-alert">Set Alert</a>
-            <span class="hero-secondary-sep" aria-hidden="true">·</span>
-            <a href="methodology.html" class="hero-secondary-link" id="hero-cta-method">How it works</a>
+            <a href="shops.html" class="hero-secondary-link" id="hero-cta-shops">Find Gold Shops</a>
           </div>
         </div>
         <div class="hero-live-card" id="hero-live-card" aria-live="polite" aria-busy="true">
@@ -200,7 +195,7 @@
             <p class="buying-guide-desc" id="guide-shops-desc">Browse listed gold shops and markets across countries. Filter by region, city, and specialty.</p>
             <span class="buying-guide-cta" id="guide-shops-cta">Explore Shops →</span>
           </a>
-          <a href="countries/uae.html" class="buying-guide-card">
+          <a href="countries/index.html" class="buying-guide-card">
             <div class="buying-guide-icon" aria-hidden="true">🗺️</div>
             <h3 class="buying-guide-title" id="guide-markets-title">Browse by Market</h3>
             <p class="buying-guide-desc" id="guide-markets-desc">View local gold prices, market context, and buying tips for each country.</p>
@@ -272,25 +267,21 @@
             <div class="history-feat-icon">📈</div>
             <h3 id="hist-feat-1-t">Price Chart</h3>
             <p id="hist-feat-1-d">24H to 5Y range. Interactive chart with full gold price history across all karats and currencies.</p>
-            <a href="tracker.html#mode=archive" class="history-feat-link" id="hist-feat-1-l">Open Chart →</a>
           </div>
           <div class="history-feat-card">
             <div class="history-feat-icon">📅</div>
             <h3 id="hist-feat-2-t">Monthly Archive</h3>
             <p id="hist-feat-2-d">Browse historical gold prices month by month for any country or karat.</p>
-            <a href="tracker.html#mode=archive" class="history-feat-link" id="hist-feat-2-l">Browse Archive →</a>
           </div>
           <div class="history-feat-card">
             <div class="history-feat-icon">⬇</div>
             <h3 id="hist-feat-3-t">Download CSV</h3>
             <p id="hist-feat-3-d">Export price data for any country or karat as a CSV file for offline analysis.</p>
-            <a href="tracker.html#mode=exports" class="history-feat-link" id="hist-feat-3-l">Go to Tracker →</a>
           </div>
           <div class="history-feat-card">
             <div class="history-feat-icon">🔍</div>
             <h3 id="hist-feat-4-t">Date Lookup</h3>
             <p id="hist-feat-4-d">Look up exactly what gold was worth on any specific date in any currency.</p>
-            <a href="tracker.html#mode=archive" class="history-feat-link" id="hist-feat-4-l">Lookup →</a>
           </div>
         </div>
       </div>
@@ -372,7 +363,7 @@
           <a href="countries/jordan.html" class="country-tile"><span>🇯🇴</span><span id="ct-jo">Jordan</span></a>
           <a href="countries/morocco.html" class="country-tile"><span>🇲🇦</span><span id="ct-ma">Morocco</span></a>
           <a href="countries/india.html" class="country-tile"><span>🇮🇳</span><span id="ct-in">India</span></a>
-          <a href="tracker.html" class="country-tile country-tile--more"><span>+</span><span id="ct-more">14 more</span></a>
+          <a href="countries/index.html" class="country-tile country-tile--more"><span>+</span><span id="ct-more">See all countries</span></a>
         </div>
       </div>
     </section>
@@ -485,16 +476,6 @@
         </div>
         <div class="faq-more-row">
           <a href="learn.html" class="section-link" id="faq-more-link">More questions answered on the Learn page →</a>
-        </div>
-      </div>
-    </section>
-
-    <!-- ═══════ BOTTOM TRACKING CTA ═══════ -->
-    <section class="home-section home-track-cta-section" aria-labelledby="track-cta-title">
-      <div class="home-section-inner">
-        <div class="home-track-cta-box">
-          <p class="home-track-cta-headline" id="track-cta-title">Live gold prices. 24+ countries. 7 karats. Free.</p>
-          <a href="tracker.html" class="btn btn-primary btn-lg" id="track-cta-btn">Open Live Tracker →</a>
         </div>
       </div>
     </section>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -74,6 +74,15 @@
     <priority>0.75</priority>
   </url>
 
+  <!-- Countries Index -->
+  <url>
+    <loc>https://vctb12.github.io/Gold-Prices/countries/index.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://vctb12.github.io/Gold-Prices/countries/index.html"/>
+    <xhtml:link rel="alternate" hreflang="ar" href="https://vctb12.github.io/Gold-Prices/countries/index.html?lang=ar"/>
+    <changefreq>weekly</changefreq>
+    <priority>0.80</priority>
+  </url>
+
   <!-- Country Pages — GCC -->
   <url>
     <loc>https://vctb12.github.io/Gold-Prices/countries/uae.html</loc>


### PR DESCRIPTION
### Motivation
- Remove duplicate or ambiguous navigation targets so each top-level nav item maps to a single clear user intent. 
- Replace the tracker-compare hash used as a “Country Pages” target with a real, discoverable countries index page. 
- Reduce CTA noise above the fold and remove repeated per-card history/alert prompts so each homepage section has a single, distinct entry point. 

### Description
- Updated navigation data in `components/nav-data.js` to replace the ambiguous `tracker.html#mode=compare` country link with `countries/index.html` and removed duplicate archive entries. 
- Added a dedicated `countries/index.html` country index page with trust framing and country tiles for a clear entry point to country pages. 
- Consolidated hero CTAs in `index.html` to one primary (`View Live Tracker`) and three secondary actions (`Browse Countries`, `Calculator`, `Find Gold Shops`), updated the buying-guide market card to point to the new countries index, removed per-card history links, and changed the country “more” tile to point at the index. 
- Updated `home.js` translation keys and DOM wiring to match the new CTA IDs/text and adjusted history feature wiring to remove duplicated per-card CTAs. 
- Added the new `countries/index.html` URL to `sitemap.xml` for SEO/discoverability. 

### Testing
- Ran the production build with `npm run build` (Vite); the build completed successfully with no errors. 
- No other automated tests are present in the repo; visual/browser QA was not performed as part of the automated test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c97f13748321a89f80a089a031a8)