### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/admin/social/index.html
+++ b/admin/social/index.html
@@ -1987,8 +1987,8 @@
                 : '<span class="event-badge badge-en">EN</span>';
             return `<tr>
           <td style="white-space:nowrap;color:var(--text-dim);font-size:0.8125rem;">${ts}</td>
-          <td>${GEN_TEMPLATE_LABELS[e.template] || e.template}</td>
-          <td>${langBadge} <span style="color:var(--text-dim);font-size:0.8125rem;">${e.platform || ''}</span></td>
+          <td>${escapeHtml((GEN_TEMPLATE_LABELS[e.template] || e.template || '').toString())}</td>
+          <td>${langBadge} <span style="color:var(--text-dim);font-size:0.8125rem;">${escapeHtml((e.platform || '').toString())}</span></td>
           <td class="history-text-preview" title="${escapeHtml(e.text || '')}">${escapeHtml(preview)}</td>
           <td><button class="btn btn-ghost btn-sm" data-reuse="${i}" type="button">Re-use</button></td>
         </tr>`;


### PR DESCRIPTION
Potential fix for [https://github.com/vctb12/Gold-Prices/security/code-scanning/9](https://github.com/vctb12/Gold-Prices/security/code-scanning/9)

The best fix is to ensure all untrusted values interpolated into HTML are escaped before insertion into `innerHTML`.

In `admin/social/index.html`, inside `renderHistory()` where each row is generated (around lines 1988–1993), escape the template label/fallback and platform text before interpolating. Keep existing behavior and layout unchanged by only wrapping these specific values with `escapeHtml(...)`. This addresses both alert variants because both taint sources (`template-select` and `custom-textarea`) eventually flow into stored `history` entries and then into the same `innerHTML` sink.

No new imports or dependencies are required, assuming `escapeHtml` already exists (it is already used on line 1992).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
