### PR TITLE
tokens(typography): add --text-4xl/5xl display tier + reconcile DESIGN_TOKENS.md to shipped scale

### DIFF
--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -97,7 +97,7 @@ the codebase.
 
 ### Type Scale
 
-Implemented in [`styles/global.css`](../styles/global.css). Body scale is tight (17–20 px) for dense
+Implemented in [`styles/global.css`](../styles/global.css). Body scale is tight (16–20 px) for dense
 price-data UI; display tier (`--text-4xl` / `--text-5xl`) is reserved for hero headings.
 
 ```css

--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -95,18 +95,23 @@ the codebase.
 --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
 ```
 
-### Type Scale (Minor-third ~1.2× ratio)
+### Type Scale
+
+Implemented in [`styles/global.css`](../styles/global.css). Body scale is tight (17–20 px) for dense
+price-data UI; display tier (`--text-4xl` / `--text-5xl`) is reserved for hero headings.
 
 ```css
 --text-2xs: 0.625rem; /* 10px */
 --text-xs: 0.75rem; /* 12px */
 --text-sm: 0.875rem; /* 14px */
 --text-base: 1rem; /* 16px */
---text-md: 1.125rem; /* 18px */
---text-lg: 1.25rem; /* 20px */
---text-xl: 1.5rem; /* 24px */
---text-2xl: 1.875rem; /* 30px */
---text-3xl: 2.25rem; /* 36px */
+--text-md: 1.0625rem; /* 17px */
+--text-lg: 1.125rem; /* 18px */
+--text-xl: 1.25rem; /* 20px */
+--text-2xl: 1.5rem; /* 24px */
+--text-3xl: 1.875rem; /* 30px */
+--text-4xl: 2.25rem; /* 36px — display tier, hero headings */
+--text-5xl: 3rem; /* 48px — display tier, hero headings */
 ```
 
 ### Font Weights

--- a/docs/REVAMP_PLAN.md
+++ b/docs/REVAMP_PLAN.md
@@ -334,9 +334,13 @@ Goal: unify the system every other track leans on. Each bullet = 1–2 commits.
       `--text-*` scale in `styles/global.css` drifts from the one documented in
       [`docs/DESIGN_TOKENS.md`](DESIGN_TOKENS.md) (e.g. `--text-3xl` is `1.875rem` in code but
       `2.25rem` in docs). Split into three sequenced slices: (1) `tokens` — reconcile `--text-*`
-      scale with DESIGN_TOKENS.md and add display-tier tokens; (2) `typography` — add canonical
+      scale with DESIGN*TOKENS.md and add display-tier tokens; (2) `typography` — add canonical
       `.h1`…`.h6` utility classes + base `h1..h6` baseline; (3) `cleanup` — migrate per-page
-      hand-sized heading selectors to the canonical classes, one page per commit.
+      hand-sized heading selectors to the canonical classes, one page per commit. \_Slice 1 (tokens)
+      shipped:* added `--text-4xl: 2.25rem` / `--text-5xl: 3rem` display-tier tokens to
+      `styles/global.css`; reconciled `docs/DESIGN_TOKENS.md` to match the implemented body scale
+      (doc→code, the safer direction — the shipped tight 17–20 px body scale is intentional for
+      dense price-data UI). Slices 2 and 3 still pending.
 - [x] **Focus ring token audit.** Canonical `:focus-visible` baseline in `styles/global.css` uses
       `--focus-ring-width` / `--focus-ring-color` / `--focus-ring-offset`. Page-level outline
       overrides normalized to the same tokens: `.calc-tab`, `.tracker-mode-tab`,

--- a/docs/REVAMP_PLAN.md
+++ b/docs/REVAMP_PLAN.md
@@ -334,10 +334,10 @@ Goal: unify the system every other track leans on. Each bullet = 1–2 commits.
       `--text-*` scale in `styles/global.css` drifts from the one documented in
       [`docs/DESIGN_TOKENS.md`](DESIGN_TOKENS.md) (e.g. `--text-3xl` is `1.875rem` in code but
       `2.25rem` in docs). Split into three sequenced slices: (1) `tokens` — reconcile `--text-*`
-      scale with DESIGN*TOKENS.md and add display-tier tokens; (2) `typography` — add canonical
+      scale with DESIGN_TOKENS.md and add display-tier tokens; (2) `typography` — add canonical
       `.h1`…`.h6` utility classes + base `h1..h6` baseline; (3) `cleanup` — migrate per-page
-      hand-sized heading selectors to the canonical classes, one page per commit. \_Slice 1 (tokens)
-      shipped:* added `--text-4xl: 2.25rem` / `--text-5xl: 3rem` display-tier tokens to
+      hand-sized heading selectors to the canonical classes, one page per commit. _Slice 1 (tokens)
+      shipped:_ added `--text-4xl: 2.25rem` / `--text-5xl: 3rem` display-tier tokens to
       `styles/global.css`; reconciled `docs/DESIGN_TOKENS.md` to match the implemented body scale
       (doc→code, the safer direction — the shipped tight 17–20 px body scale is intentional for
       dense price-data UI). Slices 2 and 3 still pending.

--- a/styles/global.css
+++ b/styles/global.css
@@ -147,6 +147,8 @@
   --text-xl: 1.25rem; /* 20px */
   --text-2xl: 1.5rem; /* 24px */
   --text-3xl: 1.875rem; /* 30px */
+  --text-4xl: 2.25rem; /* 36px — display tier, hero headings */
+  --text-5xl: 3rem; /* 48px — display tier, hero headings */
 
   /* Typography — font weights */
   --weight-light: 300;


### PR DESCRIPTION
## Task

Ship **Slice 1 (tokens)** of `REVAMP_PLAN.md` §4 Track A → _Heading scale confirmation_ —
the sequencing recorded in #167 (merged).

## Files inspected

- [`styles/global.css`](styles/global.css) — `--text-*` type scale
- [`docs/DESIGN_TOKENS.md`](docs/DESIGN_TOKENS.md) — documented scale
- `styles/**/*.css` — no existing consumers of `--text-4xl` / `--text-5xl` (purely additive)

## Finding

The documented scale in [`DESIGN_TOKENS.md`](docs/DESIGN_TOKENS.md) drifted from the scale
shipping in [`global.css`](styles/global.css) (e.g. `--text-3xl` was `1.875rem` in code vs.
`2.25rem` in docs). Flipping code to match docs would bump every `var(--text-*)` consumer
(~30+ sites) up one step — guaranteed visual regressions across dense price-data UI that is
deliberately tight. The honest reconcile direction is **doc → code**.

Hero headings also lack a display tier. Adding `--text-4xl` and `--text-5xl` is purely
additive and unblocks Slice 2 (typography) → `.h1` / `.h2` utility classes.

## Plan

Single-concern `tokens` commit:

1. Add `--text-4xl: 2.25rem` (36 px) and `--text-5xl: 3rem` (48 px) to
   [`styles/global.css`](styles/global.css).
2. Rewrite the Type Scale section in [`docs/DESIGN_TOKENS.md`](docs/DESIGN_TOKENS.md) to match
   the shipped scale exactly, including the two new display-tier tokens. Drop the
   "Minor-third ~1.2× ratio" subtitle — the real scale is deliberately tighter for dense
   price-data UI.
3. Update [`docs/REVAMP_PLAN.md`](docs/REVAMP_PLAN.md) §4 bullet to record Slice 1 shipped /
   Slices 2 & 3 still pending.

## Changes made

```
 docs/DESIGN_TOKENS.md | 17 +++++++++++------
 docs/REVAMP_PLAN.md   |  8 ++++++--
 styles/global.css     |  2 ++
 3 files changed, 19 insertions(+), 8 deletions(-)
```

## Verification

- `prettier --check` on all three touched files — clean
- `stylelint styles/global.css` — clean
- `npm run validate` — all gates green (static files, HTML async, JS imports, DOM-sink
  baseline, SEO meta on 690 HTML files, sitemap coverage 483↔648)
- `npm test` — **271/271 pass**, 60 suites

## Remaining risks

- **Zero visual risk.** The two new tokens have no consumers yet. The doc update is
  descriptive, not prescriptive.
- Slice 2 (`typography` — add `.h1`…`.h6` utility classes + base element baseline) and
  Slice 3 (`cleanup` — migrate ~40 per-page hand-sized heading selectors) remain pending and
  are tracked inline in §4 Track A.

## Scope / conflict check

- Branched off fresh `main` (`a645137c`) — includes #166 and #167 already.
- Single-concern `tokens` commit per `REVAMP_PLAN.md` §1.
- No architecture, routing, or SEO changes.
