### PR TITLE
Standardize trust labels and freshness semantics; remove duplicate Clarity script

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -54,6 +54,8 @@
             <span id="calc-aed-price">—</span>
           </div>
         </div>
+        <p class="calc-hero-sub" id="calc-freshness-note">Freshness: waiting for source timestamp…</p>
+        <p class="calc-disclaimer" id="calc-trust-note">Labels used across GoldPrices: Live, Delayed, Cached/Fallback, Estimated, Historical baseline. Calculator outputs are spot-linked reference estimates, not final retail jewelry quotes.</p>
       </div>
     </section>
 

--- a/calculator.js
+++ b/calculator.js
@@ -17,6 +17,7 @@ import { injectBreadcrumbs } from './components/breadcrumbs.js';
 const STATE = {
   lang: 'en',
   spotUsdPerOz: 0,
+  spotSource: 'cached/fallback',
   rates: {},
   fxMeta: { nextUpdateUtc: 0 },
   status: { goldStale: false, fxStale: false },
@@ -80,6 +81,8 @@ const T = {
     conv_amount: 'Amount',
     conv_from: 'From',
     conv_results_title: 'Equivalent weights',
+    freshness_waiting: 'Freshness: waiting for source timestamp…',
+    trust_note: 'Labels used across GoldPrices: Live, Delayed, Cached/Fallback, Estimated, Historical baseline. Calculator outputs are spot-linked reference estimates, not final retail jewelry quotes.',
   },
   ar: {
     pageTitle: 'حاسبة الذهب',
@@ -127,6 +130,8 @@ const T = {
     conv_amount: 'الكمية',
     conv_from: 'من',
     conv_results_title: 'الأوزان المكافئة',
+    freshness_waiting: 'حداثة البيانات: بانتظار الطابع الزمني من المصدر…',
+    trust_note: 'التسميات الموحدة عبر GoldPrices: مباشر، متأخر، مخزن/احتياطي، تقديري، وخط أساس تاريخي. نتائج الحاسبة تقديرات مرجعية مرتبطة بالسعر الفوري وليست سعر تجزئة نهائي للمجوهرات.',
   },
 };
 
@@ -422,6 +427,8 @@ function applyLang() {
   set('conv-amount-label', t('conv_amount'));
   set('conv-from-label', t('conv_from'));
   set('conv-results-title', t('conv_results_title'));
+  set('calc-freshness-note', t('freshness_waiting'));
+  set('calc-trust-note', t('trust_note'));
 
   document.documentElement.lang = STATE.lang;
   document.documentElement.dir  = STATE.lang === 'ar' ? 'rtl' : 'ltr';
@@ -442,6 +449,25 @@ function updateSpotBadge() {
     const aed24 = (STATE.spotUsdPerOz / CONSTANTS.TROY_OZ_GRAMS) * CONSTANTS.AED_PEG;
     aedPrice.textContent = `AED ${aed24.toFixed(2)}`;
     aedBadge.hidden = false;
+  }
+
+  const freshnessEl = document.getElementById('calc-freshness-note');
+  if (freshnessEl) {
+    if (!STATE.freshness.goldUpdatedAt) {
+      freshnessEl.textContent = t('freshness_waiting');
+    } else {
+      const locale = STATE.lang === 'ar' ? 'ar-AE' : 'en-US';
+      const stamp = new Date(STATE.freshness.goldUpdatedAt).toLocaleString(locale, {
+        year: 'numeric', month: 'short', day: 'numeric',
+        hour: '2-digit', minute: '2-digit',
+      });
+      const sourceLabel = STATE.spotSource === 'live'
+        ? (STATE.lang === 'ar' ? 'مباشر' : 'Live')
+        : (STATE.lang === 'ar' ? 'مخزن/احتياطي' : 'Cached/Fallback');
+      freshnessEl.textContent = STATE.lang === 'ar'
+        ? `حداثة البيانات: ${sourceLabel} · ${stamp} · المصدر: gold-api.com`
+        : `Freshness: ${sourceLabel} · ${stamp} · Source: gold-api.com`;
+    }
   }
 }
 
@@ -480,7 +506,11 @@ async function fetchLiveData() {
     const [goldRes, fxRes] = await Promise.allSettled([api.fetchGold(), api.fetchFX()]);
     if (goldRes.status === 'fulfilled') {
       STATE.spotUsdPerOz = goldRes.value.price;
+      STATE.freshness.goldUpdatedAt = goldRes.value.updatedAt || new Date().toISOString();
+      STATE.spotSource = 'live';
       cache.saveGoldPrice(goldRes.value.price, goldRes.value.updatedAt);
+    } else if (STATE.spotUsdPerOz) {
+      STATE.spotSource = 'cached/fallback';
     }
     if (fxRes.status === 'fulfilled') {
       STATE.rates = fxRes.value.rates;

--- a/countries/country-page.js
+++ b/countries/country-page.js
@@ -61,7 +61,7 @@ const T = {
     karat21: '21K',
     karat18: '18K',
     karatTitle: 'Gold Karat Prices',
-    karatSub: 'All prices are estimates based on live XAU/USD spot rate and exchange rate.',
+    karatSub: 'All prices are spot-linked reference estimates. Trust labels: Live, Delayed, Cached/Fallback, Estimated, Historical baseline.',
     usdEquiv: 'USD Equivalent',
     change: 'Change',
     from: 'from today\'s open',
@@ -69,8 +69,8 @@ const T = {
     fixedPeg: 'Fixed Peg',
     faq: 'Frequently Asked Questions',
     related: 'Related Countries',
-    disclaimer: 'Prices are indicative estimates only — not financial advice.',
-    lastUpdate: 'Last updated',
+    disclaimer: 'Spot-linked reference estimates only — not final retail jewelry quotes. Retail prices may include making charges, dealer margins, and local taxes.',
+    lastUpdate: 'Freshness',
     gram: 'gram',
     oz: 'troy oz',
     switchLang: 'العربية',
@@ -84,7 +84,7 @@ const T = {
     karat21: 'عيار 21',
     karat18: 'عيار 18',
     karatTitle: 'أسعار عيارات الذهب',
-    karatSub: 'جميع الأسعار تقديرية بناءً على سعر الذهب مقابل الدولار.',
+    karatSub: 'جميع الأسعار تقديرات مرجعية مرتبطة بالسعر الفوري. تسميات الثقة: مباشر، متأخر، مخزن/احتياطي، تقديري، وخط أساس تاريخي.',
     usdEquiv: 'ما يعادله بالدولار',
     change: 'التغيير',
     from: 'من سعر فتح اليوم',
@@ -92,8 +92,8 @@ const T = {
     fixedPeg: 'ربط ثابت',
     faq: 'الأسئلة الشائعة',
     related: 'دول أخرى',
-    disclaimer: 'الأسعار تقديرية فقط — وليست نصيحة مالية.',
-    lastUpdate: 'آخر تحديث',
+    disclaimer: 'هذه الأسعار تقديرات مرجعية مرتبطة بالسعر الفوري وليست أسعار تجزئة نهائية للمجوهرات. قد تتضمن أسعار التجزئة رسوم مصنعية وهوامش وضرائب محلية.',
+    lastUpdate: 'حداثة البيانات',
     gram: 'غرام',
     oz: 'أوقية',
     switchLang: 'English',
@@ -162,7 +162,7 @@ function renderHero(cfg) {
         <span class="badge ${changeClass}">${changeSign}${changeVal.toFixed(2)}%</span>
         <span class="cp-change-label">${t('from')}</span>
       </div>` : ''}
-      <div class="cp-update-time">${t('lastUpdate')}: ${STATE.freshness.goldUpdatedAt ? new Date(STATE.freshness.goldUpdatedAt).toLocaleString(STATE.lang === 'ar' ? 'ar-AE' : 'en-AE', { timeZone: cfg.timezone, hour12: true, year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '—'}</div>
+      <div class="cp-update-time">${t('lastUpdate')}: ${STATE.status.goldStale ? 'Cached/Fallback' : 'Live'} · ${STATE.freshness.goldUpdatedAt ? new Date(STATE.freshness.goldUpdatedAt).toLocaleString(STATE.lang === 'ar' ? 'ar-AE' : 'en-AE', { timeZone: cfg.timezone, hour12: true, year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '—'} · Source: gold-api.com</div>
     </div>`;
 }
 

--- a/countries/uae.html
+++ b/countries/uae.html
@@ -52,9 +52,6 @@
     </section>
 
     <section class="cp-section">
-      <div class="cp-trust-note">
-        ⚠ These are spot-linked bullion estimates — not retail jewelry prices. Actual store prices include making charges and shop margins. AED uses the official UAE Central Bank peg: 1 USD = 3.6725 AED (fixed).
-      </div>
       <div id="cp-karat-table"></div>
     </section>
 

--- a/home.js
+++ b/home.js
@@ -18,6 +18,8 @@ let lang = 'en';
 let goldPrice = null;
 let dayOpenPrice = null;
 let rates = {};
+let goldUpdatedAt = null;
+let priceSourceLabel = 'cached/fallback';
 let _refreshTimer = null;
 
 function getLang() {
@@ -75,6 +77,7 @@ const T = {
     lbl21usd: '21K / gram (USD)',
     fetching: 'Fetching...',
     updated: 'Updated',
+    source: 'Source',
     changeLabel: 'Today',
     marketOpen: '● Market Open',
     marketClosed: '○ Market Closed',
@@ -161,6 +164,7 @@ const T = {
     lbl21usd: 'عيار 21 / غرام (USD)',
     fetching: 'جارٍ التحميل...',
     updated: 'آخر تحديث',
+    source: 'المصدر',
     changeLabel: 'اليوم',
     marketOpen: '● السوق مفتوح',
     marketClosed: '○ السوق مغلق',
@@ -269,7 +273,9 @@ function renderHeroCard() {
   set('hlc-usd22',  fmt.formatPrice(usd22g,  'USD', 2));
   set('hlc-aed22',  fmt.formatPrice(aed22g,  'AED', 2));
   set('hlc-usd21',  fmt.formatPrice(usd21g,  'USD', 2));
-  set('hlc-updated', `${tx('updated')}: ${fmt.formatTimestampShort(new Date().toISOString(), lang)}`);
+  const freshnessTime = goldUpdatedAt || new Date().toISOString();
+  const sourceText = priceSourceLabel === 'live' ? 'Live' : 'Cached/Fallback';
+  set('hlc-updated', `${tx('updated')}: ${fmt.formatTimestampShort(freshnessTime, lang)} · ${tx('source')}: ${sourceText}`);
 
   // Change vs day open
   const changeEl = document.getElementById('hlc-change');
@@ -448,8 +454,12 @@ async function fetchLiveData() {
 
   if (goldRes.status === 'fulfilled') {
     goldPrice = goldRes.value.price;
+    goldUpdatedAt = goldRes.value.updatedAt || new Date().toISOString();
+    priceSourceLabel = 'live';
     cache.saveGoldPrice(goldRes.value.price, goldRes.value.updatedAt);
     renderHeroCard();
+  } else if (!goldPrice) {
+    priceSourceLabel = 'cached/fallback';
   }
 
   if (fxRes.status === 'fulfilled') {
@@ -514,6 +524,8 @@ async function init() {
     goldPrice = STATE_STUB.goldPriceUsdPerOz;
     dayOpenPrice = STATE_STUB.dayOpenGoldPriceUsdPerOz;
     rates = STATE_STUB.rates;
+    goldUpdatedAt = STATE_STUB.freshness?.goldUpdatedAt || null;
+    priceSourceLabel = 'cached/fallback';
   }
 
   applyLangToPage();

--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
           <div class="trust-banner-icon">⚠️</div>
           <div class="trust-banner-content">
             <h3>About Our Data</h3>
-            <p>These are <strong>spot-linked bullion estimates</strong>, not retail jewelry prices. Actual store prices include making charges and shop margins (typically 3–25 AED/gram). Prices update every 90 seconds from <a href="https://gold-api.com" target="_blank">gold-api.com</a>. <a href="methodology.html">Full methodology →</a></p>
+            <p>These are <strong>spot-linked reference estimates</strong>, not final retail jewelry prices. Retail quotes usually add making charges, dealer/shop margins, and local taxes (where applicable). Freshness labels use one shared vocabulary sitewide: <strong>Live</strong>, <strong>Delayed</strong>, <strong>Cached/Fallback</strong>, <strong>Estimated</strong>, and <strong>Historical baseline</strong>. Source: <a href="https://gold-api.com" target="_blank" rel="noopener">gold-api.com</a> for XAU/USD plus FX conversion rules. <a href="methodology.html">Full methodology →</a></p>
           </div>
         </div>
       </div>

--- a/learn.html
+++ b/learn.html
@@ -68,14 +68,6 @@
     })(window, document, "clarity", "script", "w4e0nhdxt5");
 </script>
 
-  <script type="text/javascript">
-    (function(c,l,a,r,i,t,y){
-        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-    })(window, document, "clarity", "script", "w4e0nhdxt5");
-</script>
-
   <meta name="msvalidate.01" content="E88623E4C36CDC8E8D44913FA9192725" />
   
 </head>

--- a/shops.html
+++ b/shops.html
@@ -43,6 +43,8 @@
           <span class="shops-trust-icon" aria-hidden="true">◈</span>
           <span class="shops-trust-text"><span id="shops-trust-label">Reference listings</span> · <span id="shops-last-updated">Loading...</span></span>
         </div>
+        <p class="shops-results-disclaimer" id="shops-freshness-semantics">Freshness semantics: Live / Delayed / Cached-Fallback / Estimated / Historical baseline (used consistently across GoldPrices). Directory source: editorial review timestamp.</p>
+        <p class="shops-results-disclaimer" id="shops-price-disclaimer">Listings support discovery only. Spot-linked reference prices are separate from final retail jewelry quotes.</p>
 
         <div class="shops-hero-stats" aria-label="Directory overview">
           <div class="shops-stat">

--- a/shops.js
+++ b/shops.js
@@ -114,6 +114,8 @@ const TXT = {
     quickActionsCalc: 'Calculate Value',
     quickActionsRates: 'Live Rates',
     quickActionsUAE: 'UAE Market',
+    freshnessSemantics: 'Freshness semantics: Live / Delayed / Cached-Fallback / Estimated / Historical baseline (used consistently across GoldPrices). Directory source: editorial review timestamp.',
+    priceDisclaimer: 'Listings support discovery only. Spot-linked reference prices are separate from final retail jewelry quotes.',
   },
   ar: {
     kicker: 'محلات حسب المنطقة',
@@ -192,6 +194,8 @@ const TXT = {
     quickActionsCalc: 'احسب القيمة',
     quickActionsRates: 'الأسعار المباشرة',
     quickActionsUAE: 'سوق الإمارات',
+    freshnessSemantics: 'دلالات حداثة البيانات: مباشر / متأخر / مخزن-احتياطي / تقديري / خط أساس تاريخي (موحدة عبر GoldPrices). مصدر الدليل: تاريخ مراجعة تحريرية.',
+    priceDisclaimer: 'هذه الإدراجات للاكتشاف فقط. الأسعار المرجعية المرتبطة بالسعر الفوري منفصلة عن سعر التجزئة النهائي للمجوهرات.',
   }
 };
 
@@ -454,6 +458,8 @@ function applyStaticText() {
   document.getElementById('shops-info-3-body').textContent = t('info3Body');
   document.getElementById('shops-results-legend').textContent = t('resultsLegend');
   document.getElementById('shops-results-disclaimer').textContent = t('resultsDisclaimer');
+  document.getElementById('shops-freshness-semantics').textContent = t('freshnessSemantics');
+  document.getElementById('shops-price-disclaimer').textContent = t('priceDisclaimer');
 
   const modalCloseBtn = document.querySelector('.shops-modal-close');
   if (modalCloseBtn) {

--- a/tracker-pro.js
+++ b/tracker-pro.js
@@ -255,10 +255,12 @@ function startAutoRefresh() {
     checkAlerts();
     renderAll();
     if (el.refreshBadge) {
-      const now = new Date().toLocaleTimeString();
+      const stamp = state.live?.updatedAt
+        ? new Date(state.live.updatedAt).toLocaleString()
+        : new Date().toLocaleTimeString();
       el.refreshBadge.textContent = state.hasLiveFailure
-        ? `Cached/fallback · last update ${now}`
-        : `Live source · synced ${now}`;
+        ? `Cached/Fallback · source timestamp ${stamp} · Source: gold-api.com`
+        : `Live · source timestamp ${stamp} · Source: gold-api.com`;
     }
   }, CONSTANTS.GOLD_REFRESH_MS);
 }
@@ -319,6 +321,7 @@ async function fetchLive() {
       const fb = cache.getFallbackGoldPrice();
       if (fb) {
         state.live = { price: fb.price, updatedAt: fb.updatedAt, raw: fb };
+        state.hasLiveFailure = true;
       } else {
         state.hasLiveFailure = true;
       }

--- a/tracker.html
+++ b/tracker.html
@@ -58,7 +58,7 @@
       <div class="tracker-data-trust-banner">
         <div class="tracker-trust-icon">⚠️</div>
         <div class="tracker-trust-content">
-          <strong>Spot-Linked Estimates Only:</strong> These prices are based on global XAU/USD spot rates, not retail jewelry prices which include making charges (3–25 AED/gram) and shop markups. See <a href="methodology.html">Methodology</a> for full transparency on data sources, calculation methods, and update frequencies.
+          <strong>Spot-Linked Reference Estimates:</strong> These prices are based on global XAU/USD spot data and conversion rules, not final retail jewelry quotes (which may add making charges, dealer/shop margins, and local taxes). Freshness labels follow one shared vocabulary: <strong>Live</strong>, <strong>Delayed</strong>, <strong>Cached/Fallback</strong>, <strong>Estimated</strong>, and <strong>Historical baseline</strong>. See <a href="methodology.html">Methodology</a> for definitions and source details.
         </div>
         <button class="tracker-trust-close" type="button" aria-label="Close trust banner" title="Close">&times;</button>
       </div>

--- a/tracker/render.js
+++ b/tracker/render.js
@@ -20,7 +20,7 @@ export function renderHero() {
   if (_el.liveBadgeText) {
     if (spot) {
       _el.liveBadgeText.textContent = _state.hasLiveFailure
-        ? `Fallback · XAU/USD ${spot.toLocaleString('en', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} (cached)`
+        ? `Cached/Fallback · XAU/USD ${spot.toLocaleString('en', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
         : `Live · XAU/USD ${spot.toLocaleString('en', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
     } else {
       _el.liveBadgeText.textContent = _state.hasLiveFailure ? 'Live feed unavailable — no cached data' : 'Connecting to API…';
@@ -262,7 +262,7 @@ export function renderDecisionCues() {
   const lines = [
     `Live spot: $${spot.toFixed(2)} / troy oz`,
     _state.hasLiveFailure
-      ? `⚠ Data source: fallback — using cache (API unreachable — live may return soon)`
+      ? `⚠ Data source: Cached/Fallback — using cache (API unreachable — live may return soon)`
       : `✓ Data source: live · last API fetch successful`,
     `History coverage: 2019–Aug 2025 (LBMA baseline) + ${_state.snapshots?.length || 0} session snapshots`,
   ];


### PR DESCRIPTION
### Motivation
- Task: remove a duplicate telemetry block and unify trust/freshness language so the site consistently distinguishes spot-linked reference estimates from retail jewelry prices. 
- Intent: improve user trust and reduce ambiguity by applying one shared vocabulary (`Live`, `Delayed`, `Cached/Fallback`, `Estimated`, `Historical baseline`) and clear timestamp/source semantics across core pages.

### Description
- Removed the duplicate Microsoft Clarity script block from `learn.html`, leaving a single Clarity snippet. 
- Standardized trust/disclaimer copy and introduced the shared vocabulary in `index.html`, `tracker.html`, `calculator.html`, `shops.html`, and the country template via `countries/country-page.js`, and removed the UAE-only hardcoded trust note in `countries/uae.html`. 
- Added freshness/source semantics (source label + timestamp and `gold-api.com` attribution) and UI text wiring in `home.js`, `tracker-pro.js`, `tracker/render.js`, and `calculator.js`, and localized trust/freshness strings in `shops.js`. 
- Small i18n and DOM updates to surface freshness and trust text were committed together on branch `work` as a single change set.

### Testing
- Syntax checks: ran `node --check` on `home.js`, `calculator.js`, `shops.js`, `tracker-pro.js`, `tracker/render.js`, and `countries/country-page.js`, and all files passed without syntax errors. 
- Text/search verification: confirmed a single Clarity block with `rg -n "clarity.ms/tag" learn.html` and presence of the shared vocabulary using `rg -n "Live, Delayed, Cached/Fallback, Estimated, Historical baseline|Spot-Linked Reference Estimates|Freshness:" index.html tracker.html calculator.html shops.html countries/country-page.js`. 
- Git: staged and committed the changes (`git commit`) creating commit `e37b890` on branch `work`; note that I could not perform a `main`-branch sync/merge check in this environment because only the `work` branch was available locally, so merge-conflict checks against `main` were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d032d1048321824df5549932cc87)