### PR TITLE
Potential fix for code scanning alert no. 4: Clear text storage of sensitive information

### DIFF
--- a/admin/shops/index.html
+++ b/admin/shops/index.html
@@ -880,7 +880,15 @@
       /** Cache shops to localStorage for offline resilience. */
       function cacheShops(shops) {
         try {
-          localStorage.setItem(SHOPS_CACHE_KEY, JSON.stringify(shops));
+          const safeShops = Array.isArray(shops)
+            ? shops.map((shop) => ({
+                ...shop,
+                // Avoid persisting precise coordinates in cleartext localStorage.
+                latitude: null,
+                longitude: null,
+              }))
+            : [];
+          localStorage.setItem(SHOPS_CACHE_KEY, JSON.stringify(safeShops));
         } catch {}
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/vctb12/Gold-Prices/security/code-scanning/4](https://github.com/vctb12/Gold-Prices/security/code-scanning/4)

General fix: avoid storing sensitive fields in cleartext client storage; either (a) do not store them at all, or (b) store only non-sensitive subset / opaque IDs. For browser-only code, robust encryption at rest is hard without introducing key-management issues, so field minimization is the best no-regression option.

Best fix here: sanitize shops before caching by removing `latitude` and `longitude` from each object written to localStorage, while leaving runtime behavior unchanged for data loaded from Supabase. This addresses both alert variants (latitude and longitude) at the same sink.

Edit scope (single file): `admin/shops/index.html`, in `cacheShops` and (optionally for consistency) `readCachedShops`.
- In `cacheShops`, transform `shops` to a `safeShops` array that sets `latitude`/`longitude` to `null` (or removes them) before `JSON.stringify`.
- Keep try/catch and fallback behavior unchanged.
- No new dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
