### PR TITLE
fix: home.js parse error blocking GitHub Pages deploy

### DIFF
--- a/scripts/node/validate-build.js
+++ b/scripts/node/validate-build.js
@@ -243,9 +243,14 @@ function walkJs(dir) {
 }
 
 const srcJsFiles = walkJs(path.join(ROOT, 'src'));
+const tmpModuleCheckFile = path.join(ROOT, '.tmp-validate-build-syntax-check.mjs');
 let syntaxIssues = 0;
 for (const jsFile of srcJsFiles) {
-  const result = spawnSync(process.execPath, ['--check', jsFile], {
+  const fileToCheck = jsFile.endsWith('.mjs') ? jsFile : tmpModuleCheckFile;
+  if (fileToCheck === tmpModuleCheckFile) {
+    fs.writeFileSync(tmpModuleCheckFile, fs.readFileSync(jsFile, 'utf8'), 'utf8');
+  }
+  const result = spawnSync(process.execPath, ['--check', fileToCheck], {
     encoding: 'utf8',
   });
   if (result.status !== 0) {
@@ -255,6 +260,7 @@ for (const jsFile of srcJsFiles) {
     syntaxIssues++;
   }
 }
+if (fs.existsSync(tmpModuleCheckFile)) fs.unlinkSync(tmpModuleCheckFile);
 if (syntaxIssues === 0) ok(`Checked ${srcJsFiles.length} src JS files — valid syntax`);
 
 // ── 5. Duplicate consecutive lines in page modules (merge-artifact guard) ───

--- a/scripts/node/validate-build.js
+++ b/scripts/node/validate-build.js
@@ -271,9 +271,8 @@ const DUPLICATE_LINE_MIN = 24;
 let duplicateLineIssues = 0;
 const pagesDir = path.join(ROOT, 'src/pages');
 if (fs.existsSync(pagesDir)) {
-  for (const entry of fs.readdirSync(pagesDir)) {
-    if (!entry.endsWith('.js')) continue;
-    const filePath = path.join(pagesDir, entry);
+  for (const filePath of walkJs(pagesDir)) {
+    if (!filePath.endsWith('.js')) continue;
     const lines = fs.readFileSync(filePath, 'utf8').split('\n');
     for (let i = 1; i < lines.length; i++) {
       const prev = lines[i - 1].trim();

--- a/scripts/node/validate-build.js
+++ b/scripts/node/validate-build.js
@@ -10,6 +10,8 @@
  *   1. Required static files exist (sw.js, robots.txt, etc.)
  *   2. No `await` inside non-async functions in HTML inline scripts
  *   3. Critical JS module imports resolve to existing files
+ *   4. All src JS modules pass node --check (parse errors before Vite)
+ *   5. No duplicate consecutive source lines in src/pages (merge-artifact guard)
  *
  * Exit code 0 = all checks pass, 1 = issues found.
  */
@@ -18,6 +20,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const ROOT = path.resolve(__dirname, '../..');
 let errors = 0;
@@ -219,6 +222,71 @@ for (const d of CRITICAL_DIRS) {
   }
 }
 if (importIssues === 0) ok('All critical JS imports resolve');
+
+// ── 4. JS syntax (node --check) — catches merge dupes / parse errors early ─
+
+console.log('\n\uD83D\uDD0D Checking src/**/*.js syntax (node --check)\u2026');
+
+function walkJs(dir) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+  for (const entry of fs.readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const stat = fs.statSync(full);
+    if (stat.isDirectory()) {
+      results.push(...walkJs(full));
+    } else if (entry.endsWith('.js') || entry.endsWith('.mjs')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const srcJsFiles = walkJs(path.join(ROOT, 'src'));
+let syntaxIssues = 0;
+for (const jsFile of srcJsFiles) {
+  const result = spawnSync(process.execPath, ['--check', jsFile], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    const rel = path.relative(ROOT, jsFile);
+    const detail = (result.stderr || result.stdout || '').trim().split('\n')[0];
+    error(`${rel}: syntax error${detail ? ` — ${detail}` : ''}`);
+    syntaxIssues++;
+  }
+}
+if (syntaxIssues === 0) ok(`Checked ${srcJsFiles.length} src JS files — valid syntax`);
+
+// ── 5. Duplicate consecutive lines in page modules (merge-artifact guard) ───
+
+console.log('\n\uD83D\uDD0D Checking src/pages for duplicate consecutive lines\u2026');
+
+const DUPLICATE_LINE_MIN = 24;
+let duplicateLineIssues = 0;
+const pagesDir = path.join(ROOT, 'src/pages');
+if (fs.existsSync(pagesDir)) {
+  for (const entry of fs.readdirSync(pagesDir)) {
+    if (!entry.endsWith('.js')) continue;
+    const filePath = path.join(pagesDir, entry);
+    const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+    for (let i = 1; i < lines.length; i++) {
+      const prev = lines[i - 1].trim();
+      const curr = lines[i].trim();
+      if (
+        prev.length >= DUPLICATE_LINE_MIN &&
+        prev === curr &&
+        !prev.startsWith('//') &&
+        !prev.startsWith('*')
+      ) {
+        error(
+          `${path.relative(ROOT, filePath)}:${i + 1} — duplicate consecutive line (likely merge artifact): "${curr.slice(0, 72)}${curr.length > 72 ? '\u2026' : ''}"`
+        );
+        duplicateLineIssues++;
+      }
+    }
+  }
+}
+if (duplicateLineIssues === 0) ok('No duplicate consecutive lines in src/pages');
 
 // ── Summary ─────────────────────────────────────────────────────────────────
 

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -656,7 +656,6 @@ function syncTrackerLinks(overrides = {}) {
 
 function initKaratStripTrackerHandoff() {
   document.querySelectorAll('.karat-strip-item').forEach((item) => {
-  document.querySelectorAll('.karat-strip-item').forEach((item) => {
     item.setAttribute('role', 'link');
     item.setAttribute('tabindex', '0');
     const karat = karatFromKstripItem(item);
@@ -676,8 +675,6 @@ function initKaratStripTrackerHandoff() {
         e.preventDefault();
         go();
       }
-    });
-  });
     });
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Removed a duplicate `forEach` and extra `});` in `initKaratStripTrackerHandoff()` in `src/pages/home.js` (merge artifact from PR #396).
- Extended `scripts/node/validate-build.js` with:
  - `node --check` over all `src/**/*.js` (156 files) so parse errors fail `npm run validate` before Vite.
  - Duplicate consecutive-line detection in `src/pages` to catch similar merge artifacts early.

## Why
Deploy workflow #501 failed at `npm run build` with `[PARSE_ERROR] Unexpected token` at `src/pages/home.js:682` — `validate` passed because it did not parse JS modules.

## How
Single `forEach` restored in `initKaratStripTrackerHandoff`; validation gate runs on every `npm run validate` (CI + `deploy.yml` pre-build step).

## Proof
- `npm run validate` — pass (includes new syntax + duplicate-line checks)
- `NODE_ENV=production npm run build` — pass

## Risks
Low. Duplicate-line rule only scans `src/pages` and ignores comment lines; threshold is 24+ char identical consecutive lines.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4d72c12-018e-48df-aafb-2ff0f36961cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4d72c12-018e-48df-aafb-2ff0f36961cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

