### PR TITLE
Enhance shops listing ranking, details-confidence UI, and next-step CTAs

### DIFF
--- a/shops.css
+++ b/shops.css
@@ -496,6 +496,15 @@
   max-width: 680px;
 }
 
+.shops-results-legend {
+  margin: 0.15rem 0 0;
+  color: rgba(212, 160, 23, 0.92);
+  font-size: 0.79rem;
+  line-height: 1.45;
+  font-weight: 600;
+  max-width: 760px;
+}
+
 #shops-count {
   color: var(--color-gold-dark, #b8860b);
   font-weight: 700;
@@ -639,15 +648,16 @@
 }
 
 .shop-signal {
-  flex-shrink: 0;
-  font-size: 0.65rem;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.68rem;
   font-weight: 700;
-  color: var(--color-text-muted, #888);
+  color: var(--color-text, #e8e0cc);
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid var(--color-border, #2e2b24);
   border-radius: var(--radius-pill);
-  padding: 0.22rem 0.6rem;
-  white-space: nowrap;
+  padding: 0.28rem 0.65rem;
+  white-space: normal;
   text-transform: capitalize;
 }
 
@@ -671,6 +681,51 @@
 
 .shop-card--cluster {
   border-color: rgba(180, 100, 0, 0.22);
+}
+
+.shop-confidence-block {
+  border: 1px solid rgba(212, 160, 23, 0.28);
+  border-radius: var(--radius-md);
+  background: linear-gradient(180deg, rgba(212, 160, 23, 0.09), rgba(212, 160, 23, 0.03));
+  padding: 0.62rem 0.72rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.shop-confidence-title {
+  margin: 0;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 800;
+  color: rgba(212, 160, 23, 0.95);
+}
+
+.shop-confidence-grid {
+  display: grid;
+  gap: 0.45rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.shop-confidence-item {
+  margin: 0;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.shop-confidence-item span {
+  font-size: 0.66rem;
+  color: var(--color-text-faint, #555);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+}
+
+.shop-confidence-item strong {
+  font-size: 0.8rem;
+  color: var(--color-text, #e8e0cc);
+  font-weight: 700;
+  line-height: 1.35;
 }
 
 /* ── Card meta grid ──────────────────────────────────────────────────────── */
@@ -1452,8 +1507,24 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
+}
+
+.shop-actions-row--primary {
   padding-top: 0.5rem;
   border-top: 1px solid var(--color-border, #2e2b24);
+}
+
+.shop-actions-row--secondary {
+  padding-top: 0.25rem;
+}
+
+.shop-next-action-label {
+  margin: 0;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-faint, #555);
+  font-weight: 700;
 }
 
 .shop-action-btn {
@@ -1499,6 +1570,40 @@
   border-color: rgba(99, 102, 241, 0.6);
   background: rgba(99, 102, 241, 0.12);
   color: rgba(99, 102, 241, 1);
+}
+
+.shop-action-btn--guide {
+  border-color: rgba(0, 188, 212, 0.35);
+  background: rgba(0, 188, 212, 0.08);
+  color: rgba(102, 233, 255, 0.94);
+}
+
+.shop-action-btn--guide:hover {
+  border-color: rgba(0, 188, 212, 0.58);
+  background: rgba(0, 188, 212, 0.16);
+  color: rgba(142, 240, 255, 1);
+}
+
+.shop-action-btn--website {
+  border-color: rgba(76, 175, 80, 0.35);
+  background: rgba(76, 175, 80, 0.08);
+  color: rgba(125, 211, 129, 0.95);
+}
+
+.shop-action-btn--website:hover {
+  border-color: rgba(76, 175, 80, 0.55);
+  background: rgba(76, 175, 80, 0.15);
+}
+
+.shop-action-btn--directions {
+  border-color: rgba(245, 158, 11, 0.35);
+  background: rgba(245, 158, 11, 0.08);
+  color: rgba(253, 186, 116, 0.96);
+}
+
+.shop-action-btn--directions:hover {
+  border-color: rgba(245, 158, 11, 0.55);
+  background: rgba(245, 158, 11, 0.16);
 }
 
 .shop-action-icon {
@@ -1594,6 +1699,10 @@
     justify-content: center;
     font-size: 0.7rem;
     padding: 0.3rem 0.5rem;
+  }
+
+  .shop-confidence-grid {
+    grid-template-columns: 1fr;
   }
   
   .shop-action-label {

--- a/shops.html
+++ b/shops.html
@@ -160,6 +160,7 @@
             <h2 id="shops-results-title">Listings</h2>
             <div id="shops-filter-pills" class="shops-filter-pills"></div>
             <p id="shops-active-filters" class="shops-active-filters"></p>
+            <p id="shops-results-legend" class="shops-results-legend">Legend: Store profile = direct business listing; Market-area listing = cluster/area reference. Details confidence reflects currently available contact details.</p>
             <p id="shops-results-disclaimer" class="shops-results-disclaimer">Listings may represent market areas or dealer clusters unless direct contact details are shown.</p>
           </div>
           <p id="shops-count" aria-live="polite"></p>

--- a/shops.js
+++ b/shops.js
@@ -99,7 +99,16 @@ const TXT = {
     info2Body: 'Cards indicate whether business details are limited or partially available so you know what to expect.',
     info3Title: 'Use as a shortlist',
     info3Body: 'This page is for reference and discovery. Always confirm current prices, charges, and product details directly with shops.',
+    resultsLegend: 'Legend: Store profile = direct business listing; Market-area listing = cluster/area reference. Details confidence reflects currently available contact details.',
     resultsDisclaimer: 'Listings may represent market areas or dealer clusters unless direct contact details are shown.',
+    listingConfidenceTitle: 'Listing type + details confidence',
+    detailsConfidence: 'Details confidence',
+    rankFull: 'High',
+    rankPartial: 'Medium',
+    rankLimited: 'Basic',
+    nextActionsStore: 'Best next steps',
+    nextActionsMarket: 'Area discovery',
+    areaGuide: 'Area guide',
     nextStepTitle: 'Before you buy',
     nextStepBody: 'Confirm final retail price, making charges, and taxes directly with the seller.',
     quickActionsCalc: 'Calculate Value',
@@ -168,7 +177,16 @@ const TXT = {
     info2Body: 'توضح البطاقات مستوى توفر تفاصيل النشاط حتى تعرف المعلومات المتاحة قبل التواصل.',
     info3Title: 'استخدمه كقائمة مختصرة',
     info3Body: 'هذه الصفحة للاكتشاف والمرجعية. احرص على تأكيد الأسعار والرسوم والتفاصيل مباشرة مع المحلات.',
+    resultsLegend: 'الدليل: ملف متجر = إدراج مباشر؛ إدراج منطقة سوق = مرجع لمنطقة/تجمع. مستوى الثقة يعكس تفاصيل الاتصال المتاحة حالياً.',
     resultsDisclaimer: 'قد تمثل بعض الإدراجات مناطق سوق أو تجمعات تجار ما لم تُعرض بيانات اتصال مباشرة.',
+    listingConfidenceTitle: 'نوع الإدراج + مستوى الثقة بالتفاصيل',
+    detailsConfidence: 'ثقة التفاصيل',
+    rankFull: 'مرتفع',
+    rankPartial: 'متوسط',
+    rankLimited: 'أساسي',
+    nextActionsStore: 'أفضل الخطوات التالية',
+    nextActionsMarket: 'استكشاف المنطقة',
+    areaGuide: 'دليل المنطقة',
     nextStepTitle: 'قبل الشراء',
     nextStepBody: 'أكد السعر النهائي للتجزئة ورسوم المصنعية والضرائب مباشرة مع البائع.',
     quickActionsCalc: 'احسب القيمة',
@@ -199,6 +217,18 @@ function detailsAvailabilityLabel(value) {
   return t('detailsLimited');
 }
 
+function detailsAvailabilityRank(value) {
+  if (value === 'full') return 3;
+  if (value === 'partial') return 2;
+  return 1;
+}
+
+function detailsConfidenceTier(value) {
+  if (value === 'full') return t('rankFull');
+  if (value === 'partial') return t('rankPartial');
+  return t('rankLimited');
+}
+
 function isMarketCluster(shop) {
   // Market clusters typically have "cluster", "shops", "dealers", "area", or "market" in notes
   // and empty phone/website
@@ -210,6 +240,23 @@ function isMarketCluster(shop) {
 
 function listingTypeLabel(shop) {
   return isMarketCluster(shop) ? t('marketAreaListing') : t('storeProfile');
+}
+
+function listingSortScore(shop) {
+  const detailRank = detailsAvailabilityRank(shop.detailsAvailability);
+  const contactBonus = shop.phone && shop.website ? 2 : (shop.phone || shop.website ? 1 : 0);
+  const typeBonus = isMarketCluster(shop) ? 0 : 1;
+  return (detailRank * 100) + (contactBonus * 10) + typeBonus;
+}
+
+function sortedShops(shops) {
+  return [...shops].sort((a, b) => {
+    const scoreDiff = listingSortScore(b) - listingSortScore(a);
+    if (scoreDiff !== 0) return scoreDiff;
+    const featuredDiff = Number(Boolean(b.featured)) - Number(Boolean(a.featured));
+    if (featuredDiff !== 0) return featuredDiff;
+    return a.name.localeCompare(b.name, STATE.lang);
+  });
 }
 
 function toggleShortlist(shopId) {
@@ -405,6 +452,7 @@ function applyStaticText() {
   document.getElementById('shops-info-2-body').textContent = t('info2Body');
   document.getElementById('shops-info-3-title').textContent = t('info3Title');
   document.getElementById('shops-info-3-body').textContent = t('info3Body');
+  document.getElementById('shops-results-legend').textContent = t('resultsLegend');
   document.getElementById('shops-results-disclaimer').textContent = t('resultsDisclaimer');
 
   const modalCloseBtn = document.querySelector('.shops-modal-close');
@@ -601,6 +649,12 @@ function renderCards(shops) {
     const clusterBadge = isCluster ? `<span class="shop-cluster-badge">${t('marketCluster')}</span>` : '';
     const listingTypeBadge = `<span class="shop-listing-type ${isCluster ? 'shop-listing-type--market' : 'shop-listing-type--store'}">${listingTypeLabel(shop)}</span>`;
     const inShortlist = isInShortlist(shop.id);
+    const countryUrl = country?.slug ? `countries/${country.slug}.html` : '';
+    const areaGuideUrl = `${location.pathname}?country=${encodeURIComponent(shop.countryCode)}&search=${encodeURIComponent(shop.market)}`;
+    const directionsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${shop.name}, ${shop.market}, ${shop.city}`)}`;
+    const confidenceTier = detailsConfidenceTier(shop.detailsAvailability);
+    const detailsLabel = detailsAvailabilityLabel(shop.detailsAvailability);
+    const nextActionLabel = isCluster ? t('nextActionsMarket') : t('nextActionsStore');
 
     const contactParts = [];
     if (shop.phone) contactParts.push(`${t('phone')}: ${shop.phone}`);
@@ -619,8 +673,21 @@ function renderCards(shops) {
               ${shop.featured ? `<span class="shop-featured">${t('featured')}</span>` : ''}
             </div>
           </div>
-          <span class="shop-signal shop-signal--${shop.detailsAvailability}">${detailsAvailabilityLabel(shop.detailsAvailability)}</span>
         </header>
+
+        <section class="shop-confidence-block" aria-label="${t('listingConfidenceTitle')}">
+          <p class="shop-confidence-title">${t('listingConfidenceTitle')}</p>
+          <div class="shop-confidence-grid">
+            <p class="shop-confidence-item">
+              <span>${t('category')}</span>
+              <strong>${listingTypeLabel(shop)}</strong>
+            </p>
+            <p class="shop-confidence-item">
+              <span>${t('detailsConfidence')}</span>
+              <strong class="shop-signal shop-signal--${shop.detailsAvailability}">${confidenceTier} · ${detailsLabel}</strong>
+            </p>
+          </div>
+        </section>
 
         <div class="shop-meta-grid">
           <p class="shop-meta"><span>${t('location')}</span><strong>${shop.city}, ${countryName(country)} · ${regionName(country.group)}</strong></p>
@@ -635,7 +702,31 @@ function renderCards(shops) {
 
         <p class="shop-notes">${shop.notes}</p>
         
-        <div class="shop-actions-row">
+        <div class="shop-next-action-label">${nextActionLabel}</div>
+        <div class="shop-actions-row shop-actions-row--primary">
+          ${isCluster ? `<a href="${areaGuideUrl}" class="shop-action-btn shop-action-btn--guide" aria-label="${t('areaGuide')}: ${shop.market}">
+            <span class="shop-action-icon">🧭</span>
+            <span class="shop-action-label">${t('areaGuide')}</span>
+          </a>` : ''}
+          ${!isCluster && shop.phone ? `<a href="tel:${shop.phone.replace(/\s+/g, '')}" class="shop-action-btn shop-action-btn--call" aria-label="${t('callShop')}">
+            <span class="shop-action-icon">📞</span>
+            <span class="shop-action-label">${t('callShop')}</span>
+          </a>` : ''}
+          ${!isCluster && shop.website ? `<a href="${shop.website}" target="_blank" rel="noopener" class="shop-action-btn shop-action-btn--website" aria-label="${t('visitWebsite')}">
+            <span class="shop-action-icon">🌐</span>
+            <span class="shop-action-label">${t('visitWebsite')}</span>
+          </a>` : ''}
+          ${!isCluster ? `<a href="${directionsUrl}" target="_blank" rel="noopener" class="shop-action-btn shop-action-btn--directions" aria-label="${t('directions')}">
+            <span class="shop-action-icon">🧭</span>
+            <span class="shop-action-label">${t('directions')}</span>
+          </a>` : ''}
+          ${countryUrl ? `<a href="${countryUrl}" class="shop-action-btn shop-action-btn--country" aria-label="${t('viewCountryPage')}: ${countryName(country)}">
+            <span class="shop-action-icon">📄</span>
+            <span class="shop-action-label">${countryName(country)}</span>
+          </a>` : ''}
+        </div>
+
+        <div class="shop-actions-row shop-actions-row--secondary">
           <button class="shop-action-btn shop-action-btn--save ${inShortlist ? 'is-saved' : ''}" 
                   type="button" data-shop-id="${shop.id}" aria-label="${inShortlist ? t('removeFromShortlist') : t('saveToShortlist')}">
             <span class="shop-action-icon">${inShortlist ? '✓' : '+'}</span>
@@ -645,14 +736,6 @@ function renderCards(shops) {
             <span class="shop-action-icon">↗</span>
             <span class="shop-action-label">${t('shareShop')}</span>
           </button>
-          ${shop.phone ? `<a href="tel:${shop.phone.replace(/\s+/g, '')}" class="shop-action-btn shop-action-btn--call" aria-label="${t('callShop')}">
-            <span class="shop-action-icon">📞</span>
-            <span class="shop-action-label">${t('callShop')}</span>
-          </a>` : ''}
-          ${country?.slug ? `<a href="countries/${country.slug}.html" class="shop-action-btn shop-action-btn--country" aria-label="${t('viewCountryPage')}: ${countryName(country)}">
-            <span class="shop-action-icon">📄</span>
-            <span class="shop-action-label">${countryName(country)}</span>
-          </a>` : ''}
         </div>
         
         <p class="shop-contact">${contactParts.join(' · ') || t('noContact')}</p>
@@ -845,7 +928,7 @@ function renderShortlistBar() {
 
 function render() {
   syncUrlToState();
-  const shops = filterShops();
+  const shops = sortedShops(filterShops());
   const empty = document.getElementById('shops-empty');
   const count = document.getElementById('shops-count');
   if (count) count.textContent = t('count')(shops.length);


### PR DESCRIPTION
### Motivation
- Improve trust and discovery by surfacing listings with richer contact details higher, and make listing-type and details-confidence explicit on each card. 
- Provide clearer, listing-type-specific next actions so users know the most useful next step (call/website/directions for stores; area guide/country page for market clusters).

### Description
- Added a default ranking in `shops.js` that scores listings by details availability (`full` > `partial` > `limited`) with tie-breakers for contact completeness and listing type, and applied it at render time via `sortedShops` (preserving existing filter logic and URL sync). (files: `shops.js`)
- Inserted a visible “Listing type + details confidence” block at the top of each card and promoted the details signal visually; added i18n strings for legend, confidence labels, and next-action labels in both EN/AR. (files: `shops.js`, `shops.html`)
- Implemented listing-type-specific primary CTAs: store profiles emphasize call / website / directions and country page, while market-area listings emphasize an area guide and country page; save/share remain as secondary actions. (files: `shops.js`, `shops.css`)
- Kept the existing disclaimer and added a concise one-line trust legend above results; added CSS for the legend, confidence panel, and new CTA variants with responsive behaviour. (files: `shops.html`, `shops.css`)

### Testing
- Ran `node --check shops.js` to validate JavaScript syntax: succeeded.
- Ran `git diff --check` and `git status` to verify diffs and repository state: no whitespace/patch errors.
- Confirmed commits were created locally via `git commit` in this environment: succeeded.
- Note: no in-browser visual or interaction QA was possible here and branch freshness vs `main` could not be checked because no `origin`/`main` remote was available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cb5d4d8483219d2988c893613733)