### PR TITLE
docs(revamp): scope Track A Heading-scale confirmation — split into tokens/typography/cleanup slices

### DIFF
--- a/docs/REVAMP_PLAN.md
+++ b/docs/REVAMP_PLAN.md
@@ -319,7 +319,17 @@ Goal: unify the system every other track leans on. Each bullet = 1–2 commits.
 - [ ] **Canonical card consolidation.** Merge near-duplicate `.card` / `.panel` / `.section-card`
       rules into the canonical `.card` + `.card--accent` + `.card--compact` set.
 - [ ] **Heading scale confirmation.** Ensure heading scale is applied via classes (`.h1`…`.h6`) not
-      ad-hoc sizes.
+      ad-hoc sizes. _Audit (2026-04-23):_ the `.h1`…`.h6` class system does **not** exist yet, and
+      base `h1`..`h6` element selectors are not styled in `styles/global.css`. Every page hand-sizes
+      headings via bespoke selectors (~40 sites, e.g. `.tracker-hero-copy h1`,
+      `.pricing-hero-content h1`, `.legal-hero h1`, `.method-section h2`, `.learn-section h3`).
+      Token gaps: no display-tier sizes (`--text-4xl` / `--text-5xl`) for hero headings, and the
+      `--text-*` scale in `styles/global.css` drifts from the one documented in
+      [`docs/DESIGN_TOKENS.md`](DESIGN_TOKENS.md) (e.g. `--text-3xl` is `1.875rem` in code but
+      `2.25rem` in docs). Split into three sequenced slices: (1) `tokens` — reconcile `--text-*`
+      scale with DESIGN_TOKENS.md and add display-tier tokens; (2) `typography` — add canonical
+      `.h1`…`.h6` utility classes + base `h1..h6` baseline; (3) `cleanup` — migrate per-page
+      hand-sized heading selectors to the canonical classes, one page per commit.
 - [x] **Focus ring token audit.** Canonical `:focus-visible` baseline in `styles/global.css` uses
       `--focus-ring-width` / `--focus-ring-color` / `--focus-ring-offset`. Page-level outline
       overrides normalized to the same tokens: `.calc-tab`, `.tracker-mode-tab`,


### PR DESCRIPTION
## Task

Continue [`docs/REVAMP_PLAN.md`](docs/REVAMP_PLAN.md) §4 **Track A — Cross-cutting foundation**,
working the pending **"Heading scale confirmation"** checkbox.

## Files inspected

- [`styles/global.css`](styles/global.css) — type-scale token block + all heading selectors
- `styles/**/*.css` — every `h1`..`h6` selector site (~40 page-level bespoke rules)
- [`docs/DESIGN_TOKENS.md`](docs/DESIGN_TOKENS.md) — documented type scale

## Finding

This item cannot be honestly closed as a quick checkbox flip. The concrete state is:

| Thing | Reality |
| --- | --- |
| `.h1` … `.h6` utility classes | Do **not** exist |
| Base `h1..h6` element rules in `global.css` | Do **not** exist |
| Page-level bespoke heading selectors | ~40 sites hand-size via `clamp()` / explicit rems (`.tracker-hero-copy h1`, `.pricing-hero-content h1`, `.legal-hero h1`, `.method-section h2`, `.learn-section h3`, …) |
| Display-tier tokens (`--text-4xl` / `--text-5xl`) | Do **not** exist |
| `--text-*` scale in code vs. [`DESIGN_TOKENS.md`](docs/DESIGN_TOKENS.md) | **Drifts** — e.g. `--text-3xl` is `1.875rem` in code, `2.25rem` in docs |

Doing "confirm the heading scale via `.h1`..`.h6`" properly is three sequenced commits, not
one. Forcing it into a single PR violates `REVAMP_PLAN.md` §1 commit discipline.

## Plan

Single-concern `docs` commit only. Update the Track A bullet with the audit finding and a
concrete 3-slice sequencing so the next agent can pick the smallest correct step.

## Changes made

- [`docs/REVAMP_PLAN.md`](docs/REVAMP_PLAN.md) §4 Track A: annotate the "Heading scale
  confirmation" bullet with the audit finding + three sequenced sub-slices:
  1. `tokens` — reconcile `--text-*` scale with [`DESIGN_TOKENS.md`](docs/DESIGN_TOKENS.md) and
     add `--text-4xl` / `--text-5xl` display-tier tokens.
  2. `typography` — add canonical `.h1`…`.h6` utility classes + base `h1..h6` baseline.
  3. `cleanup` — migrate per-page hand-sized heading selectors to the canonical classes, one
     page per commit.

Checkbox remains `[ ]` — the work is scoped, not finished.

## Verification

- `prettier --check docs/REVAMP_PLAN.md` — clean
- No CSS / JS / HTML touched → other gates not applicable.

## Remaining risks

- None from this PR. The sequencing is deliberately non-destructive — Slice 1 reconciles docs ↔
  code; Slice 2 adds new classes without breaking existing selectors; Slice 3 is opt-in
  migration per page.

## Scope / conflict check

- Branched off `main` (`0760e95a`).
- Touches a different bullet from the still-open #166 (Token audit). Git will auto-merge.
- Single-concern `docs` commit per `REVAMP_PLAN.md` §1.
