### PR TITLE
Potential fix for code scanning alert no. 15: Insecure configuration of Helmet security middleware

### DIFF
--- a/server.js
+++ b/server.js
@@ -77,7 +77,20 @@ app.use(
             upgradeInsecureRequests: [],
           },
         }
-      : false,
+      : {
+          directives: {
+            defaultSrc: ["'self'"],
+            scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'", 'https:'],
+            styleSrc: ["'self'", "'unsafe-inline'", 'https:'],
+            imgSrc: ["'self'", 'data:', 'blob:', 'https:'],
+            fontSrc: ["'self'", 'data:', 'https:'],
+            connectSrc: ["'self'", 'http://localhost:*', 'ws://localhost:*', 'https:'],
+            objectSrc: ["'none'"],
+            frameAncestors: ["'none'"],
+            baseUri: ["'self'"],
+            formAction: ["'self'"],
+          },
+        },
     crossOriginEmbedderPolicy: false,
     // Explicit cross-origin isolation knobs rather than Helmet defaults, so the
     // intent is visible at the server entry-point.


### PR DESCRIPTION
Potential fix for [https://github.com/vctb12/Gold-Prices/security/code-scanning/15](https://github.com/vctb12/Gold-Prices/security/code-scanning/15)

Enable Helmet CSP in all environments and avoid assigning `false` to `contentSecurityPolicy`.

Best fix in this file: replace the conditional `contentSecurityPolicy: IS_PROD ? {...} : false` with `contentSecurityPolicy: { directives: ... }` in both branches:
- Keep the current strict production directives unchanged.
- Add a development CSP object with permissive but still enabled directives (for example allowing localhost websocket/connect endpoints and `'unsafe-inline'` where needed), so debugging still works without disabling CSP entirely.

This change is localized to `server.js` in the Helmet config block (around lines 44–80). No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
