### PR TITLE
a11y(focus): wire --focus-ring-* tokens through page-level :focus-visible sites

### DIFF
--- a/docs/REVAMP_PLAN.md
+++ b/docs/REVAMP_PLAN.md
@@ -320,11 +320,15 @@ Goal: unify the system every other track leans on. Each bullet = 1–2 commits.
       rules into the canonical `.card` + `.card--accent` + `.card--compact` set.
 - [ ] **Heading scale confirmation.** Ensure heading scale is applied via classes (`.h1`…`.h6`) not
       ad-hoc sizes.
-- [ ] **Focus ring token audit.** Confirm `--focus-ring` / `--focus-ring-offset` wired through every
-      `:focus-visible` site. _(In progress: duplicate global `:focus-visible` with hardcoded
-      `2px solid var(--color-gold)` that shadowed the token-based baseline removed — page-level
-      sites (`calc-tab`, `stub-*`, `tracker-mode-tab`, `shops-*`, `methodology-link`, `.btn`) still
-      to audit.)_
+- [x] **Focus ring token audit.** Canonical `:focus-visible` baseline in `styles/global.css` uses
+      `--focus-ring-width` / `--focus-ring-color` / `--focus-ring-offset`. Page-level outline
+      overrides normalized to the same tokens: `.calc-tab`, `.tracker-mode-tab`,
+      `.shops-control--checkbox input[type='checkbox']`, `.shops-filter-toggle`, and `.btn`.
+      `.methodology-link` relies on the baseline (no override). _Follow-up (separate concern, not
+      this audit):_ sites that intentionally suppress `outline` in favor of a custom box-shadow or
+      color-only cue — `.karat-pill`, `.shops-chip`, `.shops-clear-btn`, `.modal-close-cta`,
+      `.stub-cta`, `.stub-related-link` — need a dedicated a11y review to decide whether the
+      alternative ring is visible enough.
 
 ## 5. Track B — Navigation rebuild
 

--- a/styles/global.css
+++ b/styles/global.css
@@ -2907,8 +2907,8 @@ main {
 }
 
 .btn:focus-visible {
-  outline: 3px solid var(--color-gold-glow);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .btn-primary {

--- a/styles/pages/calculator.css
+++ b/styles/pages/calculator.css
@@ -145,7 +145,7 @@
 }
 
 .calc-tab:focus-visible {
-  outline: 2px solid var(--color-gold);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
   outline-offset: -2px;
   background: rgb(196 153 62 / 9%);
   color: var(--color-gold-dark);

--- a/styles/pages/shops.css
+++ b/styles/pages/shops.css
@@ -304,8 +304,8 @@
 }
 
 .shops-control--checkbox input[type='checkbox']:focus-visible {
-  outline: 2px solid rgb(212 160 23 / 60%);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .shops-control-help {
@@ -1526,8 +1526,8 @@
 }
 
 .shops-filter-toggle:focus-visible {
-  outline: 2px solid rgb(196 153 62 / 85%);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
   border-color: rgb(196 153 62 / 70%);
   box-shadow: 0 0 0 3px rgb(196 153 62 / 20%);
 }

--- a/styles/pages/tracker-pro.css
+++ b/styles/pages/tracker-pro.css
@@ -1857,8 +1857,8 @@ body.tracker-pro-page {
 }
 
 .tracker-mode-tab:focus-visible {
-  outline: 2px solid var(--tp-gold);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .tracker-mode-tab[aria-expanded='true'] {


### PR DESCRIPTION
## Task

Continue `docs/REVAMP_PLAN.md` §4 **Track A — Cross-cutting foundation**, closing the
in-progress **"Focus ring token audit"** checkbox.

Per the priority matrix in `docs/plans/README.md`, Wave 1 hardening shipped in #164; this is
the next smallest correct Track A slice that unblocks the later B/C/D tracks.

## Files inspected

- `styles/global.css` — canonical `:focus-visible` baseline + `.btn`, `.skip-link`,
  `.nav-skip-link`, `.karat-pill`, `.methodology-link`
- `styles/pages/calculator.css` — `.calc-tab`
- `styles/pages/tracker-pro.css` — `.tracker-mode-tab`
- `styles/pages/shops.css` — `.shops-chip`, `.shops-control--checkbox`, `.shops-clear-btn`,
  `.modal-close-cta`, `.shops-filter-toggle`
- `styles/pages/stub.css` — `.stub-related-link`, `.stub-cta`

## Plan

Replace hardcoded outline declarations at page-level `:focus-visible` sites with the canonical
`--focus-ring-width` / `--focus-ring-color` / `--focus-ring-offset` tokens so every focus ring
resolves through the same token path as the global baseline in `styles/global.css`.

Single-concern `a11y` commit per §1 of the revamp plan — no visual restyling beyond the
token-aligned outline.

## Changes made

| Site | Before | After |
| --- | --- | --- |
| `.calc-tab:focus-visible` | `outline: 2px solid var(--color-gold); outline-offset: -2px;` | `outline: var(--focus-ring-width) solid var(--focus-ring-color); outline-offset: -2px;` (inset offset preserved for the tab UI) |
| `.tracker-mode-tab:focus-visible` | `outline: 2px solid var(--tp-gold); outline-offset: 2px;` | tokens |
| `.shops-control--checkbox input[type='checkbox']:focus-visible` | `outline: 2px solid rgb(212 160 23 / 60%);` | tokens |
| `.shops-filter-toggle:focus-visible` | `outline: 2px solid rgb(196 153 62 / 85%);` | tokens (box-shadow flourish kept) |
| `.btn:focus-visible` | `outline: 3px solid var(--color-gold-glow);` | tokens |

Also updated `docs/REVAMP_PLAN.md` §4 Track A checkbox to mark the audit complete and log a
follow-up for sites that intentionally suppress `outline` in favor of a custom box-shadow or
color-only focus cue (`.karat-pill`, `.shops-chip`, `.shops-clear-btn`, `.modal-close-cta`,
`.stub-cta`, `.stub-related-link`) — that's a separate a11y concern, not a token-wiring fix.

## Verification

- `npm run lint` — clean
- `npx prettier --check` on the 4 CSS files + `docs/REVAMP_PLAN.md` — clean
- `npx stylelint` on the 4 CSS files — clean
- `npm run validate` — all gates green (static files, HTML async, JS imports, DOM-sink
  baseline, SEO meta on 690 HTML files, sitemap coverage)
- `npm test` — **271/271 pass**, 60 suites

Not verified:

- Visual diff across every `:focus-visible` interaction. `.btn` shifts from a translucent
  `--color-gold-glow` ring to a solid `--color-gold` ring at the same 3 px width / 2 px offset
  (by design — that's the token convergence). `.calc-tab`, `.tracker-mode-tab`,
  `.shops-control--checkbox`, and `.shops-filter-toggle` go from 2 px to 3 px ring (token
  width), which is slightly more prominent but consistent with the global baseline.

## Remaining risks

- Minor visible change on focused buttons site-wide (solid gold ring vs. translucent glow).
  Contrast goes up, which is the a11y-positive direction.
- Follow-up: outline-suppressing sites listed above still need a dedicated a11y review — out
  of scope for this token-wiring commit.

## Scope / conflict check

- Branched off fresh `main` (`83cb74fa`). No conflicts expected.
- Single concern per `REVAMP_PLAN.md` §1 commit discipline (`a11y` bucket).
- No architecture / routing / SEO changes.
