### PR TITLE
Potential fix for code scanning alert no. 40: Clear text storage of sensitive information

### DIFF
--- a/admin/settings/index.html
+++ b/admin/settings/index.html
@@ -808,7 +808,6 @@
       }
 
       function buildCacheable(s) {
-        const keyStatus = statusForApiKeys(s.apiKeys);
         return {
           marginPercent: s.marginPercent,
           vatRate: s.vatRate,
@@ -818,12 +817,7 @@
           socialLinks: s.socialLinks,
           features: s.features,
           adminNotes: s.adminNotes,
-          // ---- key material is NEVER written to localStorage ----
-          apiKeysStatus: {
-            goldApi: keyStatus.goldApiConfigured ? 'configured' : 'unset',
-            fxApi: keyStatus.fxApiConfigured ? 'configured' : 'unset',
-          },
-          adsensePublisherId: keyStatus.adsensePublisherId,
+          // ---- nothing derived from apiKeys is written to localStorage ----
         };
       }
 
@@ -844,16 +838,15 @@
           const raw = localStorage.getItem(SETTINGS_CACHE_KEY);
           if (!raw) return null;
           const saved = JSON.parse(raw);
-          const status = saved.apiKeysStatus || {};
           return {
             ...DEFAULTS,
             ...saved,
             socialLinks: { ...DEFAULTS.socialLinks, ...(saved.socialLinks || {}) },
             features: { ...DEFAULTS.features, ...(saved.features || {}) },
             apiKeys: {
-              goldApi: status.goldApi === 'configured' ? SECRET_PLACEHOLDER : '',
-              fxApi: status.fxApi === 'configured' ? SECRET_PLACEHOLDER : '',
-              adsensePublisherId: saved.adsensePublisherId || '',
+              goldApi: '',
+              fxApi: '',
+              adsensePublisherId: '',
             },
           };
         } catch {


### PR DESCRIPTION
Potential fix for [https://github.com/vctb12/Gold-Prices/security/code-scanning/40](https://github.com/vctb12/Gold-Prices/security/code-scanning/40)

General fix: do not persist any value derived from secret-bearing structures (`apiKeys`) into `localStorage`. Persist only non-sensitive settings and reconstruct API-key UI state from defaults/placeholders at read time.

Best targeted fix in `admin/settings/index.html`:
- In `buildCacheable(s)`, remove the call to `statusForApiKeys(s.apiKeys)` and remove `apiKeysStatus` + `adsensePublisherId` from the returned cache object.
- In `readCachedSettings()`, stop reading `saved.apiKeysStatus` / `saved.adsensePublisherId`; always reconstruct `apiKeys` as empty secrets + empty AdSense ID (or defaults if desired) so no `apiKeys`-sourced value is ever stored/loaded from cache.
- Keep `statusForApiKeys` unused or leave as-is to minimize functional risk outside shown snippet.

This preserves core functionality (caching non-secret settings) while removing cleartext persistence of anything flowing from `apiKeys`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
