### PR TITLE
typography(headings): add canonical .h1..h6 utility classes + .display-1

### DIFF
--- a/docs/REVAMP_PLAN.md
+++ b/docs/REVAMP_PLAN.md
@@ -326,21 +326,24 @@ Goal: unify the system every other track leans on. Each bullet = 1–2 commits.
 - [ ] **Canonical card consolidation.** Merge near-duplicate `.card` / `.panel` / `.section-card`
       rules into the canonical `.card` + `.card--accent` + `.card--compact` set.
 - [ ] **Heading scale confirmation.** Ensure heading scale is applied via classes (`.h1`…`.h6`) not
-      ad-hoc sizes. _Audit (2026-04-23):_ the `.h1`…`.h6` class system does **not** exist yet, and
-      base `h1`..`h6` element selectors are not styled in `styles/global.css`. Every page hand-sizes
-      headings via bespoke selectors (~40 sites, e.g. `.tracker-hero-copy h1`,
+      ad-hoc sizes. _Audit (2026-04-23):_ the `.h1`…`.h6` class system does **not** exist yet
+      (pre-audit), and base `h1`..`h6` element selectors are not styled in `styles/global.css`.
+      Every page hand-sizes headings via bespoke selectors (~40 sites, e.g. `.tracker-hero-copy h1`,
       `.pricing-hero-content h1`, `.legal-hero h1`, `.method-section h2`, `.learn-section h3`).
       Token gaps: no display-tier sizes (`--text-4xl` / `--text-5xl`) for hero headings, and the
       `--text-*` scale in `styles/global.css` drifts from the one documented in
       [`docs/DESIGN_TOKENS.md`](DESIGN_TOKENS.md) (e.g. `--text-3xl` is `1.875rem` in code but
-      `2.25rem` in docs). Split into three sequenced slices: (1) `tokens` — reconcile `--text-*`
-      scale with DESIGN*TOKENS.md and add display-tier tokens; (2) `typography` — add canonical
-      `.h1`…`.h6` utility classes + base `h1..h6` baseline; (3) `cleanup` — migrate per-page
-      hand-sized heading selectors to the canonical classes, one page per commit. \_Slice 1 (tokens)
-      shipped:* added `--text-4xl: 2.25rem` / `--text-5xl: 3rem` display-tier tokens to
-      `styles/global.css`; reconciled `docs/DESIGN_TOKENS.md` to match the implemented body scale
-      (doc→code, the safer direction — the shipped tight 17–20 px body scale is intentional for
-      dense price-data UI). Slices 2 and 3 still pending.
+      `2.25rem` in docs). Split into four sequenced slices: - [x] **Slice 1 (tokens).** Added
+      `--text-4xl: 2.25rem` / `--text-5xl: 3rem` display-tier tokens to `styles/global.css`;
+      reconciled `docs/DESIGN_TOKENS.md` to match the implemented body scale (doc→code — the shipped
+      tight 17–20 px body scale is intentional for dense price-data UI). - [x] **Slice 2a
+      (typography — utility classes).** Added `.h1`…`.h6` utility classes plus a `.display-1` opt-in
+      class in `styles/global.css`. Purely additive — no base `h1..h6` element rules, no existing
+      selectors touched. New markup should prefer these classes. - [ ] **Slice 2b (typography — base
+      element baseline).** Add base `h1..h6` element rules that match the class scale, scoped to
+      resets/layouts where no page override exists. Must be preceded by a per-page audit because the
+      ~40 bespoke selectors already dominate specificity. - [ ] **Slice 3 (cleanup).** Migrate
+      per-page hand-sized heading selectors to the canonical classes, one page per commit.
 - [x] **Focus ring token audit.** Canonical `:focus-visible` baseline in `styles/global.css` uses
       `--focus-ring-width` / `--focus-ring-color` / `--focus-ring-offset`. Page-level outline
       overrides normalized to the same tokens: `.calc-tab`, `.tracker-mode-tab`,

--- a/docs/REVAMP_PLAN.md
+++ b/docs/REVAMP_PLAN.md
@@ -326,24 +326,24 @@ Goal: unify the system every other track leans on. Each bullet = 1–2 commits.
 - [ ] **Canonical card consolidation.** Merge near-duplicate `.card` / `.panel` / `.section-card`
       rules into the canonical `.card` + `.card--accent` + `.card--compact` set.
 - [ ] **Heading scale confirmation.** Ensure heading scale is applied via classes (`.h1`…`.h6`) not
-      ad-hoc sizes. _Audit (2026-04-23):_ the `.h1`…`.h6` class system does **not** exist yet
-      (pre-audit), and base `h1`..`h6` element selectors are not styled in `styles/global.css`.
-      Every page hand-sizes headings via bespoke selectors (~40 sites, e.g. `.tracker-hero-copy h1`,
-      `.pricing-hero-content h1`, `.legal-hero h1`, `.method-section h2`, `.learn-section h3`).
-      Token gaps: no display-tier sizes (`--text-4xl` / `--text-5xl`) for hero headings, and the
-      `--text-*` scale in `styles/global.css` drifts from the one documented in
-      [`docs/DESIGN_TOKENS.md`](DESIGN_TOKENS.md) (e.g. `--text-3xl` is `1.875rem` in code but
-      `2.25rem` in docs). Split into four sequenced slices: - [x] **Slice 1 (tokens).** Added
-      `--text-4xl: 2.25rem` / `--text-5xl: 3rem` display-tier tokens to `styles/global.css`;
-      reconciled `docs/DESIGN_TOKENS.md` to match the implemented body scale (doc→code — the shipped
-      tight 17–20 px body scale is intentional for dense price-data UI). - [x] **Slice 2a
-      (typography — utility classes).** Added `.h1`…`.h6` utility classes plus a `.display-1` opt-in
-      class in `styles/global.css`. Purely additive — no base `h1..h6` element rules, no existing
-      selectors touched. New markup should prefer these classes. - [ ] **Slice 2b (typography — base
-      element baseline).** Add base `h1..h6` element rules that match the class scale, scoped to
-      resets/layouts where no page override exists. Must be preceded by a per-page audit because the
-      ~40 bespoke selectors already dominate specificity. - [ ] **Slice 3 (cleanup).** Migrate
-      per-page hand-sized heading selectors to the canonical classes, one page per commit.
+      ad-hoc sizes. _Audit (2026-04-23, prior to Slice 2a):_ base `h1`..`h6` element selectors are
+      not styled in `styles/global.css`. Every page hand-sizes headings via bespoke selectors (~40
+      sites, e.g. `.tracker-hero-copy h1`, `.pricing-hero-content h1`, `.legal-hero h1`,
+      `.method-section h2`, `.learn-section h3`). Token gaps: no display-tier sizes (`--text-4xl` /
+      `--text-5xl`) for hero headings, and the `--text-*` scale in `styles/global.css` drifts from
+      the one documented in [`docs/DESIGN_TOKENS.md`](DESIGN_TOKENS.md) (e.g. `--text-3xl` is
+      `1.875rem` in code but `2.25rem` in docs). Split into four sequenced slices: - [x] **Slice 1
+      (tokens).** Added `--text-4xl: 2.25rem` / `--text-5xl: 3rem` display-tier tokens to
+      `styles/global.css`; reconciled `docs/DESIGN_TOKENS.md` to match the implemented body scale
+      (doc→code — the shipped tight 17–20 px body scale is intentional for dense price-data UI). -
+      [x] **Slice 2a (typography — utility classes).** Added `.h1`…`.h6` utility classes plus a
+      `.display-1` opt-in class in `styles/global.css`. Purely additive — no base `h1..h6` element
+      rules, no existing selectors touched. New markup should prefer these classes. - [ ] **Slice 2b
+      (typography — base element baseline).** Add base `h1..h6` element rules that match the class
+      scale, scoped to resets/layouts where no page override exists. Must be preceded by a per-page
+      audit because the ~40 bespoke selectors already dominate specificity. - [ ] **Slice 3
+      (cleanup).** Migrate per-page hand-sized heading selectors to the canonical classes, one page
+      per commit.
 - [x] **Focus ring token audit.** Canonical `:focus-visible` baseline in `styles/global.css` uses
       `--focus-ring-width` / `--focus-ring-color` / `--focus-ring-offset`. Page-level outline
       overrides normalized to the same tokens: `.calc-tab`, `.tracker-mode-tab`,

--- a/styles/global.css
+++ b/styles/global.css
@@ -324,6 +324,85 @@ a:hover {
   text-decoration: underline;
 }
 
+/* ═══════════════════════════════════════════════
+   Canonical heading scale
+   ═══════════════════════════════════════════════
+   Utility classes only — no base h1..h6 element rules here, to avoid
+   regressing the ~40 page-level bespoke heading selectors (e.g.
+   `.tracker-hero-copy h1`, `.pricing-hero-content h1`, `.legal-hero h1`).
+   New markup should prefer these classes. Page selectors will be migrated
+   one page per commit in Slice 3 of REVAMP_PLAN.md §4 Track A.
+
+   Scale:
+     .h1 → --text-4xl (36px)  display, hero
+     .h2 → --text-3xl (30px)  section heading
+     .h3 → --text-2xl (24px)  subsection
+     .h4 → --text-xl  (20px)  card / block
+     .h5 → --text-lg  (18px)  minor block
+     .h6 → --text-base (16px) label / eyebrow
+   ═══════════════════════════════════════════════ */
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  font-family: var(--font-main);
+  color: var(--color-text);
+  text-wrap: balance;
+  margin: 0;
+}
+
+.h1 {
+  font-size: var(--text-4xl);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+}
+
+.h2 {
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+}
+
+.h3 {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+}
+
+.h4 {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+}
+
+.h5 {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+}
+
+.h6 {
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-normal);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+
+/* Display tier — opt-in for hero surfaces that need larger than .h1. */
+.display-1 {
+  font-size: var(--text-5xl);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  text-wrap: balance;
+  margin: 0;
+}
+
 button,
 select,
 input {

--- a/styles/global.css
+++ b/styles/global.css
@@ -334,12 +334,13 @@ a:hover {
    one page per commit in Slice 3 of REVAMP_PLAN.md §4 Track A.
 
    Scale:
-     .h1 → --text-4xl (36px)  display, hero
-     .h2 → --text-3xl (30px)  section heading
-     .h3 → --text-2xl (24px)  subsection
-     .h4 → --text-xl  (20px)  card / block
-     .h5 → --text-lg  (18px)  minor block
-     .h6 → --text-base (16px) label / eyebrow
+     .display-1 → --text-5xl (48px)  hero / display
+     .h1        → --text-4xl (36px)  display, hero
+     .h2        → --text-3xl (30px)  section heading
+     .h3        → --text-2xl (24px)  subsection
+     .h4        → --text-xl  (20px)  card / block
+     .h5        → --text-lg  (18px)  minor block
+     .h6        → --text-base (16px) label / eyebrow
    ═══════════════════════════════════════════════ */
 .h1,
 .h2,
@@ -347,8 +348,8 @@ a:hover {
 .h4,
 .h5,
 .h6 {
-  font-family: var(--font-main);
-  color: var(--color-text);
+  font-family: inherit;
+  color: inherit;
   text-wrap: balance;
   margin: 0;
 }


### PR DESCRIPTION
## Task

Ship **Slice 2a** of `REVAMP_PLAN.md` §4 Track A → _Heading scale confirmation_.

> **Stacked on #168** (`tokens/text-scale-reconcile`). Slice 2a references `--text-4xl` /
> `--text-5xl`, added in #168. Rebase this PR onto `main` after #168 merges.

## Files inspected

- [`styles/global.css`](styles/global.css) — type scale block + heading rules
- [`docs/REVAMP_PLAN.md`](docs/REVAMP_PLAN.md) §4 Track A
- `styles/**/*.css` — existing bespoke heading selectors (~40 sites, all untouched)

## Plan

Single-concern `typography` commit. Adds **utility classes only** — no base `h1..h6` element
rules. Adding base element rules risks regressing the ~40 page-level bespoke selectors that
already dominate specificity on existing markup. That's now carved out as a separate Slice 2b
with a per-page audit pre-requisite.

## Scale

| Class         | Size (token)             | Weight         | Line-height    | Extra                                  |
| ------------- | ------------------------ | -------------- | -------------- | -------------------------------------- |
| `.display-1`  | `--text-5xl` (48 px)     | bold           | tight          | `text-wrap: balance`, tight tracking   |
| `.h1`         | `--text-4xl` (36 px)     | bold           | tight          | `text-wrap: balance`, tight tracking   |
| `.h2`         | `--text-3xl` (30 px)     | bold           | tight          | `text-wrap: balance`, tight tracking   |
| `.h3`         | `--text-2xl` (24 px)     | semibold       | snug           | `text-wrap: balance`                   |
| `.h4`         | `--text-xl`  (20 px)     | semibold       | snug           | `text-wrap: balance`                   |
| `.h5`         | `--text-lg`  (18 px)     | semibold       | snug           | `text-wrap: balance`                   |
| `.h6`         | `--text-base` (16 px)    | semibold       | normal         | uppercase, `--tracking-wide`           |

## Changes made (this commit)

```
 docs/REVAMP_PLAN.md |  21 +++++++++-----
 styles/global.css   |  81 ++++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 93 insertions(+), 11 deletions(-)
```

Cumulative vs `main` (this PR + #168):

```
 docs/DESIGN_TOKENS.md |  17 +++++++----
 docs/REVAMP_PLAN.md   |  21 ++++++++-----
 styles/global.css     |  83 +++++++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 106 insertions(+), 13 deletions(-)
```

Also restructures the Track A "Heading scale confirmation" bullet into explicit sub-checkboxes
(Slice 1 ✅ · Slice 2a ✅ · Slice 2b ⬜ · Slice 3 ⬜) so the next agent can pick up cleanly.

## Verification

- `prettier --check` on both touched files — clean
- `stylelint styles/global.css` — clean
- `npm run validate` — all gates green (static files, HTML async, JS imports, DOM-sink
  baseline, SEO meta on 690 HTML files, sitemap coverage 483↔648)
- `npm test` — **271/271 pass**, 60 suites

## Remaining risks

- **Zero visual risk today.** No existing markup references these classes; no base element
  rules added.
- Future consumers (Slice 3) will introduce visible changes as they migrate from the bespoke
  selectors — that's expected and intentional, one page per commit.
- `text-wrap: balance` is a progressive enhancement — browsers that don't support it simply
  fall back to default wrapping (no layout break).

## Scope / conflict check

- Branched off `tokens/text-scale-reconcile` (#168). **Stacked PR** — merge #168 first, then
  GitHub will auto-retarget this PR to `main`.
- Single-concern `typography` commit per `REVAMP_PLAN.md` §1.
- No architecture, routing, or SEO changes.
