### PR TITLE
Tracker: add URL panel support, canonicalize legacy hashes, and sync overlays with state

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -38,8 +38,8 @@ export function injectFooter(lang = 'en', depth = 0) {
         <h4 class="footer-col-heading">${isAr ? 'الأسواق' : 'Markets'}</h4>
         <a href="${r('../tracker.html')}">${isAr ? 'تتبع مباشر' : 'Live Tracker'}</a>
         <a href="${r('../countries/uae.html')}">${isAr ? 'ذهب الإمارات اليوم' : 'UAE Gold Today'}</a>
-        <a href="${r('../tracker.html#section-countries')}">${isAr ? 'مقارنة دول الخليج' : 'GCC Compare'}</a>
-        <a href="${r('../tracker.html#section-chart')}">${isAr ? 'البيانات التاريخية' : 'History &amp; Data'}</a>
+        <a href="${r('../tracker.html#mode=compare')}">${isAr ? 'مقارنة دول الخليج' : 'GCC Compare'}</a>
+        <a href="${r('../tracker.html#mode=archive')}">${isAr ? 'البيانات التاريخية' : 'History &amp; Data'}</a>
         <a href="${r('../shops.html')}">${isAr ? 'دليل المحلات' : 'Shop Directory'}</a>
       </div>
 
@@ -47,8 +47,8 @@ export function injectFooter(lang = 'en', depth = 0) {
       <div class="footer-col footer-col--links">
         <h4 class="footer-col-heading">${isAr ? 'الأدوات' : 'Tools'}</h4>
         <a href="${r('../calculator.html')}">${isAr ? 'حاسبة الذهب' : 'Gold Calculator'}</a>
-        <a href="${r('../tracker.html#section-alerts')}">${isAr ? 'تنبيهات السعر' : 'Price Alerts'}</a>
-        <a href="${r('../tracker.html#section-chart')}">${isAr ? 'تنزيل البيانات' : 'Downloads'}</a>
+        <a href="${r('../tracker.html#mode=live&panel=alerts')}">${isAr ? 'تنبيهات السعر' : 'Price Alerts'}</a>
+        <a href="${r('../tracker.html#mode=exports')}">${isAr ? 'تنزيل البيانات' : 'Downloads'}</a>
       </div>
 
       <!-- GCC column -->

--- a/components/nav-data.js
+++ b/components/nav-data.js
@@ -23,7 +23,7 @@ export const NAV_DATA = {
         label: 'Tools',
         items: [
           { href: '../calculator.html',                label: 'Calculator'   },
-          { href: '../tracker.html#mode=alerts',         label: 'Alerts'       },
+          { href: '../tracker.html#mode=live&panel=alerts',         label: 'Alerts'       },
           { href: '../tracker.html#mode=exports',        label: 'Downloads'    },
           { href: '../tracker.html#mode=archive',        label: 'Date Lookup'  },
           { href: '../tracker.html#mode=archive',        label: 'Archive'      },
@@ -96,7 +96,7 @@ export const NAV_DATA = {
         label: 'أدوات',
         items: [
           { href: '../calculator.html',                label: 'حاسبة'             },
-          { href: '../tracker.html#mode=alerts',         label: 'تنبيهات'           },
+          { href: '../tracker.html#mode=live&panel=alerts',         label: 'تنبيهات'           },
           { href: '../tracker.html#mode=exports',        label: 'تنزيلات'           },
           { href: '../tracker.html#mode=archive',        label: 'البحث بالتاريخ'    },
           { href: '../tracker.html#mode=archive',        label: 'الأرشيف'           },

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
           <div class="hero-ctas-secondary">
             <a href="calculator.html" class="hero-secondary-link" id="hero-cta-calc">Calculator</a>
             <span class="hero-secondary-sep" aria-hidden="true">·</span>
-            <a href="tracker.html#section-alerts" class="hero-secondary-link" id="hero-cta-alert">Set Alert</a>
+            <a href="tracker.html#mode=live&panel=alerts" class="hero-secondary-link" id="hero-cta-alert">Set Alert</a>
             <span class="hero-secondary-sep" aria-hidden="true">·</span>
             <a href="methodology.html" class="hero-secondary-link" id="hero-cta-method">How it works</a>
           </div>
@@ -265,20 +265,20 @@
             <h2 id="history-section-title" class="home-section-title">Historical Gold Prices</h2>
             <p class="home-section-sub" id="history-section-sub">Explore daily, monthly &amp; annual data — download CSV, look up any date</p>
           </div>
-          <a href="tracker.html#section-chart" class="section-link" id="history-see-all">Open Full History →</a>
+          <a href="tracker.html#mode=archive" class="section-link" id="history-see-all">Open Full History →</a>
         </div>
         <div class="history-feature-grid">
           <div class="history-feat-card history-feat-card--chart">
             <div class="history-feat-icon">📈</div>
             <h3 id="hist-feat-1-t">Price Chart</h3>
             <p id="hist-feat-1-d">24H to 5Y range. Interactive chart with full gold price history across all karats and currencies.</p>
-            <a href="tracker.html#section-chart" class="history-feat-link" id="hist-feat-1-l">Open Chart →</a>
+            <a href="tracker.html#mode=archive" class="history-feat-link" id="hist-feat-1-l">Open Chart →</a>
           </div>
           <div class="history-feat-card">
             <div class="history-feat-icon">📅</div>
             <h3 id="hist-feat-2-t">Monthly Archive</h3>
             <p id="hist-feat-2-d">Browse historical gold prices month by month for any country or karat.</p>
-            <a href="tracker.html#section-chart" class="history-feat-link" id="hist-feat-2-l">Browse Archive →</a>
+            <a href="tracker.html#mode=archive" class="history-feat-link" id="hist-feat-2-l">Browse Archive →</a>
           </div>
           <div class="history-feat-card">
             <div class="history-feat-icon">⬇</div>
@@ -290,7 +290,7 @@
             <div class="history-feat-icon">🔍</div>
             <h3 id="hist-feat-4-t">Date Lookup</h3>
             <p id="hist-feat-4-d">Look up exactly what gold was worth on any specific date in any currency.</p>
-            <a href="tracker.html#section-chart" class="history-feat-link" id="hist-feat-4-l">Lookup →</a>
+            <a href="tracker.html#mode=archive" class="history-feat-link" id="hist-feat-4-l">Lookup →</a>
           </div>
         </div>
       </div>
@@ -416,7 +416,7 @@
             <h2 id="alert-cta-title">Set a Price Alert</h2>
             <p id="alert-cta-desc">Get notified when UAE 24K crosses your target price. Free, stored locally — no account needed.</p>
           </div>
-          <a href="tracker.html#alerts" class="btn btn-primary btn-lg" id="alert-cta-btn">Set Alert</a>
+          <a href="tracker.html#mode=live&panel=alerts" class="btn btn-primary btn-lg" id="alert-cta-btn">Set Alert</a>
         </div>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -44,6 +44,26 @@
   --color-error:       #b81428;
   --color-error-bg:    rgba(184,20,40,0.08);
 
+  /* Semantic surfaces (canonical) */
+  --surface-canvas:    var(--color-bg);
+  --surface-primary:   var(--color-surface);
+  --surface-secondary: var(--color-surface-2);
+  --surface-tertiary:  var(--color-surface-3);
+  --surface-accent:    var(--color-gold-bg);
+
+  /* Semantic text tiers (canonical) */
+  --text-primary:      var(--color-text);
+  --text-secondary:    var(--color-text-muted);
+  --text-tertiary:     var(--color-text-faint);
+  --text-accent:       var(--color-gold-dark);
+  --text-on-dark:      #ffffff;
+
+  /* Semantic borders (canonical) */
+  --border-default:    var(--color-border);
+  --border-subtle:     var(--color-border-subtle);
+  --border-strong:     #d9cfb7;
+  --border-accent:     var(--color-gold);
+
   /* Radii */
   --radius-xs: 4px;
   --radius-sm: 8px;
@@ -51,6 +71,12 @@
   --radius-lg: 18px;
   --radius-xl: 24px;
   --radius-pill: 999px;
+
+  /* Radius semantic aliases (canonical) */
+  --radius-control:    var(--radius-sm);
+  --radius-card:       var(--radius-lg);
+  --radius-panel:      var(--radius-xl);
+  --radius-badge:      var(--radius-pill);
 
   /* Shadows — luxury layered depth */
   --shadow-xs: 0 1px 2px rgba(0,0,0,0.04), 0 1px 1px rgba(0,0,0,0.02);
@@ -62,11 +88,30 @@
   --shadow-gold-lg: 0 8px 32px rgba(196,153,62,0.28), 0 2px 8px rgba(196,153,62,0.12);
   --shadow-card-hover: 0 8px 28px rgba(0,0,0,0.10), 0 2px 6px rgba(196,153,62,0.08);
 
+  /* Elevation semantic aliases (canonical) */
+  --elev-1:            var(--shadow-xs);
+  --elev-2:            var(--shadow-sm);
+  --elev-3:            var(--shadow-md);
+  --elev-4:            var(--shadow-lg);
+  --elev-5:            var(--shadow-xl);
+  --elev-accent:       var(--shadow-gold);
+  --elev-accent-strong: var(--shadow-gold-lg);
+
   /* Premium gradients */
   --gradient-gold: linear-gradient(135deg, #c4993e 0%, #e0b84a 50%, #c4993e 100%);
   --gradient-gold-subtle: linear-gradient(135deg, rgba(196,153,62,0.08) 0%, rgba(224,184,74,0.04) 100%);
   --gradient-dark: linear-gradient(155deg, #3d2005 0%, #1e0e03 45%, #0c0802 100%);
   --gradient-surface: linear-gradient(180deg, #ffffff 0%, #fdfbf7 100%);
+
+  /* Spacing scale (canonical) */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+  --space-8: 4rem;
 
   /* Typography */
   --font-main: 'Cairo', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/tracker/state.js
+++ b/tracker/state.js
@@ -11,6 +11,7 @@ export const STORAGE_KEYS = {
 };
 
 export const VALID_MODES = new Set(['live', 'compare', 'archive', 'exports', 'method']);
+export const VALID_PANELS = new Set(['alerts', 'planner']);
 
 export const DEFAULT_STATE = {
   lang: 'en',
@@ -25,6 +26,7 @@ export const DEFAULT_STATE = {
   favoritesOnly: false,
   liveWireOn: true,
   activeRegion: 'gcc',
+  panel: null,
   // Market + history
   live: null,
   rates: {},
@@ -104,6 +106,7 @@ export function createInitialState() {
   base.favoritesOnly = !!saved.favoritesOnly;
   base.liveWireOn = saved.liveWireOn !== false;
   base.activeRegion = saved.activeRegion || base.activeRegion;
+  base.panel = null;
 
   base.alerts = readLocal(CONSTANTS.CACHE_KEYS.alerts || 'gold_price_alerts', []);
   base.presets = readLocal(STORAGE_KEYS.presets, []);
@@ -141,16 +144,28 @@ export function persistState(state) {
 
 export function syncUrlFromState(state) {
   const url = new URL(window.location.href);
-  url.hash = `mode=${state.mode}&cur=${state.selectedCurrency}&k=${state.selectedKarat}&u=${state.selectedUnit}&r=${state.range}&cmp=${state.compareCurrency}&lang=${state.lang}`;
+  const params = new URLSearchParams();
+  params.set('mode', VALID_MODES.has(state.mode) ? state.mode : 'live');
+  params.set('cur', state.selectedCurrency);
+  params.set('k', state.selectedKarat);
+  params.set('u', state.selectedUnit);
+  params.set('r', state.range);
+  params.set('cmp', state.compareCurrency);
+  params.set('lang', state.lang);
+  if (state.panel && VALID_PANELS.has(state.panel)) params.set('panel', state.panel);
+  url.hash = params.toString();
   history.replaceState(null, '', url.toString());
 }
 
 export function applyUrlState(state) {
-  const hash = window.location.hash.slice(1);
-  if (!hash) return;
-  const params = new URLSearchParams(hash);
-  const urlMode = params.get('mode');
-  if (urlMode && VALID_MODES.has(urlMode)) state.mode = urlMode;
+  const parsed = parseHash(window.location.hash.slice(1));
+  state.panel = null;
+
+  if (!parsed.hasHash) return parsed;
+  if (parsed.mode) state.mode = parsed.mode;
+  if (parsed.panel) state.panel = parsed.panel;
+
+  const params = parsed.params;
   state.selectedCurrency = params.get('cur') || state.selectedCurrency;
   state.selectedKarat = params.get('k') || state.selectedKarat;
   state.selectedUnit = params.get('u') || state.selectedUnit;
@@ -158,6 +173,58 @@ export function applyUrlState(state) {
   state.compareCurrency = params.get('cmp') || state.compareCurrency;
   const urlLang = params.get('lang');
   if (urlLang === 'en' || urlLang === 'ar') state.lang = urlLang;
+  return parsed;
+}
+
+function parseHash(hash) {
+  const raw = (hash || '').trim();
+  if (!raw) {
+    return { hasHash: false, params: new URLSearchParams(), mode: null, panel: null, shouldCanonicalize: false };
+  }
+
+  // Legacy one-token hashes (task-1 compatibility)
+  if (raw === 'alerts' || raw === 'section-alerts') {
+    return {
+      hasHash: true,
+      params: new URLSearchParams(),
+      mode: 'live',
+      panel: 'alerts',
+      shouldCanonicalize: true,
+    };
+  }
+
+  const params = new URLSearchParams(raw);
+  const explicitMode = params.get('mode');
+  let mode = null;
+  let panel = null;
+  let shouldCanonicalize = false;
+
+  if (explicitMode === 'alerts') {
+    mode = 'live';
+    panel = 'alerts';
+    shouldCanonicalize = true;
+  } else if (explicitMode) {
+    if (VALID_MODES.has(explicitMode)) mode = explicitMode;
+    else {
+      mode = 'live';
+      shouldCanonicalize = true;
+    }
+  }
+
+  const explicitPanel = params.get('panel');
+  if (explicitPanel) {
+    if (VALID_PANELS.has(explicitPanel)) panel = explicitPanel;
+    else shouldCanonicalize = true;
+  }
+
+  // Deterministic behavior: panel-only hashes should not depend on persisted mode.
+  // Canonical form is live mode + panel.
+  if (panel && !mode) {
+    mode = 'live';
+    shouldCanonicalize = true;
+  }
+
+  return { hasHash: true, params, mode, panel, shouldCanonicalize };
 }
 
 function readLocal(key, fallback) {

--- a/tracker/ui-shell.js
+++ b/tracker/ui-shell.js
@@ -2,7 +2,7 @@
 import { injectNav, updateNavLang } from '../components/nav.js';
 import { injectFooter } from '../components/footer.js';
 import { injectTicker, updateTicker, updateTickerLang } from '../components/ticker.js';
-import { syncUrlFromState, persistState, applyUrlState } from './state.js';
+import { syncUrlFromState, persistState, applyUrlState, VALID_MODES, VALID_PANELS } from './state.js';
 
 let _openPanel = null;
 
@@ -50,9 +50,7 @@ export function mountShell(state, els, onModeChange, onLangChange) {
   });
 
   // Initial mode selection (never allow alerts/planner as mode)
-  const safeMode = ['live', 'compare', 'archive', 'exports', 'method'].includes(state.mode)
-    ? state.mode
-    : 'live';
+  const safeMode = VALID_MODES.has(state.mode) ? state.mode : 'live';
   setMode(safeMode);
 
   // Overlay system for Alerts and Planner
@@ -62,10 +60,12 @@ export function mountShell(state, els, onModeChange, onLangChange) {
   };
 
   function openOverlay(name) {
+    if (!VALID_PANELS.has(name)) return;
     if (_openPanel && _openPanel !== name) closeOverlay(_openPanel);
     const overlay = overlays[name];
     if (!overlay) return;
     _openPanel = name;
+    state.panel = name;
     overlay.hidden = false;
     overlay.removeAttribute('aria-hidden');
     document.body.classList.add('tp-overlay-open');
@@ -79,16 +79,18 @@ export function mountShell(state, els, onModeChange, onLangChange) {
   }
 
   function closeOverlay(name) {
-    const overlay = overlays[name || _openPanel];
+    const panelName = name || _openPanel;
+    const overlay = overlays[panelName];
     if (!overlay) return;
     overlay.hidden = true;
     overlay.setAttribute('aria-hidden', 'true');
     document.body.classList.remove('tp-overlay-open');
-    document.querySelectorAll(`.tracker-overlay-btn[data-overlay="${name || _openPanel}"]`).forEach(btn => {
+    document.querySelectorAll(`.tracker-overlay-btn[data-overlay="${panelName}"]`).forEach(btn => {
       btn.classList.remove('is-active');
       btn.setAttribute('aria-expanded', 'false');
     });
     _openPanel = null;
+    state.panel = null;
     syncUrlFromState(state);
   }
 
@@ -114,14 +116,24 @@ export function mountShell(state, els, onModeChange, onLangChange) {
     });
   });
 
+  function syncOverlayFromState() {
+    const desiredPanel = state.panel && VALID_PANELS.has(state.panel) ? state.panel : null;
+    if (!desiredPanel) {
+      if (_openPanel) closeOverlay(_openPanel);
+      return;
+    }
+    if (_openPanel !== desiredPanel) openOverlay(desiredPanel);
+  }
+
+  syncOverlayFromState();
+
   // Sync back/forward navigation
   window.addEventListener('hashchange', () => {
-    applyUrlState(state);
-    const m = ['live', 'compare', 'archive', 'exports', 'method'].includes(state.mode)
-      ? state.mode
-      : 'live';
+    const parsed = applyUrlState(state);
+    const m = VALID_MODES.has(state.mode) ? state.mode : 'live';
     setMode(m);
-    if (typeof onModeChange === 'function') onModeChange(state.mode);
+    syncOverlayFromState();
+    if (parsed?.shouldCanonicalize) syncUrlFromState(state);
   });
 
   // Keyboard shortcuts


### PR DESCRIPTION
### Motivation

- Stabilize and standardize tracker deep-links by moving from legacy one-token hashes to explicit `mode`/`panel` hash parameters and ensure deterministic behavior for overlay panels like alerts and planner.
- Keep URL state and UI overlays in sync so opening/closing overlays reflects in the URL and back/forward navigation restores overlay state.

### Description

- Introduces `VALID_PANELS` and a `panel` field in tracker state and default state to represent open overlays.  
- Reworks URL handling: `syncUrlFromState` now builds a canonical `mode`/`panel` hash with `URLSearchParams`, and `applyUrlState` uses a new `parseHash` helper that recognizes legacy hashes (e.g. `alerts`, `section-alerts`) and normalizes them to `mode=live&panel=alerts` while validating values.  
- Updates UI shell to wire overlay open/close to `state.panel`, restrict panel actions to valid panels, restore overlay state on load and on `hashchange`, and canonicalize URLs when needed.  
- Updates footer, nav and index links to use the new `mode=`/`panel=` hash forms for compare, archive, alerts, exports and related links.

### Testing

- Ran the project build (`npm run build`) in CI-style mode and the build completed successfully.  
- Ran the automated test suite (`npm test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7bde470008321b07683c143c6640f)