### PR TITLE
Potential fix for code scanning alert no. 14: Client-side cross-site scripting

### DIFF
--- a/src/pages/shops.js
+++ b/src/pages/shops.js
@@ -1087,7 +1087,7 @@ function renderFilterPills() {
     pills.push({
       type: 'search',
       value: '',
-      label: `"${esc(q)}"`,
+      label: `"${q}"`,
       ariaLabel: `Remove "${q}" search filter`,
     });
   }
@@ -1107,8 +1107,8 @@ function renderFilterPills() {
       .map((pill) => {
         const ariaLabel = pill.ariaLabel || `Remove ${pill.label} filter`;
         return `
-      <button class="shops-filter-pill" data-type="${pill.type}" data-value="${pill.value || ''}" type="button" aria-label="${ariaLabel}">
-        ${pill.label}
+      <button class="shops-filter-pill" data-type="${esc(String(pill.type || ''))}" data-value="${esc(String(pill.value || ''))}" type="button" aria-label="${esc(String(ariaLabel || ''))}">
+        ${esc(String(pill.label || ''))}
         <span class="shops-filter-pill-remove" aria-hidden="true">×</span>
       </button>
     `;


### PR DESCRIPTION
Potential fix for [https://github.com/vctb12/Gold-Prices/security/code-scanning/14](https://github.com/vctb12/Gold-Prices/security/code-scanning/14)

General fix: never interpolate untrusted data directly into HTML strings assigned to `innerHTML`. Either build DOM nodes with `textContent`/`setAttribute`, or strictly escape all untrusted values for their output context.

Best minimal fix without changing behavior: keep current rendering structure, but escape **all** dynamic fields used in the generated HTML (`pill.type`, `pill.value`, visible label text, and aria-label). Also avoid pre-escaping only one source (`search`) and instead escape at render time consistently.  
In `src/pages/shops.js`:
- In the search pill object, store raw display label (`"${q}"`) instead of pre-escaped text.
- In the `.map((pill) => ...)` block that builds `innerHTML`, wrap dynamic values with `esc(...)` before interpolation:
  - `data-type="${esc(...)}"`
  - `data-value="${esc(...)}"`
  - `aria-label="${esc(...)}"`
  - `${esc(...)}`
This ensures tainted query param values cannot break out into executable HTML/JS.

No new methods/imports are required because `esc` is already imported from `../lib/safe-dom.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
