### PR TITLE
Potential fix for code scanning alert no. 42: Incomplete URL substring sanitization

### DIFF
--- a/tests/seo-sitewide.test.js
+++ b/tests/seo-sitewide.test.js
@@ -41,6 +41,15 @@ const FORBIDDEN_ORIGINS = [
   'http://www.goldtickerlive.com',
 ];
 
+function isCanonicalOriginUrl(candidate) {
+  try {
+    const u = new URL(candidate);
+    return u.protocol === 'https:' && u.hostname === 'goldtickerlive.com';
+  } catch {
+    return false;
+  }
+}
+
 // Directories that are never shipped as public pages.
 const SKIP_DIRS = new Set([
   'node_modules',
@@ -161,7 +170,7 @@ test('every "noindex,follow" and meta-refresh stub has a canonical and a title',
   const bad = [];
   for (const p of followableStubs) {
     if (!p.canonical) bad.push(`${p.file} — missing canonical`);
-    else if (!p.canonical.startsWith(CANONICAL_ORIGIN))
+    else if (!isCanonicalOriginUrl(p.canonical))
       bad.push(`${p.file} — canonical "${p.canonical}" not on canonical origin`);
     if (!p.title) bad.push(`${p.file} — missing <title>`);
   }
@@ -179,7 +188,7 @@ test('every indexable HTML page has canonical + hreflang(x-default,en,ar) + titl
       bad.push(`${p.file} — missing canonical`);
       continue;
     }
-    if (!p.canonical.startsWith(CANONICAL_ORIGIN + '/') && p.canonical !== CANONICAL_ORIGIN + '/') {
+    if (!isCanonicalOriginUrl(p.canonical)) {
       bad.push(`${p.file} — canonical "${p.canonical}" not on canonical origin`);
     }
     // Hreflang triple


### PR DESCRIPTION
Potential fix for [https://github.com/vctb12/Gold-Prices/security/code-scanning/42](https://github.com/vctb12/Gold-Prices/security/code-scanning/42)

Use URL parsing (`new URL(...)`) and exact host/scheme checks instead of `startsWith(...)`.

Best fix in this file:
1. Add a small helper function in `tests/seo-sitewide.test.js` (near constants) that:
   - Parses a candidate URL with `new URL(candidate)`.
   - Verifies protocol is `https:`.
   - Verifies hostname equals `goldtickerlive.com`.
   - Returns `false` on parse failure.
2. Replace both prefix-based canonical checks:
   - Line ~164 in the “noindex,follow stub” test.
   - Line ~182 in the “indexable HTML page” test.
   with calls to this helper.
3. Keep behavior otherwise unchanged (same error messages, same control flow).

No new dependency is required; `URL` is built into Node.js.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
