### PR TITLE
docs(revamp): close Track A Token audit — inventory shows no bespoke palette drift

### DIFF
--- a/docs/REVAMP_PLAN.md
+++ b/docs/REVAMP_PLAN.md
@@ -314,8 +314,15 @@ Goal: unify the system every other track leans on. Each bullet = 1–2 commits.
 - [x] **`count-up` primitive** `src/lib/count-up.js` — rAF easeOutQuad, duration magnitude-capped
       180–800 ms, auto directional `data-flash`, reduced-motion no-op, robust numeric parse.
       (`0b03c603`, `0a3c7591`)
-- [ ] **Token audit.** Inventory current `--tp-*`, `--home-*`, `--nav-*`, `--shops-*` bespoke
-      palettes; alias each to canonical tokens.
+- [x] **Token audit.** Inventoried per-prefix: `--tp-*` in `styles/pages/tracker-pro.css` is already
+      fully aliased to canonical site tokens (`--surface-*`, `--border-*`, `--text-*`,
+      `--color-gold*`, `--color-live*`, `--color-error*`, `--color-fixed*`, `--shadow-*`,
+      `--radius-*`); `--home-*`, `--nav-*`, and `--shops-*` color palettes do not exist (only a
+      single `--nav-height` sizing token in `styles/global.css`). `--invest-*` in
+      `styles/pages/invest.css` is an intentional dark-premium page identity that differs from the
+      canonical dark mode on purpose — not drift. `styles/critical.css` intentionally inlines
+      fallback hex for `--tp-bg` / `--tp-text` / `--tp-accent` so above-the-fold paint doesn't
+      depend on the deferred global-token sheet.
 - [ ] **Canonical card consolidation.** Merge near-duplicate `.card` / `.panel` / `.section-card`
       rules into the canonical `.card` + `.card--accent` + `.card--compact` set.
 - [ ] **Heading scale confirmation.** Ensure heading scale is applied via classes (`.h1`…`.h6`) not


### PR DESCRIPTION
## Task

Continue [`docs/REVAMP_PLAN.md`](docs/REVAMP_PLAN.md) §4 **Track A — Cross-cutting foundation**,
closing the pending **"Token audit"** checkbox.

## Files inspected

- [styles/global.css](styles/global.css) — canonical token inventory
- [styles/pages/tracker-pro.css](styles/pages/tracker-pro.css) — `--tp-*` palette
- [styles/pages/invest.css](styles/pages/invest.css) — `--invest-*` palette
- [styles/critical.css](styles/critical.css) — inlined fallback hex
- Repo-wide grep for `--home-*`, `--nav-*`, `--shops-*` color palettes

## Finding

Single-concern `docs` commit. No CSS change.

| Palette       | State                                                                                                                    |
| ------------- | ------------------------------------------------------------------------------------------------------------------------ |
| `--tp-*`      | Already fully aliased to canonical tokens (`--surface-*`, `--border-*`, `--text-*`, `--color-gold*`, `--radius-*`, etc.) |
| `--home-*`    | Does not exist                                                                                                            |
| `--nav-*`     | Only `--nav-height` (sizing), no color palette                                                                            |
| `--shops-*`   | Does not exist                                                                                                            |
| `--invest-*`  | Intentional dark-premium page identity — differs from canonical dark mode on purpose, not drift                           |
| `critical.css` fallback hex | Deliberate so above-the-fold paint doesn't depend on the deferred global-token sheet                        |

## Plan

Update the Track A checkbox with the concrete inventory + rationale so the next reader doesn't
re-open the audit. No code changes.

## Changes made

- [`docs/REVAMP_PLAN.md`](docs/REVAMP_PLAN.md) §4 Track A: flip the "Token audit" checkbox to
  `[x]` and record the finding per-prefix.

## Verification

- `prettier --check docs/REVAMP_PLAN.md` — clean
- No CSS / JS / HTML touched → other gates (`lint`, `validate`, `test`) not applicable to this
  diff.

## Remaining risks

- None. If a future prompt wants `--invest-*` aliased, that's a deliberate design decision on
  the invest page — this PR intentionally does not alter it.

## Scope / conflict check

- Branched off fresh `main` (`0760e95a`), which already includes #165.
- Single-concern `docs` commit per `REVAMP_PLAN.md` §1 commit discipline.
- No architecture, routing, or SEO changes.
