### PR TITLE
Potential fix for code scanning alert no. 43: Double escaping or unescaping

### DIFF
--- a/scripts/node/inventory-seo.js
+++ b/scripts/node/inventory-seo.js
@@ -87,12 +87,13 @@ function firstMatch(html, re) {
 function decode(str) {
   if (str == null) return null;
   // Only decode the five HTML entities likely to appear in SEO attributes.
+  // Decode `&amp;` last to avoid double-unescaping sequences like `&amp;quot;`.
   return str
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'");
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
 }
 
 function attr(name) {


### PR DESCRIPTION
Potential fix for [https://github.com/vctb12/Gold-Prices/security/code-scanning/43](https://github.com/vctb12/Gold-Prices/security/code-scanning/43)

Fix by decoding `&amp;` **last**, after all other entities.  
That preserves correct single-pass behavior and avoids turning `&amp;X;` into `X;` and then decoding it again.

Best minimal fix (no functionality expansion): in `scripts/node/inventory-seo.js`, update only `decode(str)` replacement order so `&amp;` is the final `.replace(...)`. No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
