### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/admin/orders/index.html
+++ b/admin/orders/index.html
@@ -789,14 +789,16 @@
         const orders = await loadOrders();
         const idx = orders.findIndex((o) => o.id === id);
         if (idx === -1) return null;
+        const normalizedStatus = String(newStatus || '').toLowerCase();
+        if (!ORDER_STATUSES.includes(normalizedStatus)) return null;
         const now = new Date().toISOString();
-        const entry = { status: newStatus, timestamp: now, note: note || '' };
+        const entry = { status: normalizedStatus, timestamp: now, note: note || '' };
         if (!Array.isArray(orders[idx].statusHistory)) orders[idx].statusHistory = [];
         orders[idx].statusHistory.push(entry);
-        orders[idx].status = newStatus;
+        orders[idx].status = normalizedStatus;
         orders[idx].updatedAt = now;
         await saveOrder(orders[idx]);
-        logActivity('order_status', `Order ${id} → ${newStatus}${note ? ': ' + note : ''}`);
+        logActivity('order_status', `Order ${id} → ${normalizedStatus}${note ? ': ' + note : ''}`);
         return orders[idx];
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/vctb12/Gold-Prices/security/code-scanning/7](https://github.com/vctb12/Gold-Prices/security/code-scanning/7)

Best fix: **validate and normalize status values at write time** and **escape status-derived output at render time** before inclusion in any HTML string assigned to `innerHTML`.

In this file (`admin/orders/index.html`), the single best minimal change is to enforce an allowlist for `newStatus` inside `updateOrderStatus(...)` before storing it. This breaks the taint path and preserves functionality (only legitimate workflow statuses are stored). Since the UI already uses allowed transitions, this should not change normal behavior.

Concretely:
- In `updateOrderStatus(id, newStatus, note)`, before writing `orders[idx].status`, normalize to lowercase and ensure it is one of `ORDER_STATUSES`.
- If invalid, return `null` early (or ignore update), preventing persistence of attacker-injected strings that could later reach `innerHTML`.

No import/dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
