### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,3 +186,46 @@ Non-negotiables. Each has a one-line _Why:_ so you can make good edge-case decis
 - **Codex / Cursor / Windsurf / Aider / Gemini CLI** — read this file directly per the
   [`AGENTS.md`](https://agents.md) convention (stewarded by the Agentic AI Foundation). No
   vendor-specific branches in this file.
+
+## Cursor Cloud specific instructions
+
+### Environment
+
+- Node.js 24 is required (`.nvmrc`). The update script handles `nvm install 24` automatically.
+- No Docker, databases, or external services are needed for local development. The backend uses JSON
+  file persistence in `data/`.
+
+### Required env vars for running tests or the backend
+
+```bash
+export JWT_SECRET="dev-secret-key-for-local-development-32chars"
+export ADMIN_PASSWORD="admin-dev-password"
+export ADMIN_ACCESS_PIN="123456"
+```
+
+These must be set before `npm test` or `npm start`. The Vite dev server (`npm run dev`) does not
+require them.
+
+### Running services
+
+| Service             | Command       | Port | Notes                         |
+| ------------------- | ------------- | ---- | ----------------------------- |
+| Frontend (Vite HMR) | `npm run dev` | 5000 | No env vars needed            |
+| Backend (Express)   | `npm start`   | 3000 | Requires all 3 env vars above |
+
+### Key commands (see §2 above for full list)
+
+- `npm test` — 745 tests; 1 pre-existing failure in `tests/analytics.test.js` (Node 24 `navigator`
+  getter issue)
+- `npm run lint` — ESLint flat config
+- `npm run build` — full production build pipeline
+- `npm run validate` — CI-equivalent integrity checks
+
+### Admin API login for testing
+
+```
+POST http://localhost:3000/api/admin/auth/login
+{"email": "admin@goldprices.com", "password": "<ADMIN_PASSWORD env var value>"}
+```
+
+Returns a JWT token for authenticated endpoints at `/api/admin/*`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add a `## Cursor Cloud specific instructions` section to `AGENTS.md` with environment setup notes, required env vars, service ports, key commands, and admin API login details for future Cursor Cloud agents working on this repository.

## Implementation notes

- Appended a new section at the end of `AGENTS.md` (after §10 Agent-specific notes)
- Documents Node.js 24 requirement, env var setup, service ports, known test issues, and admin API authentication
- No code changes — documentation only

## Verification

- ✅ `npm run lint` — passes clean
- ✅ `npm test` — 744/745 pass (1 pre-existing Node 24 issue)
- ✅ `npm run build` — production build succeeds
- ✅ `npm run dev` — Vite dev server serves frontend on port 5000
- ✅ `npm start` — Express backend runs on port 3000, health check returns OK
- ✅ Admin login and authenticated API calls work end-to-end

[Gold Ticker Live homepage](https://cursor.com/agents/bc-65091b74-1cc1-4b90-a730-cf8b170653b0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Gold Price Tracker page](https://cursor.com/agents/bc-65091b74-1cc1-4b90-a730-cf8b170653b0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftracker_page.webp)
[Gold Shops directory page](https://cursor.com/agents/bc-65091b74-1cc1-4b90-a730-cf8b170653b0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshops_page.webp)

## Checklist
- [x] Run `npm ci` and `npm run quality`
- [x] Run `npm run build` and `node scripts/node/check-links.js --dir dist`
- [ ] Playwright smoke tests: `npm run test:playwright` (skipped — not required for docs-only change)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65091b74-1cc1-4b90-a730-cf8b170653b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65091b74-1cc1-4b90-a730-cf8b170653b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

