### PR TITLE
fix(ux): Phase 1 first paint — skeletons, cache-first prices, parallel fetch

### DIFF
--- a/countries/algeria/index.html
+++ b/countries/algeria/index.html
@@ -83,15 +83,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/bahrain/index.html
+++ b/countries/bahrain/index.html
@@ -82,15 +82,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/country-page.js
+++ b/countries/country-page.js
@@ -32,6 +32,7 @@ import { injectNav, updateNavLang } from '../src/components/nav.js';
 import { injectFooter } from '../src/components/footer.js';
 import { injectTicker, updateTicker, updateTickerLang } from '../src/components/ticker.js';
 import { renderBreadcrumbs } from '../src/components/breadcrumbs.js';
+import { renderPriceFetchError } from '../src/components/price-fetch-error.js';
 
 // Minimal shared STATE for country pages
 const STATE = {
@@ -157,6 +158,16 @@ function calcChange(price) {
   return ((price - STATE.dayOpenGoldPriceUsdPerOz) / STATE.dayOpenGoldPriceUsdPerOz) * 100;
 }
 
+function priceValueMarkup(value, currency, decimals) {
+  if (value != null && Number.isFinite(value)) {
+    return formatPrice(value, currency, decimals);
+  }
+  if (!STATE.goldPriceUsdPerOz) {
+    return '<span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span>';
+  }
+  return '—';
+}
+
 // ── Render hero price block ──────────────────────────────────────────────────
 function renderHero(cfg) {
   const rate = getRate(cfg);
@@ -193,15 +204,15 @@ function renderHero(cfg) {
       <div class="cp-prices-row">
         <div class="cp-price-card">
           <div class="cp-price-label">${t('karat22')} · ${t('perGram')}</div>
-          <div class="cp-price-value">${gram22 ? formatPrice(gram22, cfg.currency, cfg.decimals) : '—'}</div>
+          <div class="cp-price-value">${priceValueMarkup(gram22, cfg.currency, cfg.decimals)}</div>
         </div>
         <div class="cp-price-card">
           <div class="cp-price-label">${t('karat24')} · ${t('perGram')}</div>
-          <div class="cp-price-value">${gram24 ? formatPrice(gram24, cfg.currency, cfg.decimals) : '—'}</div>
+          <div class="cp-price-value">${priceValueMarkup(gram24, cfg.currency, cfg.decimals)}</div>
         </div>
         <div class="cp-price-card">
           <div class="cp-price-label">${t('karat24')} · ${t('perOz')}</div>
-          <div class="cp-price-value">${oz24usd ? formatPrice(oz24usd, 'USD', 2) : '—'}</div>
+          <div class="cp-price-value">${priceValueMarkup(oz24usd, 'USD', 2)}</div>
         </div>
       </div>
       ${
@@ -573,22 +584,33 @@ function renderAll(cfg) {
 // ── Live data fetch ──────────────────────────────────────────────────────────
 async function fetchLiveData(cfg) {
   try {
-    const [goldData, fxData] = await Promise.allSettled([api.fetchGold(), api.fetchFX()]);
+    const { gold, fx } = await api.fetchGoldAndFX();
 
-    if (goldData.status === 'fulfilled') {
-      STATE.goldPriceUsdPerOz = goldData.value.price;
-      STATE.freshness.goldUpdatedAt = goldData.value.updatedAt;
-      cache.saveGoldPrice(goldData.value.price, goldData.value.updatedAt);
+    if (gold?.price) {
+      STATE.goldPriceUsdPerOz = gold.price;
+      STATE.freshness.goldUpdatedAt = gold.updatedAt;
+      cache.saveGoldPrice(gold.price, gold.updatedAt);
     }
 
-    if (fxData.status === 'fulfilled') {
-      const rates = fxData.value.rates;
-      rates.AED = undefined;
+    if (fx?.rates) {
+      const rates = { ...fx.rates };
+      delete rates.AED;
       STATE.rates = rates;
       cache.saveFXRates(rates, {
-        lastUpdateUtc: fxData.value.time_last_update_utc,
-        nextUpdateUtc: fxData.value.time_next_update_utc,
+        lastUpdateUtc: fx.time_last_update_utc,
+        nextUpdateUtc: fx.time_next_update_utc,
       });
+    }
+
+    if (!STATE.goldPriceUsdPerOz) {
+      const heroEl = document.getElementById('cp-hero-price');
+      if (heroEl) {
+        renderPriceFetchError(heroEl, {
+          lang: STATE.lang,
+          onRetry: () => fetchLiveData(cfg),
+        });
+      }
+      return;
     }
 
     // Append today's snapshot so the "Should I Buy Today?" indicator can build a

--- a/countries/egypt/cities/cairo.html
+++ b/countries/egypt/cities/cairo.html
@@ -109,15 +109,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">21K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/egypt/index.html
+++ b/countries/egypt/index.html
@@ -78,15 +78,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/india/index.html
+++ b/countries/india/index.html
@@ -78,15 +78,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/jordan/index.html
+++ b/countries/jordan/index.html
@@ -82,15 +82,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/kuwait/index.html
+++ b/countries/kuwait/index.html
@@ -82,15 +82,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/lebanon/index.html
+++ b/countries/lebanon/index.html
@@ -83,15 +83,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/libya/index.html
+++ b/countries/libya/index.html
@@ -79,15 +79,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/morocco/index.html
+++ b/countries/morocco/index.html
@@ -82,15 +82,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/oman/index.html
+++ b/countries/oman/index.html
@@ -74,15 +74,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/qatar/cities/doha.html
+++ b/countries/qatar/cities/doha.html
@@ -106,15 +106,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/qatar/index.html
+++ b/countries/qatar/index.html
@@ -78,15 +78,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/saudi-arabia/cities/riyadh.html
+++ b/countries/saudi-arabia/cities/riyadh.html
@@ -112,15 +112,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/saudi-arabia/index.html
+++ b/countries/saudi-arabia/index.html
@@ -82,15 +82,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/sudan/index.html
+++ b/countries/sudan/index.html
@@ -79,15 +79,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/tunisia/index.html
+++ b/countries/tunisia/index.html
@@ -83,15 +83,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/uae/cities/abu-dhabi.html
+++ b/countries/uae/cities/abu-dhabi.html
@@ -109,15 +109,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/uae/cities/dubai.html
+++ b/countries/uae/cities/dubai.html
@@ -107,15 +107,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/countries/uae/index.html
+++ b/countries/uae/index.html
@@ -77,15 +77,15 @@
             <div class="cp-prices-row">
               <div class="cp-price-card">
                 <div class="cp-price-label">22K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per gram</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="cp-price-card">
                 <div class="cp-price-label">24K · per oz</div>
-                <div class="cp-price-value">Loading…</div>
+                <div class="cp-price-value" aria-busy="true"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
           </div>

--- a/docs/audits/UI_UX_AUDIT_SESSION_REGISTRY.md
+++ b/docs/audits/UI_UX_AUDIT_SESSION_REGISTRY.md
@@ -6,7 +6,7 @@
 | Session | Phase | Branch | PR | Status | Merged | Notes |
 | :-----: | ----- | ------ | -- | ------ | ------ | ----- |
 | 0 | Planning | `cursor/ui-ux-audit-session-program-8c0a` | [#387](https://github.com/vctb12/GoldTickerLive/pull/387) | 🟡 open | — | Docs + prompts only |
-| 1 | First paint | `cursor/ui-ux-phase1-first-paint-f3bc` | — | 🟡 open | — | Skeletons, cache-first, parallel fetch, error retry |
+| 1 | First paint | `cursor/ui-ux-phase1-first-paint-f3bc` | [#388](https://github.com/vctb12/GoldTickerLive/pull/388) | 🟡 open | — | Skeletons, cache-first, parallel fetch, error retry |
 | 2 | Empty pages | `cursor/ui-ux-phase2-empty-pages-8c0a` | — | ⬜ queued | — | Learn static body; invest decision; shops; 404 |
 | 3 | Consistency | `cursor/ui-ux-phase3-consistency-8c0a` | — | ⬜ queued | — | May split 3a/3b |
 | 4 | Nav & layout | `cursor/ui-ux-phase4-nav-layout-8c0a` | — | ⬜ queued | — | May split 4a/4b/4c |

--- a/docs/audits/UI_UX_AUDIT_SESSION_REGISTRY.md
+++ b/docs/audits/UI_UX_AUDIT_SESSION_REGISTRY.md
@@ -6,7 +6,7 @@
 | Session | Phase | Branch | PR | Status | Merged | Notes |
 | :-----: | ----- | ------ | -- | ------ | ------ | ----- |
 | 0 | Planning | `cursor/ui-ux-audit-session-program-8c0a` | [#387](https://github.com/vctb12/GoldTickerLive/pull/387) | 🟡 open | — | Docs + prompts only |
-| 1 | First paint | `cursor/ui-ux-phase1-first-paint-8c0a` | — | ⬜ queued | — | **Start here** after Session 0 merges |
+| 1 | First paint | `cursor/ui-ux-phase1-first-paint-f3bc` | — | 🟡 open | — | Skeletons, cache-first, parallel fetch, error retry |
 | 2 | Empty pages | `cursor/ui-ux-phase2-empty-pages-8c0a` | — | ⬜ queued | — | Learn static body; invest decision; shops; 404 |
 | 3 | Consistency | `cursor/ui-ux-phase3-consistency-8c0a` | — | ⬜ queued | — | May split 3a/3b |
 | 4 | Nav & layout | `cursor/ui-ux-phase4-nav-layout-8c0a` | — | ⬜ queued | — | May split 4a/4b/4c |

--- a/docs/plans/2026-06-01_ui-ux-audit-remediation-program.md
+++ b/docs/plans/2026-06-01_ui-ux-audit-remediation-program.md
@@ -9,9 +9,9 @@ created: "2026-06-01"
 last_updated: "2026-06-01"
 source: external-audit-prompt-2026-06-01
 sessions_total: 6
-sessions_open: 5
-next_session: 1
-next_branch: cursor/ui-ux-phase1-first-paint-8c0a
+sessions_open: 4
+next_session: 2
+next_branch: cursor/ui-ux-phase2-empty-pages-8c0a
 blocked_on: ""
 guardrails_reviewed: true
 skills_used: [mobile-ux-review, pricing-data-integrity, frontend-design-system, seo-governance]
@@ -79,12 +79,12 @@ copy and placeholders.
 
 ### Phase 1 — Kill Loading…/— first paint (CRITICAL)
 
-- [ ] Reusable skeleton component + CSS utilities (price cards, tables, freshness strip)
-- [ ] Replace literal `Loading…`, `Preparing…`, `Connecting…`, bare `—` on index, tracker, shops,
+- [x] Reusable skeleton component + CSS utilities (price cards, tables, freshness strip)
+- [x] Replace literal `Loading…`, `Preparing…`, `Connecting…`, bare `—` on index, tracker, shops,
       country/city, invest
-- [ ] Hydrate from `localStorage` / existing cache layer before network
-- [ ] Error empty state (icon, message, retry) on `api.js` failure path when no cache
-- [ ] Parallelize gold + FX fetches (today: sequential)
+- [x] Hydrate from `localStorage` / existing cache layer before network
+- [x] Error empty state (icon, message, retry) on `api.js` failure path when no cache
+- [x] Parallelize gold + FX fetches (today: sequential)
 
 **Verify:** `npm test`, `npm run validate`, `npm run build`; manual 360px LTR + RTL first paint &
       hard-offline.
@@ -187,3 +187,12 @@ TODO (owner): add under backlog / UX in [`docs/REVAMP_PLAN.md`](../REVAMP_PLAN.m
 - **Next action:** Open Session 1 branch `cursor/ui-ux-phase1-first-paint-8c0a`; paste prompt from
   [`2026-06-01_ui-ux-audit-session-prompts.md`](./2026-06-01_ui-ux-audit-session-prompts.md) or
   `@.github/prompts/ui-ux-audit-phase1-first-paint.prompt.md`
+
+### 2026-06-01 — cursor (Session 1 — first paint)
+
+- **Slice:** Phase 1
+- **Branch:** `cursor/ui-ux-phase1-first-paint-f3bc`
+- **Completed:** `skeleton.js`, `price-fetch-error.js`, `fetchGoldAndFX`, cache-first hydrators,
+  skeleton HTML on index/tracker/shops/invest/country shells
+- **Validation:** `npm test`, `npm run lint`, `npm run validate`, `npm run build` (agent-run)
+- **Next action:** Session 2 empty pages (`cursor/ui-ux-phase2-empty-pages-8c0a`)

--- a/index.html
+++ b/index.html
@@ -235,19 +235,19 @@
             <div class="hlc-grid">
               <div class="hlc-item">
                 <span class="hlc-item-label" id="hlc-label-aed24">24K / gram (AED)</span>
-                <span class="hlc-item-val" id="hlc-aed24">—</span>
+                <span class="hlc-item-val skeleton-inline shell-skeleton-karat" id="hlc-aed24" aria-busy="true"></span>
               </div>
               <div class="hlc-item">
                 <span class="hlc-item-label" id="hlc-label-aed22">22K / gram (AED)</span>
-                <span class="hlc-item-val" id="hlc-aed22">—</span>
+                <span class="hlc-item-val skeleton-inline shell-skeleton-karat" id="hlc-aed22" aria-busy="true"></span>
               </div>
               <div class="hlc-item">
                 <span class="hlc-item-label" id="hlc-label-aed21">21K / gram (AED)</span>
-                <span class="hlc-item-val" id="hlc-aed21">—</span>
+                <span class="hlc-item-val skeleton-inline shell-skeleton-karat" id="hlc-aed21" aria-busy="true"></span>
               </div>
               <div class="hlc-item">
                 <span class="hlc-item-label" id="hlc-label-aed18">18K / gram (AED)</span>
-                <span class="hlc-item-val" id="hlc-aed18">—</span>
+                <span class="hlc-item-val skeleton-inline shell-skeleton-karat" id="hlc-aed18" aria-busy="true"></span>
               </div>
             </div>
             <div class="hlc-footer">
@@ -257,7 +257,7 @@
                 role="status"
                 aria-live="polite"
                 aria-atomic="true"
-                >Loading…</span
+                ><span class="skeleton-inline shell-skeleton-freshness-strip" role="presentation" aria-hidden="true"></span></span
               >
               <a href="tracker.html" class="hlc-tracker-link" id="hlc-tracker-link"
                 >Full Tracker →</a
@@ -293,15 +293,13 @@
                   data-tone="live"
                   id="home-command-freshness"
                   aria-busy="true"
-                  >Loading freshness…</span
-                >
+                ></span>
                 <span
                   class="trust-chip skeleton-inline home-command-chip--loading"
                   data-tone="info"
                   id="home-command-spot-chip"
                   aria-busy="true"
-                  >XAU/USD —</span
-                >
+                ></span>
               </div>
             </div>
 
@@ -455,7 +453,11 @@
                     <span class="mobile-command-card__metric-label" id="home-snapshot-uae-label"
                       >UAE reference</span
                     >
-                    <strong class="mobile-command-card__metric-value" id="home-snapshot-uae-value">—</strong>
+                    <strong
+                      class="mobile-command-card__metric-value skeleton-inline shell-skeleton-karat"
+                      id="home-snapshot-uae-value"
+                      aria-busy="true"
+                    ></strong>
                     <span class="mobile-command-card__metric-note" id="home-snapshot-uae-note"
                       >24K per gram in AED</span
                     >
@@ -464,7 +466,11 @@
                     <span class="mobile-command-card__metric-label" id="home-snapshot-global-label"
                       >Global spot</span
                     >
-                    <strong class="mobile-command-card__metric-value" id="home-snapshot-global-value">—</strong>
+                    <strong
+                      class="mobile-command-card__metric-value skeleton-inline shell-skeleton-karat"
+                      id="home-snapshot-global-value"
+                      aria-busy="true"
+                    ></strong>
                     <span class="mobile-command-card__metric-note" id="home-snapshot-global-note"
                       >XAU/USD per troy ounce</span
                     >
@@ -484,7 +490,11 @@
                     <span class="mobile-command-card__metric-label" id="home-snapshot-status-label"
                       >Status</span
                     >
-                    <strong class="mobile-command-card__metric-value" id="home-snapshot-status-value">—</strong>
+                    <strong
+                      class="mobile-command-card__metric-value skeleton-inline shell-skeleton-karat"
+                      id="home-snapshot-status-value"
+                      aria-busy="true"
+                    ></strong>
                     <span class="mobile-command-card__metric-note" id="home-snapshot-status-note"
                       >Live, cached, or stale is always labeled.</span
                     >
@@ -555,8 +565,8 @@
               <span
                 class="karat-strip-v skeleton-inline shell-skeleton-karat"
                 id="kstrip-24-val"
-                >—</span
-              >
+                aria-busy="true"
+              ></span>
               <button
                 class="kstrip-copy-btn"
                 id="kstrip-24-copy"
@@ -570,8 +580,8 @@
               <span
                 class="karat-strip-v skeleton-inline shell-skeleton-karat"
                 id="kstrip-22-val"
-                >—</span
-              >
+                aria-busy="true"
+              ></span>
               <button
                 class="kstrip-copy-btn"
                 id="kstrip-22-copy"
@@ -585,8 +595,8 @@
               <span
                 class="karat-strip-v skeleton-inline shell-skeleton-karat"
                 id="kstrip-21-val"
-                >—</span
-              >
+                aria-busy="true"
+              ></span>
               <button
                 class="kstrip-copy-btn"
                 id="kstrip-21-copy"
@@ -600,8 +610,8 @@
               <span
                 class="karat-strip-v skeleton-inline shell-skeleton-karat"
                 id="kstrip-18-val"
-                >—</span
-              >
+                aria-busy="true"
+              ></span>
               <button
                 class="kstrip-copy-btn"
                 id="kstrip-18-copy"
@@ -615,8 +625,8 @@
               <span
                 class="karat-strip-v skeleton-inline shell-skeleton-karat"
                 id="kstrip-14-val"
-                >—</span
-              >
+                aria-busy="true"
+              ></span>
               <button
                 class="kstrip-copy-btn"
                 id="kstrip-14-copy"
@@ -627,7 +637,9 @@
             </div>
           </div>
           <div class="karat-strip-actions">
-            <span class="karat-strip-updated" id="karat-strip-updated" aria-live="polite">Loading freshness…</span>
+            <span class="karat-strip-updated" id="karat-strip-updated" aria-live="polite"
+              ><span class="skeleton-inline shell-skeleton-freshness-strip" role="presentation" aria-hidden="true"></span
+            ></span>
             <a href="tracker.html" class="karat-strip-link" id="karat-strip-cta">Full tracker →</a>
           </div>
         </div>

--- a/invest.html
+++ b/invest.html
@@ -264,25 +264,25 @@
               <div class="invest-results-grid">
                 <div class="invest-result-card">
                   <div class="invest-result-label" data-i18n="resultBudget"></div>
-                  <div class="invest-result-value" id="result-budget">—</div>
+                  <div class="invest-result-value skeleton-inline shell-skeleton-price-md" id="result-budget" aria-busy="true"></div>
                   <div class="invest-result-note" id="result-budget-note"></div>
                 </div>
 
                 <div class="invest-result-card">
                   <div class="invest-result-label" data-i18n="resultGrams"></div>
-                  <div class="invest-result-value" id="result-grams">—</div>
+                  <div class="invest-result-value skeleton-inline shell-skeleton-karat" id="result-grams" aria-busy="true"></div>
                   <div class="invest-result-note" id="result-grams-note"></div>
                 </div>
 
                 <div class="invest-result-card">
                   <div class="invest-result-label" data-i18n="resultOunces"></div>
-                  <div class="invest-result-value" id="result-ounces">—</div>
+                  <div class="invest-result-value skeleton-inline shell-skeleton-karat" id="result-ounces" aria-busy="true"></div>
                   <div class="invest-result-note" id="result-ounces-note"></div>
                 </div>
 
                 <div class="invest-result-card">
                   <div class="invest-result-label" id="result-fourth-label"></div>
-                  <div class="invest-result-value" id="result-fourth">—</div>
+                  <div class="invest-result-value skeleton-inline shell-skeleton-karat" id="result-fourth" aria-busy="true"></div>
                   <div class="invest-result-note" id="result-fourth-note"></div>
                 </div>
               </div>

--- a/shops.html
+++ b/shops.html
@@ -95,7 +95,7 @@
             <span class="shops-trust-icon" aria-hidden="true">◈</span>
             <span class="shops-trust-text"
               ><span id="shops-trust-label">Reference listings</span> ·
-              <span id="shops-last-updated">Loading...</span></span
+              <span id="shops-last-updated" class="skeleton-inline shell-skeleton-freshness-strip" aria-busy="true"></span></span
             >
           </div>
           <p class="shops-results-disclaimer" id="shops-freshness-semantics">
@@ -367,10 +367,12 @@
           </div>
 
           <div id="shops-grid" class="shops-grid"></div>
-          <div id="shops-loading" class="shops-empty" hidden aria-live="polite">
-            <span class="ses-icon" aria-hidden="true">⏳</span>
-            <h3>Loading listings…</h3>
-            <p>Fetching verified shops, markets, and sponsored placements.</p>
+          <div id="shops-loading" class="shops-empty shops-loading-skeleton" hidden aria-live="polite">
+            <div class="shops-skeleton-grid" aria-hidden="true">
+              <div class="shops-skeleton-card"><span class="skeleton-inline shell-skeleton-block"></span></div>
+              <div class="shops-skeleton-card"><span class="skeleton-inline shell-skeleton-block"></span></div>
+              <div class="shops-skeleton-card"><span class="skeleton-inline shell-skeleton-block"></span></div>
+            </div>
           </div>
           <div id="shops-error" class="shops-empty" hidden aria-live="polite">
             <span class="ses-icon" aria-hidden="true">⚠️</span>

--- a/src/components/price-fetch-error.js
+++ b/src/components/price-fetch-error.js
@@ -1,0 +1,43 @@
+/**
+ * Inline empty state when gold/FX fetch fails and no cache is available.
+ */
+
+import { TRANSLATIONS } from '../config/translations.js';
+import { el, clear } from '../lib/safe-dom.js';
+
+function tx(lang, key) {
+  return TRANSLATIONS[lang]?.[key] ?? TRANSLATIONS.en?.[key] ?? key;
+}
+
+/**
+ * @param {HTMLElement} container
+ * @param {{ lang?: 'en'|'ar', onRetry?: () => void }} opts
+ */
+export function renderPriceFetchError(container, { lang = 'en', onRetry } = {}) {
+  if (!container) return;
+  clear(container);
+  container.classList.add('price-fetch-error');
+  container.hidden = false;
+
+  const icon = el('span', { class: 'price-fetch-error__icon', 'aria-hidden': 'true' }, '⚠');
+  const message = el('p', { class: 'price-fetch-error__message' }, tx(lang, 'status.noData'));
+
+  container.append(icon, message);
+
+  if (typeof onRetry === 'function') {
+    const btn = el(
+      'button',
+      { type: 'button', class: 'btn btn-secondary btn-sm price-fetch-error__retry' },
+      tx(lang, 'status.retry')
+    );
+    btn.addEventListener('click', onRetry);
+    container.append(btn);
+  }
+}
+
+export function hidePriceFetchError(container) {
+  if (!container) return;
+  container.hidden = true;
+  container.classList.remove('price-fetch-error');
+  clear(container);
+}

--- a/src/components/skeleton.js
+++ b/src/components/skeleton.js
@@ -1,0 +1,69 @@
+/**
+ * Reusable skeleton placeholders for price surfaces (cards, tables, freshness chips).
+ * Uses safe DOM only — shimmer via `.skeleton-inline` + size utilities in shell/skeleton CSS.
+ */
+
+import { el } from '../lib/safe-dom.js';
+
+/** @typedef {'priceLg'|'priceMd'|'karat'|'freshnessChip'|'freshnessStrip'|'tableCell'|'block'} SkeletonVariant */
+
+const VARIANT_CLASS = {
+  priceLg: 'shell-skeleton-price-lg',
+  priceMd: 'shell-skeleton-price-md',
+  karat: 'shell-skeleton-karat',
+  freshnessChip: 'shell-skeleton-freshness-chip',
+  freshnessStrip: 'shell-skeleton-freshness-strip',
+  tableCell: 'shell-skeleton-table-cell',
+  block: 'shell-skeleton-block',
+};
+
+/**
+ * @param {SkeletonVariant|string} variant
+ * @param {{ className?: string, block?: boolean }} [opts]
+ */
+export function skeletonNode(variant = 'karat', opts = {}) {
+  const sizeClass = VARIANT_CLASS[variant] || variant;
+  const classes = ['skeleton-inline', sizeClass, opts.className].filter(Boolean).join(' ');
+  if (opts.block) {
+    return el('div', { class: classes, role: 'presentation', 'aria-hidden': 'true' });
+  }
+  return el('span', { class: classes, role: 'presentation', 'aria-hidden': 'true' });
+}
+
+/**
+ * Replace target content with a skeleton and mark busy for assistive tech.
+ * @param {HTMLElement|null} target
+ * @param {SkeletonVariant|string} [variant='karat']
+ */
+export function mountSkeleton(target, variant = 'karat') {
+  if (!target) return;
+  target.replaceChildren(skeletonNode(variant));
+  target.setAttribute('aria-busy', 'true');
+}
+
+/**
+ * @param {HTMLElement|null} target
+ */
+export function clearSkeletonBusy(target) {
+  if (!target) return;
+  target.removeAttribute('aria-busy');
+}
+
+/**
+ * @param {HTMLElement|null} target
+ */
+export function hasSkeleton(target) {
+  return Boolean(target?.querySelector?.('.skeleton-inline'));
+}
+
+/**
+ * Build a row of table-cell skeletons (for karat tables while loading).
+ * @param {number} cols
+ */
+export function skeletonTableRow(cols = 3) {
+  const cells = [];
+  for (let i = 0; i < cols; i++) {
+    cells.push(el('td', null, [skeletonNode('tableCell')]));
+  }
+  return el('tr', { class: 'skeleton-table-row', 'aria-hidden': 'true' }, cells);
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -278,3 +278,30 @@ export async function fetchFX() {
   }
   throw new NetworkError('FX rates unavailable — live fetch and cache both failed');
 }
+
+/**
+ * Fetch gold spot and FX rates in parallel (no waterfall).
+ * Individual fetchers still apply cache fallbacks; this helper surfaces partial success.
+ *
+ * @param {{ signal?: AbortSignal, timeoutMs?: number }} [options]
+ * @returns {Promise<{
+ *   gold: Awaited<ReturnType<typeof fetchGold>>|null,
+ *   fx: Awaited<ReturnType<typeof fetchFX>>|null,
+ *   errors: { gold: Error|null, fx: Error|null }
+ * }>}
+ */
+export async function fetchGoldAndFX(options = {}) {
+  const [goldRes, fxRes] = await Promise.allSettled([
+    fetchGold(options),
+    fetchFX(options),
+  ]);
+
+  return {
+    gold: goldRes.status === 'fulfilled' ? goldRes.value : null,
+    fx: fxRes.status === 'fulfilled' ? fxRes.value : null,
+    errors: {
+      gold: goldRes.status === 'rejected' ? goldRes.reason : null,
+      fx: fxRes.status === 'rejected' ? fxRes.reason : null,
+    },
+  };
+}

--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -212,6 +212,17 @@ export function getFallbackFXRates() {
 }
 
 /**
+ * Snapshot of last-known gold + FX from localStorage for cache-first paint.
+ * @returns {{ gold: ReturnType<typeof getFallbackGoldPrice>, fx: ReturnType<typeof getFallbackFXRates> }}
+ */
+export function getCachedPriceSnapshot() {
+  return {
+    gold: getFallbackGoldPrice(),
+    fx: getFallbackFXRates(),
+  };
+}
+
+/**
  * Persist a single user-preference key/value pair. The full preferences object
  * is read-modify-written atomically.
  *

--- a/src/lib/page-hydrator.js
+++ b/src/lib/page-hydrator.js
@@ -15,6 +15,8 @@ import { injectFooter } from '../components/footer.js';
 import { injectSpotBar, updateSpotBar, updateSpotBarLang } from '../components/spotBar.js';
 import { injectBreadcrumbs } from '../components/breadcrumbs.js';
 import { el, safeHref, clear, setText } from './safe-dom.js';
+import { skeletonNode } from '../components/skeleton.js';
+import { renderPriceFetchError } from '../components/price-fetch-error.js';
 import { track, EVENTS } from './analytics.js';
 import '../lib/reveal.js';
 import { initPageEnter } from './page-enter.js';
@@ -142,36 +144,55 @@ function calcLocalPrice(spotUsdPerOz, purity, fxRate, unit = 'gram') {
   return localPerGram;
 }
 
+function goldFromCache() {
+  const fallback = cache.getFallbackGoldPrice();
+  return fallback
+    ? { price: fallback.price, updatedAt: fallback.updatedAt, source: 'cache-fallback' }
+    : null;
+}
+
+function fxFromCache() {
+  const cached = cache.getFallbackFXRates();
+  return cached
+    ? {
+        rates: cached.rates || {},
+        time_last_update_utc: cached.time_last_update_utc,
+        source: 'cache-fallback',
+      }
+    : { rates: {}, source: 'unavailable' };
+}
+
 async function fetchPrices() {
-  try {
-    const [goldRes, fxRes] = await Promise.allSettled([api.fetchGold(), api.fetchFX()]);
-    const gold =
-      goldRes.status === 'fulfilled'
-        ? goldRes.value
-        : (() => {
-            const fallback = cache.getFallbackGoldPrice();
-            return fallback
-              ? { price: fallback.price, updatedAt: fallback.updatedAt, source: 'cache-fallback' }
-              : null;
-          })();
+  const { gold: liveGold, fx: liveFx } = await api.fetchGoldAndFX();
+  const gold = liveGold || goldFromCache();
+  const fx = liveFx || fxFromCache();
+  return { gold, fx };
+}
 
-    const fx =
-      fxRes.status === 'fulfilled'
-        ? fxRes.value
-        : cache.getFXRates?.()
-          ? { ...cache.getFXRates(), source: 'cache-fallback' }
-          : { rates: {}, source: 'unavailable' };
-
-    return { gold, fx };
-  } catch {
-    const fallback = cache.getFallbackGoldPrice();
-    return {
-      gold: fallback
-        ? { price: fallback.price, updatedAt: fallback.updatedAt, source: 'cache-fallback' }
-        : null,
-      fx: { rates: {}, source: 'unavailable' },
-    };
-  }
+function renderLegacyLoadingSkeleton(loadingEl) {
+  if (!loadingEl) return;
+  clear(loadingEl);
+  loadingEl.className = 'ph-loading-skeleton';
+  loadingEl.append(
+    el('div', { class: 'ph-karat-skeleton-grid', 'aria-hidden': 'true' }, [
+      el('div', { class: 'ph-karat-card ph-karat-card--skeleton' }, [
+        skeletonNode('tableCell', { block: true }),
+        skeletonNode('priceMd', { block: true }),
+      ]),
+      el('div', { class: 'ph-karat-card ph-karat-card--skeleton' }, [
+        skeletonNode('tableCell', { block: true }),
+        skeletonNode('priceMd', { block: true }),
+      ]),
+      el('div', { class: 'ph-karat-card ph-karat-card--skeleton' }, [
+        skeletonNode('tableCell', { block: true }),
+        skeletonNode('priceMd', { block: true }),
+      ]),
+      el('div', { class: 'ph-karat-card ph-karat-card--skeleton' }, [
+        skeletonNode('tableCell', { block: true }),
+        skeletonNode('priceMd', { block: true }),
+      ]),
+    ])
+  );
 }
 
 function freshnessTone(key) {
@@ -839,26 +860,36 @@ function renderDisclaimerLegacy(country, pageUrl) {
   ]);
 }
 
-async function hydrateLegacyPage({ country, karatSlug }) {
+function renderLegacyFromCache(country, karatSlug) {
+  const cachedGold = cache.getFallbackGoldPrice();
+  const cachedFx = cache.getFallbackFXRates();
+  if (!cachedGold?.price) return false;
+
+  const gold = {
+    price: cachedGold.price,
+    updatedAt: cachedGold.updatedAt,
+    source: 'cache-fallback',
+  };
+  const fx = cachedFx
+    ? {
+        rates: cachedFx.rates || {},
+        time_last_update_utc: cachedFx.time_last_update_utc,
+        source: 'cache-fallback',
+      }
+    : { rates: {}, source: 'unavailable' };
+
+  return applyLegacyPriceRender({ country, karatSlug, gold, fx });
+}
+
+function applyLegacyPriceRender({ country, karatSlug, gold, fx }) {
   const loadingEl = document.getElementById('price-loading');
   const displayEl = document.getElementById('price-display');
   const karatsEl = document.getElementById('karat-cards');
   const freshEl = document.getElementById('freshness-badge');
   const disclaimerEl = document.getElementById('price-disclaimer');
 
-  const { gold, fx } = await fetchPrices();
-  if (!gold) {
-    if (loadingEl) loadingEl.textContent = 'Unable to fetch prices. Please try again.';
-    updateSpotBar({ updatedAt: null });
-    return;
-  }
-
   const rate = getCountryFxRate(country, fx);
-  if (!rate) {
-    if (loadingEl) loadingEl.textContent = `FX rate for ${country.currency} unavailable.`;
-    updateSpotBar({ updatedAt: gold.updatedAt, hasLiveFailure: true });
-    return;
-  }
+  if (!rate) return false;
 
   if (karatsEl)
     karatsEl.replaceChildren(
@@ -867,7 +898,7 @@ async function hydrateLegacyPage({ country, karatSlug }) {
   if (freshEl) freshEl.replaceChildren(renderFreshnessBadgeLegacy(gold.updatedAt));
   if (disclaimerEl) disclaimerEl.replaceChildren(renderDisclaimerLegacy(country, location.href));
 
-  const aed24g = (gold.price / CONSTANTS.TROY_OZ_GRAMS) * AED_PEG;
+  const aed24g = (gold.price / TROY_OZ_GRAMS) * AED_PEG;
   updateSpotBar({
     xauUsd: gold.price,
     aed24kGram: aed24g,
@@ -876,7 +907,54 @@ async function hydrateLegacyPage({ country, karatSlug }) {
   });
 
   if (displayEl) displayEl.style.display = '';
-  if (loadingEl) loadingEl.style.display = 'none';
+  if (loadingEl) {
+    loadingEl.style.display = 'none';
+    loadingEl.hidden = true;
+  }
+  return true;
+}
+
+async function hydrateLegacyPage({ country, karatSlug, lang = 'en' }) {
+  const loadingEl = document.getElementById('price-loading');
+  const displayEl = document.getElementById('price-display');
+
+  renderLegacyLoadingSkeleton(loadingEl);
+  renderLegacyFromCache(country, karatSlug);
+
+  const refresh = async () => {
+    const { gold, fx } = await fetchPrices();
+    if (!gold) {
+      if (!cache.getFallbackGoldPrice()?.price && loadingEl) {
+        renderPriceFetchError(loadingEl, {
+          lang,
+          onRetry: () => {
+            renderLegacyLoadingSkeleton(loadingEl);
+            refresh();
+          },
+        });
+        loadingEl.style.display = '';
+        loadingEl.hidden = false;
+        if (displayEl) displayEl.style.display = 'none';
+      }
+      updateSpotBar({ updatedAt: null });
+      return;
+    }
+
+    if (!applyLegacyPriceRender({ country, karatSlug, gold, fx })) {
+      if (loadingEl) {
+        setText(
+          loadingEl,
+          lang === 'ar'
+            ? `سعر صرف ${country.currency} غير متوفر.`
+            : `FX rate for ${country.currency} unavailable.`
+        );
+      }
+      updateSpotBar({ updatedAt: gold.updatedAt, hasLiveFailure: true });
+      return;
+    }
+  };
+
+  await refresh();
 }
 
 async function hydrate() {
@@ -904,6 +982,27 @@ async function hydrate() {
       countryUrl: withBase(`countries/${country.slug}/gold-price/`),
     });
     const pageData = getCountryPageData();
+    const cachedGold = cache.getFallbackGoldPrice();
+    const cachedFx = cache.getFallbackFXRates();
+    if (cachedGold?.price) {
+      renderCountryPage({
+        country,
+        pageData,
+        lang,
+        gold: {
+          price: cachedGold.price,
+          updatedAt: cachedGold.updatedAt,
+          source: 'cache-fallback',
+        },
+        fx: cachedFx
+          ? {
+              rates: cachedFx.rates || {},
+              time_last_update_utc: cachedFx.time_last_update_utc,
+              source: 'cache-fallback',
+            }
+          : { rates: {}, source: 'unavailable' },
+      });
+    }
     const { gold, fx } = await fetchPrices();
     renderCountryPage({ country, pageData, lang, gold, fx });
     track(EVENTS.COUNTRY_PAGE_VIEW, {
@@ -915,7 +1014,7 @@ async function hydrate() {
     return;
   }
 
-  await hydrateLegacyPage({ country, karatSlug: route.karatSlug });
+  await hydrateLegacyPage({ country, karatSlug: route.karatSlug, lang });
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -31,6 +31,7 @@ import { copyWithToast } from '../lib/copy-toast.js';
 import { mountQuickConvertWidget } from '../components/QuickConvertWidget.js';
 import { initSwUpdateToast } from '../lib/sw-update-toast.js';
 import { showDataStatusBanner, hideDataStatusBanner } from '../lib/data-status-banner.js';
+import { mountSkeleton, skeletonNode } from '../components/skeleton.js';
 import { clear, el, safeHref } from '../lib/safe-dom.js';
 import { track, EVENTS } from '../lib/analytics.js';
 import { enforceCanonicalOnDocument } from '../seo/canonical.js';
@@ -182,6 +183,25 @@ function formatCountrySearchEmpty(query = '') {
   const trimmed = query.trim();
   if (!trimmed) return tx('countrySearchEmpty');
   return tx('countrySearchEmptyQuery').replace('{query}', trimmed);
+}
+
+function ensureHeroLoadingSkeletons() {
+  mountSkeleton(document.getElementById('hlc-updated'), 'freshnessStrip');
+  for (const id of ['hlc-aed24', 'hlc-aed22', 'hlc-aed21', 'hlc-aed18']) {
+    mountSkeleton(document.getElementById(id), 'karat');
+  }
+  mountSkeleton(document.getElementById('karat-strip-updated'), 'freshnessStrip');
+  for (const id of ['home-snapshot-uae-value', 'home-snapshot-global-value', 'home-snapshot-status-value']) {
+    mountSkeleton(document.getElementById(id), 'karat');
+  }
+  const freshnessChip = document.getElementById('home-command-freshness');
+  const spotChip = document.getElementById('home-command-spot-chip');
+  if (freshnessChip?.classList.contains('home-command-chip--loading')) {
+    freshnessChip.replaceChildren(skeletonNode('freshnessChip'));
+  }
+  if (spotChip?.classList.contains('home-command-chip--loading')) {
+    spotChip.replaceChildren(skeletonNode('freshnessChip'));
+  }
 }
 
 function setTrustChip(id, text, freshnessKey = 'neutral') {
@@ -367,6 +387,8 @@ function renderHeroCard() {
   ]) {
     const cell = document.getElementById(id);
     if (cell && val) {
+      cell.classList.remove('skeleton-inline', 'shell-skeleton-karat');
+      cell.removeAttribute('aria-busy');
       countUp(cell, val, {
         decimals: 2,
         format: (n) => fmt.formatPrice(n, 'AED', 2),
@@ -381,6 +403,8 @@ function renderHeroCard() {
   const ageClass = freshnessAgeClass(getLiveFreshness({ updatedAt: goldUpdatedAt, lang }).ageMs);
   const hlcUpdatedEl = document.getElementById('hlc-updated');
   if (hlcUpdatedEl) {
+    hlcUpdatedEl.classList.remove('skeleton-text', 'skeleton-inline', 'shell-skeleton-freshness-strip');
+    hlcUpdatedEl.removeAttribute('aria-busy');
     hlcUpdatedEl.textContent = `${txGlobal('freshness.statusLabel')}: ${statusText} · ${tx('source')}: ${sourceText} · ${tx('updated')}: ${ageText}`;
     hlcUpdatedEl.dataset.freshnessKey = key;
     hlcUpdatedEl.dataset.freshnessAge = ageClass;
@@ -1034,15 +1058,25 @@ function applyLangToPage() {
 async function fetchLiveData() {
   if (!navigator.onLine) return;
   try {
-    const fxData = await api.fetchFX();
-    rates = fxData.rates ?? {};
-    cache.saveFXRates(rates, {
-      lastUpdateUtc: fxData.time_last_update_utc,
-      nextUpdateUtc: fxData.time_next_update_utc,
-    });
-    renderGCCGrid();
+    const { gold, fx } = await api.fetchGoldAndFX();
+    if (fx?.rates) {
+      rates = fx.rates ?? {};
+      cache.saveFXRates(rates, {
+        lastUpdateUtc: fx.time_last_update_utc,
+        nextUpdateUtc: fx.time_next_update_utc,
+      });
+      renderGCCGrid();
+    }
+    if (gold?.price && !goldPrice) {
+      goldPrice = gold.price;
+      goldUpdatedAt = gold.updatedAt || goldUpdatedAt;
+      cache.saveGoldPrice(gold.price, goldUpdatedAt);
+      renderHeroCard();
+      renderCommandCenter();
+      renderKaratStrip();
+    }
   } catch {
-    // keep previous FX data
+    // keep previous FX / gold data
   }
 }
 
@@ -1062,8 +1096,8 @@ function applyRealtimeSnapshot(snapshot) {
   } else if (!goldPrice) {
     const priceEl = document.getElementById('hlc-price');
     if (priceEl) {
-      priceEl.classList.remove('hlc-price--loading');
-      priceEl.textContent = '—';
+      priceEl.classList.add('hlc-price--loading');
+      mountSkeleton(priceEl, 'priceLg');
     }
   }
 
@@ -1363,6 +1397,7 @@ async function init() {
     isOnline: navigator.onLine,
   };
   cache.loadState(cacheState);
+  ensureHeroLoadingSkeletons();
 
   if (cacheState.goldPriceUsdPerOz) {
     goldPrice = cacheState.goldPriceUsdPerOz;
@@ -1456,7 +1491,7 @@ async function init() {
     const priceEl = document.getElementById('hlc-price');
     if (priceEl && priceEl.classList.contains('hlc-price--loading')) {
       priceEl.classList.remove('hlc-price--loading');
-      priceEl.textContent = '—';
+      mountSkeleton(priceEl, 'priceLg');
       const updEl = document.getElementById('hlc-updated');
       if (updEl) {
         updEl.textContent = tx('priceUnavailableConnection');
@@ -1471,7 +1506,10 @@ async function init() {
       }
       document.getElementById('hero-live-card')?.removeAttribute('aria-busy');
       setTrustChip('home-command-freshness', tx('sourceUnavailable'), 'unavailable');
-      setTrustChip('home-command-spot-chip', 'XAU/USD —', 'unavailable');
+      setTrustChip('home-command-spot-chip', tx('sourceUnavailable'), 'unavailable');
+      for (const id of ['hlc-aed24', 'hlc-aed22', 'hlc-aed21', 'hlc-aed18']) {
+        mountSkeleton(document.getElementById(id), 'karat');
+      }
       setTextById('home-snapshot-status-value', tx('sourceUnavailable'));
       setTextById('home-snapshot-status-note', tx('priceUnavailableConnection'));
       showDataStatusBanner({

--- a/src/pages/invest.js
+++ b/src/pages/invest.js
@@ -1,6 +1,8 @@
-import { CONSTANTS, KARATS } from '../config/index.js';
+import { CONSTANTS, KARATS, TRANSLATIONS } from '../config/index.js';
 import * as api from '../lib/api.js';
 import * as cache from '../lib/cache.js';
+import { mountSkeleton } from '../components/skeleton.js';
+import { showDataStatusBanner, hideDataStatusBanner } from '../lib/data-status-banner.js';
 import * as calc from '../lib/price-calculator.js';
 import * as fmt from '../lib/formatter.js';
 import { updateTicker } from '../components/ticker.js';
@@ -877,12 +879,26 @@ function renderPlanner() {
   );
   document.getElementById('result-budget-note').textContent = tx('planBudgetNote');
 
-  document.getElementById('result-grams').textContent = formatWeightGrams(grams);
+  const gramsEl = document.getElementById('result-grams');
+  const ouncesEl = document.getElementById('result-ounces');
+  if (grams != null) {
+    gramsEl.textContent = formatWeightGrams(grams);
+  } else if (!state.goldPriceUsdPerOz) {
+    mountSkeleton(gramsEl, 'karat');
+  } else {
+    gramsEl.textContent = formatWeightGrams(grams);
+  }
   document.getElementById('result-grams-note').textContent = pricePerGram
     ? `${formatCurrency(pricePerGram, currency, decimals)} / g`
-    : tx('fetching');
+    : '';
 
-  document.getElementById('result-ounces').textContent = formatWeightOz(ounces);
+  if (ounces != null) {
+    ouncesEl.textContent = formatWeightOz(ounces);
+  } else if (!state.goldPriceUsdPerOz) {
+    mountSkeleton(ouncesEl, 'karat');
+  } else {
+    ouncesEl.textContent = formatWeightOz(ounces);
+  }
   document.getElementById('result-ounces-note').textContent = tx('planOuncesNote');
 
   const fourthLabel = document.getElementById('result-fourth-label');
@@ -1024,24 +1040,42 @@ function renderLiveCard() {
   const panel = document.getElementById('invest-live-panel');
   const status = getMarketStatus();
   const spot = state.goldPriceUsdPerOz;
-  const p24 = getLocalPricePerGram('24', 'AE');
-  const p22 = getLocalPricePerGram('22', 'AE');
-  const p21 = getLocalPricePerGram('21', 'AE');
+  const p24 = spot ? getLocalPricePerGram('24', 'AE') : null;
+  const p22 = spot ? getLocalPricePerGram('22', 'AE') : null;
+  const p21 = spot ? getLocalPricePerGram('21', 'AE') : null;
 
   const statusEl = document.getElementById('invest-market-status');
-  statusEl.textContent = status === 'open' ? tx('marketOpen') : tx('marketClosed');
-  statusEl.className = `invest-market-chip ${status === 'open' ? 'is-open' : 'is-closed'}`;
+  if (spot) {
+    statusEl.textContent = status === 'open' ? tx('marketOpen') : tx('marketClosed');
+    statusEl.className = `invest-market-chip ${status === 'open' ? 'is-open' : 'is-closed'}`;
+  } else {
+    mountSkeleton(statusEl, 'freshnessChip');
+  }
 
-  document.getElementById('stat-spot').textContent = formatCurrency(spot, 'USD', 2);
-  document.getElementById('stat-24').textContent = formatCurrency(p24, 'AED', 2);
-  document.getElementById('stat-22').textContent = formatCurrency(p22, 'AED', 2);
-  document.getElementById('stat-21').textContent = formatCurrency(p21, 'AED', 2);
+  const setStat = (id, value, currency, decimals) => {
+    const elNode = document.getElementById(id);
+    if (!elNode) return;
+    if (spot && value != null) {
+      elNode.textContent = formatCurrency(value, currency, decimals);
+    } else {
+      mountSkeleton(elNode, 'priceMd');
+    }
+  };
+  setStat('stat-spot', spot, 'USD', 2);
+  setStat('stat-24', p24, 'AED', 2);
+  setStat('stat-22', p22, 'AED', 2);
+  setStat('stat-21', p21, 'AED', 2);
 
-  document.getElementById('invest-updated').textContent = state.goldPriceUsdPerOz
-    ? `${tx('updated')}: ${fmt.formatTimestampShort(new Date().toISOString(), state.lang)}`
-    : tx('fetching');
+  const updatedEl = document.getElementById('invest-updated');
+  if (updatedEl) {
+    if (state.goldPriceUsdPerOz) {
+      updatedEl.textContent = `${tx('updated')}: ${fmt.formatTimestampShort(new Date().toISOString(), state.lang)}`;
+    } else {
+      mountSkeleton(updatedEl, 'freshnessStrip');
+    }
+  }
 
-  panel.removeAttribute('aria-busy');
+  if (spot) panel.removeAttribute('aria-busy');
 
   if (spot) {
     const p18 = getLocalPricePerGram('18', 'AE');
@@ -1074,18 +1108,30 @@ function applyLang() {
 async function fetchLiveData() {
   if (!navigator.onLine) return;
 
-  const [goldRes, fxRes] = await Promise.allSettled([api.fetchGold(), api.fetchFX()]);
+  const { gold, fx, errors } = await api.fetchGoldAndFX();
 
-  if (goldRes.status === 'fulfilled') {
-    state.goldPriceUsdPerOz = goldRes.value.price;
-    cache.saveGoldPrice(goldRes.value.price, goldRes.value.updatedAt);
+  if (gold?.price) {
+    state.goldPriceUsdPerOz = gold.price;
+    cache.saveGoldPrice(gold.price, gold.updatedAt);
+    hideDataStatusBanner();
   }
 
-  if (fxRes.status === 'fulfilled') {
-    state.rates = fxRes.value.rates ?? {};
+  if (fx?.rates) {
+    state.rates = fx.rates ?? {};
     cache.saveFXRates(state.rates, {
-      lastUpdateUtc: fxRes.value.time_last_update_utc,
-      nextUpdateUtc: fxRes.value.time_next_update_utc,
+      lastUpdateUtc: fx.time_last_update_utc,
+      nextUpdateUtc: fx.time_next_update_utc,
+    });
+  }
+
+  if (!state.goldPriceUsdPerOz && (errors.gold || errors.fx)) {
+    showDataStatusBanner({
+      lang: state.lang,
+      variant: 'error',
+      message:
+        TRANSLATIONS[state.lang]?.['status.noData'] ??
+        TRANSLATIONS.en['status.noData'],
+      onRetry: fetchLiveData,
     });
   }
 
@@ -1154,6 +1200,8 @@ async function init() {
 
   bindBudgetInputs();
   applyLang();
+  renderLiveCard();
+  renderPlanner();
   await fetchLiveData();
 
   if (state.timer) clearInterval(state.timer);

--- a/src/pages/tracker-pro.js
+++ b/src/pages/tracker-pro.js
@@ -1270,18 +1270,32 @@ async function refreshData(forceLive = true, includeWire = true) {
 }
 
 async function fetchLive() {
+  const tasks = [];
   if (realtimeEngine) {
-    await realtimeEngine.refreshNow('manual-refresh');
+    tasks.push(realtimeEngine.refreshNow('manual-refresh'));
   }
-
+  tasks.push(
+    api.fetchGoldAndFX().then(({ gold, fx, errors }) => {
+      if (fx?.rates) {
+        state.rates = fx.rates;
+        state.fxMeta = {
+          lastUpdateUtc: fx.time_last_update_utc,
+          nextUpdateUtc: new Date(fx.time_next_update_utc).getTime(),
+        };
+        cache.saveFXRates(state.rates, state.fxMeta);
+      }
+      if (!state.live?.price && gold?.price) {
+        state.live = {
+          price: gold.price,
+          updatedAt: gold.updatedAt || new Date().toISOString(),
+          raw: gold.raw || {},
+        };
+      }
+      if (errors.gold || errors.fx) state.hasLiveFailure = true;
+    })
+  );
   try {
-    const data = await api.fetchFX();
-    state.rates = data.rates;
-    state.fxMeta = {
-      lastUpdateUtc: data.time_last_update_utc,
-      nextUpdateUtc: new Date(data.time_next_update_utc).getTime(),
-    };
-    cache.saveFXRates(state.rates, state.fxMeta);
+    await Promise.all(tasks);
   } catch (_e) {
     console.warn('[tracker] refreshData failed', _e);
     state.hasLiveFailure = true;

--- a/src/tracker/hero.js
+++ b/src/tracker/hero.js
@@ -2,6 +2,7 @@
 import { CONSTANTS, KARATS, COUNTRIES } from '../config/index.js';
 import { _state, _el, _priceFor, _currentSpot, tx, formatUsd, formatUnitLabel } from './_ctx.js';
 import { clear, el, setText } from '../lib/safe-dom.js';
+import { mountSkeleton, skeletonNode } from '../components/skeleton.js';
 import { getMarketStatus } from '../lib/live-status.js';
 import { pulseFreshness } from '../lib/freshness-pulse.js';
 import { countUp } from '../lib/count-up.js';
@@ -116,8 +117,10 @@ export function renderHero() {
         pulseTarget: _el.xauUsdValue?.closest('.tracker-hero-price, .tracker-metric'),
       });
       pulseFreshness(_el.xauUsdValue);
-    } else {
+    } else if (_state.hasLiveFailure) {
       setText(_el.xauUsdValue, '—');
+    } else {
+      mountSkeleton(_el.xauUsdValue, 'priceLg');
     }
   }
   const xauBadge = document.getElementById('tp-xauusd-badge');
@@ -255,6 +258,16 @@ export function renderHero() {
   } else if (_el.heroStats && !spot) {
     clear(_el.heroStats);
     _el.heroStats.setAttribute('aria-busy', 'true');
+    const labels = ['XAU/USD', 'UAE 24K', 'UAE 22K', 'USD/g 24K'];
+    labels.forEach((label) => {
+      _el.heroStats.append(
+        el('div', { class: 'tracker-hero-stat tracker-hero-stat--skeleton', 'aria-hidden': 'true' }, [
+          el('div', { class: 'tracker-hero-k' }, label),
+          el('div', { class: 'tracker-hero-v' }, [skeletonNode('priceMd', { block: true })]),
+          el('div', { class: 'tracker-hero-s' }, [skeletonNode('freshnessStrip')]),
+        ])
+      );
+    });
   }
 
   if (_el.summaryList) {

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,4 +1,5 @@
 @import url('./partials/shell.css');
+@import url('./partials/skeleton.css');
 @import url('./partials/market-summary-ticker.css');
 
 /* ═══════════════════════════════════════════════

--- a/styles/partials/skeleton.css
+++ b/styles/partials/skeleton.css
@@ -1,0 +1,100 @@
+/* Skeleton size utilities — paired with .skeleton-inline in global.css */
+
+.shell-skeleton-price-md {
+  inline-size: 5.5rem;
+  block-size: 1.35em;
+}
+
+.shell-skeleton-freshness-chip {
+  inline-size: 9rem;
+  block-size: 1.25rem;
+}
+
+.shell-skeleton-freshness-strip {
+  inline-size: 12rem;
+  block-size: 0.9em;
+}
+
+.shell-skeleton-table-cell {
+  display: block;
+  inline-size: 4.5rem;
+  block-size: 1em;
+}
+
+.shell-skeleton-block {
+  display: block;
+  inline-size: 100%;
+  block-size: 4rem;
+  border-radius: var(--radius-control);
+}
+
+.skeleton-table-row td {
+  padding-block: var(--space-3);
+}
+
+/* Price fetch failure — compact empty state for hero / country mounts */
+.price-fetch-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  padding: var(--space-6) var(--space-4);
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.price-fetch-error__icon {
+  font-size: var(--text-2xl);
+  line-height: 1;
+  color: var(--color-warning, #d97706);
+}
+
+.price-fetch-error__message {
+  margin: 0;
+  max-inline-size: 22rem;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.price-fetch-error__retry {
+  margin-block-start: var(--space-1);
+}
+
+.ph-loading-skeleton {
+  padding: var(--space-6) var(--space-4);
+}
+
+.ph-karat-skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: var(--space-4);
+}
+
+.shops-skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+  gap: var(--space-4);
+  width: 100%;
+}
+
+.shops-skeleton-card {
+  min-block-size: 7rem;
+}
+
+.ph-karat-card--skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: var(--radius-control);
+  background: var(--surface-secondary);
+  border: 1px solid var(--border-subtle);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-inline {
+    animation: none;
+    background: var(--color-surface-2);
+  }
+}

--- a/tests/first-paint-skeleton.test.js
+++ b/tests/first-paint-skeleton.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.join(__dirname, '..');
+
+test('api.js exports parallel fetchGoldAndFX', async () => {
+  const src = fs.readFileSync(path.join(root, 'src/lib/api.js'), 'utf8');
+  assert.match(src, /export async function fetchGoldAndFX/);
+  assert.match(src, /Promise\.allSettled/);
+});
+
+test('skeleton component exposes mount helpers', async () => {
+  const src = fs.readFileSync(path.join(root, 'src/components/skeleton.js'), 'utf8');
+  assert.match(src, /export function mountSkeleton/);
+  assert.match(src, /shell-skeleton-price-md/);
+});
+
+test('price-fetch-error uses translation keys', async () => {
+  const src = fs.readFileSync(path.join(root, 'src/components/price-fetch-error.js'), 'utf8');
+  assert.match(src, /status\.noData/);
+  assert.match(src, /status\.retry/);
+});
+
+test('index.html avoids literal Loading freshness copy in hero', () => {
+  const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+  assert.doesNotMatch(html, /id="hlc-updated"[^>]*>Loading/);
+  assert.doesNotMatch(html, /id="karat-strip-updated"[^>]*>Loading freshness/);
+  assert.match(html, /id="hlc-updated"[\s\S]*shell-skeleton-freshness-strip/);
+});
+
+test('tracker.html hero uses skeleton placeholders instead of Connecting', () => {
+  const html = fs.readFileSync(path.join(root, 'tracker.html'), 'utf8');
+  assert.doesNotMatch(html, /tracker-hero-s">Connecting/);
+  assert.match(html, /id="tp-xauusd-value"[\s\S]*shell-skeleton-price-lg/);
+});
+
+test('country index shells use price skeletons not Loading ellipsis', () => {
+  const sample = fs.readFileSync(path.join(root, 'countries/bahrain/index.html'), 'utf8');
+  assert.doesNotMatch(sample, /cp-price-value">Loading/);
+  assert.match(sample, /shell-skeleton-price-md/);
+});

--- a/tests/home-hero-loading.test.js
+++ b/tests/home-hero-loading.test.js
@@ -18,14 +18,15 @@ test('home hero command chips expose localized status landmark hook', () => {
 test('home command chips render with loading skeleton classes', () => {
   assert.match(
     HTML,
-    /class="trust-chip skeleton-inline home-command-chip--loading"[\s\S]*id="home-command-freshness"/,
+    /class="trust-chip skeleton-inline home-command-chip--loading"[\s\S]*id="home-command-freshness"[\s\S]*aria-busy="true"/,
     'freshness chip should ship with loading skeleton class'
   );
   assert.match(
     HTML,
-    /class="trust-chip skeleton-inline home-command-chip--loading"[\s\S]*id="home-command-spot-chip"/,
+    /class="trust-chip skeleton-inline home-command-chip--loading"[\s\S]*id="home-command-spot-chip"[\s\S]*aria-busy="true"/,
     'spot chip should ship with loading skeleton class'
   );
+  assert.doesNotMatch(HTML, /id="home-command-freshness"[^>]*>Loading freshness/);
 });
 
 test('home command metric values ship with skeleton placeholders', () => {

--- a/tracker.html
+++ b/tracker.html
@@ -182,7 +182,7 @@
                 aria-atomic="true"
               >
                 <span class="tracker-badge-dot" aria-hidden="true"></span>
-                <span id="tp-live-badge-text">Preparing live feed</span>
+                <span id="tp-live-badge-text" class="skeleton-inline shell-skeleton-freshness-chip" aria-busy="true"></span>
                 <span class="tracker-badge-separator" aria-hidden="true">·</span>
                 <span id="tp-refresh-badge" role="status" aria-live="polite">Waiting for first sync</span>
               </span>
@@ -190,7 +190,7 @@
               <span class="tracker-badge tracker-badge-xauusd tracker-hero-price" id="tp-xauusd-badge" aria-label="XAU/USD spot price">
                 <span aria-hidden="true">🏅</span>
                 <span>XAU/USD</span>
-                <strong id="tp-xauusd-value">—</strong>
+                <strong id="tp-xauusd-value" class="skeleton-inline shell-skeleton-price-lg" aria-busy="true"></strong>
               </span>
               <span class="tracker-badge tracker-badge-market" id="tp-market-badge">
                 <span aria-hidden="true">📊</span>
@@ -225,23 +225,23 @@
             <div class="tracker-hero-stats" id="tp-hero-stats" aria-label="Key live metrics" aria-busy="true">
               <div class="tracker-hero-stat tracker-hero-stat--skeleton" aria-hidden="true">
                 <div class="tracker-hero-k">XAU/USD</div>
-                <div class="tracker-hero-v tracker-skeleton-pulse">—</div>
-                <div class="tracker-hero-s">Connecting…</div>
+                <div class="tracker-hero-v"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
+                <div class="tracker-hero-s"><span class="skeleton-inline shell-skeleton-freshness-strip" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="tracker-hero-stat tracker-hero-stat--skeleton" aria-hidden="true">
                 <div class="tracker-hero-k">UAE 24K</div>
-                <div class="tracker-hero-v tracker-skeleton-pulse">—</div>
-                <div class="tracker-hero-s">per gram</div>
+                <div class="tracker-hero-v"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
+                <div class="tracker-hero-s"><span class="skeleton-inline shell-skeleton-freshness-strip" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="tracker-hero-stat tracker-hero-stat--skeleton" aria-hidden="true">
                 <div class="tracker-hero-k">UAE 22K</div>
-                <div class="tracker-hero-v tracker-skeleton-pulse">—</div>
-                <div class="tracker-hero-s">per gram</div>
+                <div class="tracker-hero-v"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
+                <div class="tracker-hero-s"><span class="skeleton-inline shell-skeleton-freshness-strip" role="presentation" aria-hidden="true"></span></div>
               </div>
               <div class="tracker-hero-stat tracker-hero-stat--skeleton" aria-hidden="true">
                 <div class="tracker-hero-k">USD/g 24K</div>
-                <div class="tracker-hero-v tracker-skeleton-pulse">—</div>
-                <div class="tracker-hero-s">per gram</div>
+                <div class="tracker-hero-v"><span class="skeleton-inline shell-skeleton-price-md" role="presentation" aria-hidden="true"></span></div>
+                <div class="tracker-hero-s"><span class="skeleton-inline shell-skeleton-freshness-strip" role="presentation" aria-hidden="true"></span></div>
               </div>
             </div>
 
@@ -533,7 +533,7 @@
                 </p>
               </div>
               <div class="tracker-mobile-summary-chips">
-                <span class="trust-chip" data-tone="live" id="tp-mobile-summary-status">Preparing…</span>
+                <span class="trust-chip skeleton-inline shell-skeleton-freshness-chip" data-tone="live" id="tp-mobile-summary-status" aria-busy="true"></span>
                 <span class="trust-chip" data-tone="info" id="tp-mobile-summary-source">Source note</span>
               </div>
             </div>
@@ -541,22 +541,22 @@
             <div class="mobile-command-card__metrics">
               <div class="mobile-command-card__metric">
                 <span class="mobile-command-card__metric-label" id="tp-mobile-selected-label">Selected view</span>
-                <strong class="mobile-command-card__metric-value" id="tp-mobile-selected-value">—</strong>
+                <strong class="mobile-command-card__metric-value skeleton-inline shell-skeleton-karat" id="tp-mobile-selected-value" aria-busy="true"></strong>
                 <span class="mobile-command-card__metric-note" id="tp-mobile-selected-note">Currency, karat, and unit</span>
               </div>
               <div class="mobile-command-card__metric">
                 <span class="mobile-command-card__metric-label" id="tp-mobile-price-label">Reference price</span>
-                <strong class="mobile-command-card__metric-value" id="tp-mobile-price-value">—</strong>
+                <strong class="mobile-command-card__metric-value skeleton-inline shell-skeleton-karat" id="tp-mobile-price-value" aria-busy="true"></strong>
                 <span class="mobile-command-card__metric-note" id="tp-mobile-price-note">Spot-linked selected view</span>
               </div>
               <div class="mobile-command-card__metric">
                 <span class="mobile-command-card__metric-label" id="tp-mobile-spot-label">Global spot</span>
-                <strong class="mobile-command-card__metric-value" id="tp-mobile-spot-value">—</strong>
+                <strong class="mobile-command-card__metric-value skeleton-inline shell-skeleton-karat" id="tp-mobile-spot-value" aria-busy="true"></strong>
                 <span class="mobile-command-card__metric-note" id="tp-mobile-spot-note">XAU/USD per troy ounce</span>
               </div>
               <div class="mobile-command-card__metric">
                 <span class="mobile-command-card__metric-label" id="tp-mobile-updated-label">Freshness</span>
-                <strong class="mobile-command-card__metric-value" id="tp-mobile-updated-value">—</strong>
+                <strong class="mobile-command-card__metric-value skeleton-inline shell-skeleton-karat" id="tp-mobile-updated-value" aria-busy="true"></strong>
                 <span class="mobile-command-card__metric-note" id="tp-mobile-updated-note">Live, cached, or derived is always labeled</span>
               </div>
             </div>
@@ -723,7 +723,7 @@
               </div>
             </div>
             <p class="tracker-chart-caption" id="tp-history-caption" role="status" aria-live="polite">
-              Preparing historical explorer…
+              <span class="skeleton-inline shell-skeleton-freshness-strip" role="presentation" aria-hidden="true"></span>
             </p>
             <p class="source-note tracker-chart-source-note" id="tp-chart-source-note">
               Selected chart data may combine live, cached, and baseline points. Freshness remains


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Session 1 / Phase 1 of the [UI/UX audit remediation program](docs/plans/2026-06-01_ui-ux-audit-remediation-program.md): eliminate the “broken dev site” first paint on price surfaces.

- Reusable skeleton utilities (`src/components/skeleton.js`, `styles/partials/skeleton.css`)
- Price fetch failure empty state with retry (`src/components/price-fetch-error.js`)
- `api.fetchGoldAndFX()` for parallel gold + FX (no waterfall)
- `cache.getCachedPriceSnapshot()` + cache-first hydration in `page-hydrator.js`, `home.js`, `invest.js`, `country-page.js`
- HTML/JS updates on `index.html`, `tracker.html`, `shops.html`, `invest.html`, and country index shells (skeletons instead of `Loading…` / bare `—`)

## Why

Users and crawlers were seeing literal loading copy and em dashes before ES modules fetched prices. That reads as unfinished even when the pipeline is healthy. Cache-first paint plus sized skeletons keeps trust labels honest while data loads.

## How

- Skeleton shimmer reuses existing `.skeleton-inline` tokens; new size utilities match hero cards, karat cells, and freshness chips.
- Pages call `cache.loadState` / `getFallbackGoldPrice` before `fetchGoldAndFX`, then refresh from network.
- Legacy country/city hydrator renders cached prices immediately, shows skeleton grid while fetching, and `renderPriceFetchError` + retry when network and cache both fail.
- Tracker `fetchLive` runs realtime refresh and `fetchGoldAndFX` in parallel.

## Proof

| Check | Result |
| ----- | ------ |
| `npm test` | **1008 pass / 2 fail** — failures are pre-existing (`audit-content-pages`, `insights-feed-core` parse); **9/9** new/updated first-paint tests pass |
| `npm run lint` | **2 pre-existing errors** in `src/pages/insights.js` (duplicate identifier); no new errors in touched Phase 1 files |
| `npm run validate` | `validate-build.js` **pass**; full chain stops on **pre-existing** unsafe-DOM baseline drift in unrelated files |
| `npm run build` | **Fails on `main`** too (`insights.js` parse) — not introduced by this PR |

Manual (recommended before merge): 360px LTR + RTL on home/tracker; throttled network; offline after cache warm — confirm cached numbers or skeletons, then live refresh with freshness labels intact.

## Risks

- Country hero still uses `innerHTML` in `country-page.js` (pre-existing); skeleton markup is static and escaped.
- Service worker cache versioning unchanged; freshness labels remain on all rendered prices.
- Did **not** touch production workflows, `sw.js`, `constants.js`, or `data/gold_price.json`.

Docs: Phase 1 checkboxes + session log updated in program doc; registry row set to open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d80d104-7817-49bd-8d36-20199231f3bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d80d104-7817-49bd-8d36-20199231f3bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

