### PR TITLE
Add Cursor automation governance rule

### DIFF
--- a/.cursor/rules/automation-governance.mdc
+++ b/.cursor/rules/automation-governance.mdc
@@ -1,0 +1,33 @@
+---
+alwaysApply: true
+---
+
+# Automation Governance
+
+> Applies to all Cursor agents and background automations on vctb12/GoldTickerLive.
+
+## Before creating any PR
+- Check open PRs first. Do not create a PR if one already exists for the same fix or the same files.
+- Reference @PLAN.md before starting any task to check for context or blockers.
+
+## Scope discipline
+- Only edit files directly required by the task.
+- Do not refactor, rename, or restructure files that aren't part of the task scope.
+- Do not add dependencies without explicit instruction.
+
+## Production-critical files — extra caution required
+These files affect live production. Do not modify without a dry-run or explicit owner approval:
+- `post_gold.yml` — hourly X posting
+- `gold-price-fetch.yml` — live price data
+- `data/gold_price.json` — committed price state
+- `sw.js` — service worker (affects PWA cache)
+- `src/config/constants.js` — AED peg, troy ounce constant
+
+## Merge behavior (fully autonomous mode)
+- Agents may merge PRs **only after** all required CI checks pass (green).
+- Never merge if CodeQL, Gold Bakeoff Readiness, or Perf & QA Checks are failing.
+- Never merge to main if `post_gold.yml` or `gold-price-fetch.yml` are the only changed files — those need human review.
+
+## Secrets
+- Public repo. Never write secret values to any file, PR body, log, or comment.
+- `.env.example` contains variable names only — never real values.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `.cursor/rules/automation-governance.mdc` — an always-applied Cursor rule for agents and background automations on this repo.

## Why

Centralizes governance for autonomous work: PR deduplication, scope discipline, production-critical file guardrails, merge policy when CI is green, and secrets handling.

## How

Single new file under `.cursor/rules/` with `alwaysApply: true` frontmatter. No code, workflow, or dependency changes.

## Proof

- Only `.cursor/rules/automation-governance.mdc` changed (1 file, +33 lines).
- No tests or build required for a rules-only doc addition.

## Risks

Low — documentation-only for Cursor; does not alter runtime site behavior or GitHub Actions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3effd9e7-d167-4052-9bf4-3822ac7dd8fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3effd9e7-d167-4052-9bf4-3822ac7dd8fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

