### PR TITLE
fix: repair home.js parse error after PR #399 merge (CodeQL + deploy)

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -46,6 +46,7 @@ import { enforceCanonicalOnDocument } from '../seo/canonical.js';
 import { enforceHreflangAlternates } from '../seo/hreflang.js';
 import { buildMethodologyFaqSchema, injectFaqSchema } from '../seo/faq-schema.js';
 import { buildHomeTrackerHref } from '../lib/cross-page-links.js';
+import { applyTrackerHandoffToIds, HOME_DEFAULT_TRACKER_LINK_IDS } from '../lib/page-handoff.js';
 import { serializeCalculatorUrlState } from './calculator/url-state.js';
 
 // ── Constants ──────────────────────────────────────────────────────────────
@@ -390,7 +391,11 @@ function renderHeroCard() {
   const ageClass = freshnessAgeClass(getLiveFreshness({ updatedAt: goldUpdatedAt, lang }).ageMs);
   const hlcUpdatedEl = document.getElementById('hlc-updated');
   if (hlcUpdatedEl) {
-    hlcUpdatedEl.classList.remove('skeleton-text', 'skeleton-inline', 'shell-skeleton-freshness-strip');
+    hlcUpdatedEl.classList.remove(
+      'skeleton-text',
+      'skeleton-inline',
+      'shell-skeleton-freshness-strip'
+    );
     hlcUpdatedEl.removeAttribute('aria-busy');
     hlcUpdatedEl.textContent = `${txGlobal('freshness.statusLabel')}: ${statusText} · ${tx('source')}: ${sourceText} · ${tx('updated')}: ${ageText}`;
     hlcUpdatedEl.dataset.freshnessKey = key;
@@ -704,42 +709,12 @@ function renderGCCGrid() {
 function syncCrossPageLinks() {
   const unit = karatStripUnit === 'tola' ? 'tola' : karatStripUnit === 'oz' ? 'oz' : 'gram';
   const trackerHref = buildHomeTrackerHref(homeTrackerKarat, unit, lang);
-  for (const id of ['hero-cta-tracker', 'hlc-tracker-link', 'karat-strip-cta']) {
-    const node = document.getElementById(id);
-    if (node) node.setAttribute('href', trackerHref);
-  }
+  applyTrackerHandoffToIds(trackerHref, HOME_DEFAULT_TRACKER_LINK_IDS);
   const calcHref = buildCalculatorHref();
   for (const id of ['hero-cta-calculator', 'home-action-calc']) {
     const node = document.getElementById(id);
     if (node) node.setAttribute('href', calcHref);
   }
-function syncTrackerLinks(overrides = {}) {
-  applyTrackerHandoffToIds(buildTrackerHref(overrides));
-}
-
-function initKaratStripTrackerHandoff() {
-  document.querySelectorAll('.karat-strip-item').forEach((item) => {
-    item.setAttribute('role', 'link');
-    item.setAttribute('tabindex', '0');
-    const karat = karatFromKstripItem(item);
-    const go = () => {
-      if (!karat) return;
-      const href = buildTrackerHref({ k: karat });
-      track(EVENTS.TRACKER_VIEW, { surface: 'home_karat_strip', karat, currency: 'AED' });
-      window.location.assign(href);
-    };
-    item.addEventListener('click', (e) => {
-      if (e.target.closest('.kstrip-copy-btn')) return;
-      go();
-    });
-    item.addEventListener('keydown', (e) => {
-      if (e.target.closest('.kstrip-copy-btn')) return;
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        go();
-      }
-    });
-  });
 }
 
 // ── Apply full page language ───────────────────────────────────────────────
@@ -1243,8 +1218,6 @@ async function init() {
       }, 1500);
     }
   });
-
-  initKaratStripTrackerHandoff();
 
   // Karat strip unit toggle
   document.querySelectorAll('.kstrip-unit-btn').forEach((btn) => {

--- a/tests/page-handoff.test.js
+++ b/tests/page-handoff.test.js
@@ -1,13 +1,17 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import {
-  buildTrackerHandoffUrl,
-  buildShopsHandoffUrl,
-  karatFromKstripItem,
-  HOME_DEFAULT_TRACKER_LINK_IDS,
-} from '../src/lib/page-handoff.js';
+'use strict';
 
-test('buildTrackerHandoffUrl encodes live mode hash with karat and unit', () => {
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+async function loadModule() {
+  const url = pathToFileURL(path.resolve(__dirname, '..', 'src', 'lib', 'page-handoff.js'));
+  return import(url.href);
+}
+
+test('buildTrackerHandoffUrl encodes live mode hash with karat and unit', async () => {
+  const { buildTrackerHandoffUrl } = await loadModule();
   const href = buildTrackerHandoffUrl({
     mode: 'live',
     cur: 'AED',
@@ -19,14 +23,16 @@ test('buildTrackerHandoffUrl encodes live mode hash with karat and unit', () => 
   assert.equal(href, 'tracker.html#mode=live&cur=AED&k=22&u=tola&lang=ar&r=30D');
 });
 
-test('buildTrackerHandoffUrl rejects invalid mode and karat', () => {
+test('buildTrackerHandoffUrl rejects invalid mode and karat', async () => {
+  const { buildTrackerHandoffUrl } = await loadModule();
   const href = buildTrackerHandoffUrl({ mode: 'bogus', k: '99', u: 'stone' });
   assert.ok(href.startsWith('tracker.html#mode=live'));
   assert.ok(!href.includes('k=99'));
   assert.ok(!href.includes('u=stone'));
 });
 
-test('buildShopsHandoffUrl passes country and lang query params', () => {
+test('buildShopsHandoffUrl passes country and lang query params', async () => {
+  const { buildShopsHandoffUrl } = await loadModule();
   assert.equal(
     buildShopsHandoffUrl({ countryCode: 'ae', lang: 'en' }),
     'shops.html?country=AE&lang=en'
@@ -34,13 +40,15 @@ test('buildShopsHandoffUrl passes country and lang query params', () => {
   assert.equal(buildShopsHandoffUrl(), 'shops.html');
 });
 
-test('karatFromKstripItem parses strip item ids', () => {
+test('karatFromKstripItem parses strip item ids', async () => {
+  const { karatFromKstripItem } = await loadModule();
   assert.equal(karatFromKstripItem({ id: 'kstrip-22' }), '22');
   assert.equal(karatFromKstripItem({ id: 'kstrip-24' }), '24');
   assert.equal(karatFromKstripItem({ id: 'other' }), null);
 });
 
-test('HOME_DEFAULT_TRACKER_LINK_IDS includes action rail and markets CTA', () => {
+test('HOME_DEFAULT_TRACKER_LINK_IDS includes action rail and markets CTA', async () => {
+  const { HOME_DEFAULT_TRACKER_LINK_IDS } = await loadModule();
   assert.ok(HOME_DEFAULT_TRACKER_LINK_IDS.includes('home-action-track'));
   assert.ok(HOME_DEFAULT_TRACKER_LINK_IDS.includes('markets-see-tracker'));
   assert.ok(HOME_DEFAULT_TRACKER_LINK_IDS.includes('home-tool-tracker'));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Close `syncCrossPageLinks()` in `src/pages/home.js` and remove merge-corrupted `syncTrackerLinks` / `initKaratStripTrackerHandoff` stubs that referenced undefined symbols.
- Wire tracker CTAs through `buildHomeTrackerHref` + `applyTrackerHandoffToIds` (`HOME_DEFAULT_TRACKER_LINK_IDS`) so action rail, markets, and tool links inherit the selected karat/unit/lang.
- Convert `tests/page-handoff.test.js` to the repo's CommonJS `node:test` pattern (dynamic `import()`), fixing a load failure introduced with WB-102.

## Why
PR #399 (WB-102 cross-page deep links) merged on top of PR #401 and left `home.js` with an unclosed `syncCrossPageLinks()` block. That caused:
- CodeQL JavaScript parse warning ("Unexpected token")
- `npm run validate` / Deploy to GitHub Pages failure on `main` (`Unexpected end of input` at EOF)

## How
Restore the intended WB-102 structure from the PR branch: `bindKaratStripSelection` for karat pickers, `syncCrossPageLinks` for href sync, no duplicate tracker-navigation handlers.

## Proof
- `node --check src/pages/home.js` — pass
- `npm run validate` — pass (includes `node --check` over all `src/**/*.js`)
- `NODE_ENV=production npm run build` — pass
- `npm test` — pass (1067 tests; `page-handoff.test.js` now loads under CJS runner)

## Risks
Low. Karat strip items remain selection buttons (not direct navigation links), matching WB-102; tracker navigation uses CTAs and `karat-strip-cta` with synced hash state.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53b92848-0182-407c-9547-239ec58a100d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53b92848-0182-407c-9547-239ec58a100d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

