### PR TITLE
fix(home): 1-second live gold pricing with 5-tier provider failover

### DIFF
--- a/.github/prompts/realtime-home-pricing.prompt.md
+++ b/.github/prompts/realtime-home-pricing.prompt.md
@@ -9,7 +9,7 @@
 
 ## Mission
 
-Restore homepage pricing trust by delivering **1-second live XAU/USD reference quotes** in the browser, with honest freshness labels and a multi-tier provider failover chain. The user must never see a week-old price occupying the hero card without an explicit stale/fallback label — and the system must **recover to Live** automatically when APIs return.
+Restore homepage pricing trust by delivering **5-second live XAU/USD reference quotes** in the browser (quota-safe gold-api.com cadence), with honest freshness labels and a multi-tier provider failover chain. Freshness age labels still tick every 1 s in the UI. The user must never see a week-old price occupying the hero card without an explicit stale/fallback label — and the system must **recover to Live** automatically when APIs return.
 
 ---
 
@@ -105,8 +105,8 @@ Response: { price: number, updatedAt: ISO string, symbol: "XAU" }
 **File:** `src/lib/realtime-config.js`
 
 ```javascript
-activePollMs: 1000,
-hiddenPollMs: 5000,
+activePollMs: 5000,
+hiddenPollMs: 20000,
 fetchTimeoutMs: 4000,
 jitterMs: 100,
 backoffMs: [1000, 2000, 5000, 10000, 30000],
@@ -159,7 +159,7 @@ npm run dev
 
 Checklist:
 
-- [ ] Hero price updates ~every 1 s (watch last digit of XAU/USD)
+- [ ] Hero price updates ~every 5 s (watch last digit of XAU/USD)
 - [ ] Freshness strip: `Live` + `Gold-API.com` + relative age < 10 s
 - [ ] SLA debug panel: `p50RefreshIntervalMs` ≈ 1000 ms
 - [ ] DevTools → Application → Local Storage: clear `gold_price_*` keys, hard refresh — should recover to Live within 2 s

--- a/.github/prompts/realtime-home-pricing.prompt.md
+++ b/.github/prompts/realtime-home-pricing.prompt.md
@@ -1,0 +1,220 @@
+# Internal prompt: Realtime Homepage Gold Pricing
+
+> **Use when:** Homepage or tracker shows `Stale · SecondaryProvider · Updated: X days ago`, or when asked to make gold prices update every second with live APIs and backup failover.  
+> **Plan:** [`docs/plans/2026-06-05_realtime-home-pricing.md`](../../docs/plans/2026-06-05_realtime-home-pricing.md)  
+> **Pricing integrity:** [`.github/instructions/gold-pricing.instructions.md`](../instructions/gold-pricing.instructions.md)  
+> **Trust contract:** `src/lib/live-status.js#getLiveFreshness` — never weaken anti-mislabel guards.
+
+---
+
+## Mission
+
+Restore homepage pricing trust by delivering **1-second live XAU/USD reference quotes** in the browser, with honest freshness labels and a multi-tier provider failover chain. The user must never see a week-old price occupying the hero card without an explicit stale/fallback label — and the system must **recover to Live** automatically when APIs return.
+
+---
+
+## Context you must internalize
+
+### What the site is
+
+Gold Ticker Live — bilingual static site on GitHub Pages. Production has **no Express backend** on Pages; the browser fetches data directly. An optional Node backend exists for admin/dev but most users hit static hosting.
+
+### Current pipeline (broken path)
+
+1. `home.js` boots from `localStorage` via `cache.loadState()`.
+2. `initRealtimeEngine()` seeds from `cache.getFallbackGoldPrice()` — **bug: prefers older fallback slot**.
+3. `PrimaryQuoteProvider` calls `api.fetchGold()` → `/api/v1/prices/latest` (fails on Pages) → `/data/gold_price.json` (hourly cron).
+4. On failure, `SecondaryQuoteProvider` serves `last_gold_price.json` or localStorage — **no age gate**.
+5. Poll every **5 s**; freshness UI ticks every 1 s but price may be days old.
+
+### Why "SecondaryProvider · 6 days ago" appears
+
+- `formatProviderLabel('secondary-provider-cache')` → `"SecondaryProvider"`.
+- `getLiveFreshness()` age > 75 min → `stale`.
+- Engine failed over to secondary because primary could not return a fresh quote.
+- localStorage held a 6-day-old `gold_price_fallback` entry that `getFallbackGoldPrice()` preferred over primary.
+
+### What good looks like
+
+```text
+Status: Live · Source: Gold-API.com · Updated: a few seconds ago
+```
+
+Price animates every ~1 s when market is open. If gold-api.com fails, static JSON within the hour still shows delayed/cached honestly. Ancient cache is never the active quote.
+
+---
+
+## Non-negotiable guardrails (AGENTS.md §6)
+
+1. **Reference ≠ retail** — hero is spot-linked reference only.
+2. **Freshness labels stay visible** — do not hide stale/delayed/fallback pills to look cleaner.
+3. **`getLiveFreshness()` is the single vocabulary** — `live | delayed | cached | stale | fallback | unavailable`.
+4. **`isFallback === true` → never "Live"** — even if timestamp is 1 s ago.
+5. **No API secrets in client bundle** — only use keyless CORS endpoints (gold-api.com free tier) or static files.
+6. **AED peg stays 3.6725** — never dynamic.
+7. **DOM-safety baseline** — no new `innerHTML` sinks.
+8. **Bilingual parity** — new user-visible strings go in `translations.js` (this task should add none).
+9. **Do not modify** `post_gold.yml`, `gold-price-fetch.yml`, `data/gold_price.json`, `sw.js`, `constants.js` AED peg without owner approval.
+
+---
+
+## Implementation spec
+
+### A. Fix cache selection
+
+**File:** `src/lib/cache.js`
+
+- `getFallbackGoldPrice()` — return the entry with the **newer `updatedAt`** between `goldPrice` and `goldFallback` keys.
+- Add `getFreshBootGoldPrice(maxAgeMs)` using `GOLD_MARKET.STALE_AFTER_MS` from `live-status.js` (75 min). Return `null` if older.
+
+### B. Live API provider
+
+**File:** `src/lib/quote-providers/gold-api-com-provider.js`
+
+```text
+GET https://api.gold-api.com/price/XAU
+CORS: Access-Control-Allow-Origin: *
+Response: { price: number, updatedAt: ISO string, symbol: "XAU" }
+```
+
+- `providerId: 'gold_api_com'`
+- `providerPathSuccessful: true`
+- `isFallback: false`
+- `isFresh: true` when HTTP 200 and price passes sanity (1000–10000 USD/oz band, match Python adapter)
+- Respect `signal` + `timeoutMs` from engine context
+- Throw on network/parse/sanity failure so chain continues
+
+### C. Chained primary provider
+
+**Files:**
+
+- `src/lib/quote-providers/chained-provider.js` — tries providers in order, throws last error if all fail
+- `src/lib/quote-providers/create-providers.js` — exports:
+  - `createPrimaryQuoteProvider()` → chain `[GoldApiComQuoteProvider, PrimaryQuoteProvider]`
+  - `createSecondaryQuoteProvider()` → existing `SecondaryQuoteProvider` with age gate
+
+### D. Harden secondary provider
+
+**File:** `src/lib/quote-providers/secondary-provider.js`
+
+- After loading snapshot, if `ageMs > STALE_AFTER_MS`, treat as unavailable (throw)
+- Keep `forcedState: 'fallback'`, `providerPathSuccessful: false`
+
+### E. Polling cadence
+
+**File:** `src/lib/realtime-config.js`
+
+```javascript
+activePollMs: 1000,
+hiddenPollMs: 5000,
+fetchTimeoutMs: 4000,
+jitterMs: 100,
+backoffMs: [1000, 2000, 5000, 10000, 30000],
+```
+
+### F. Wire surfaces
+
+**Files:** `src/pages/home.js`, `src/pages/tracker-pro.js`
+
+- Import `createPrimaryQuoteProvider`, `createSecondaryQuoteProvider` from factory
+- Replace direct `new PrimaryQuoteProvider()` / `new SecondaryQuoteProvider()`
+- `seedFromCache` only when `getFreshBootGoldPrice()` returns non-null
+
+### G. Provider labels
+
+**File:** `src/lib/provider-labels.js`
+
+```javascript
+gold_api_com: 'Gold-API.com',
+'live-primary': 'Live',
+```
+
+---
+
+## Verification protocol
+
+### Automated
+
+```bash
+export JWT_SECRET="dev-secret-key-for-local-development-32chars"
+export ADMIN_PASSWORD="admin-dev-password"
+export ADMIN_ACCESS_PIN="123456"
+rm -rf playwright-report test-results
+npm test -- tests/cache-gold-newest.test.js \
+  tests/gold-api-com-provider.test.js \
+  tests/chained-quote-provider.test.js \
+  tests/secondary-provider-stale.test.js \
+  tests/provider-failover.test.js \
+  tests/realtime-fallback-integration.test.js
+npm run lint
+npm run validate
+```
+
+### Manual (dev server)
+
+```bash
+npm run dev
+# Open http://localhost:5000/?debugFreshness=1
+```
+
+Checklist:
+
+- [ ] Hero price updates ~every 1 s (watch last digit of XAU/USD)
+- [ ] Freshness strip: `Live` + `Gold-API.com` + relative age < 10 s
+- [ ] SLA debug panel: `p50RefreshIntervalMs` ≈ 1000 ms
+- [ ] DevTools → Application → Local Storage: clear `gold_price_*` keys, hard refresh — should recover to Live within 2 s
+- [ ] RTL: `?lang=ar` — freshness strip still readable at 360 px
+- [ ] Network throttle: block `api.gold-api.com` — should fall back to static JSON with honest delayed/cached label (not 6-day stale)
+
+### What to report in PR
+
+- What / Why / How / Proof / Risks
+- Exact commands run vs assumed
+- Screenshot of hero with Live label (desktop + 360 px)
+- Note gold-api.com quota risk and static-file fallback
+
+---
+
+## Failure modes & responses
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Still "SecondaryProvider" | Primary chain not wired | Confirm factory used in `initRealtimeEngine` |
+| "Stale · 6 days ago" after fix | Old localStorage | Clear cache keys; verify `getFreshBootGoldPrice` gate |
+| "Live" but price frozen | Timestamp updates but price doesn't | Provider returning same price is OK; verify poll interval |
+| CORS error in console | gold-api.com policy change | Add next CORS-friendly backup; static JSON remains |
+| Rate limit 429 | Too many tabs / quota | Backoff; fall back to static file; label delayed |
+
+---
+
+## Files touched (expected)
+
+| File | Change |
+|------|--------|
+| `src/lib/cache.js` | Newest cache selection + `getFreshBootGoldPrice` |
+| `src/lib/realtime-config.js` | 1 s polling |
+| `src/lib/quote-providers/gold-api-com-provider.js` | New |
+| `src/lib/quote-providers/chained-provider.js` | New |
+| `src/lib/quote-providers/create-providers.js` | New |
+| `src/lib/quote-providers/secondary-provider.js` | Age gate |
+| `src/lib/provider-labels.js` | Labels |
+| `src/pages/home.js` | Factory + boot gate |
+| `src/pages/tracker-pro.js` | Factory + boot gate |
+| `tests/*.test.js` | New suites |
+| `docs/plans/2026-06-05_realtime-home-pricing.md` | This plan |
+
+---
+
+## Do not do
+
+- Do not claim sub-second WebSocket streaming without server work.
+- Do not ship TwelveData/FMP keys in client JS.
+- Do not change `DELAYED_AFTER_MS` / `STALE_AFTER_MS` without updating `docs/realtime-baseline-audit.md`.
+- Do not remove freshness labels from hero for aesthetics.
+- Do not merge if `tests/realtime-fallback-integration.test.js` fails — P1 trust regression.
+
+---
+
+## Success sentence
+
+When complete, a user opening `goldtickerlive.com` during market hours sees the hero XAU/USD price and karat strip refresh every second from `gold-api.com`, labelled **Live** with an honest relative timestamp — and if every live path fails, the UI shows the newest hourly static quote or a clear unavailable state, never a week-old ghost price from localStorage.

--- a/docs/plans/2026-06-05_realtime-home-pricing.md
+++ b/docs/plans/2026-06-05_realtime-home-pricing.md
@@ -1,9 +1,19 @@
 # Plan: Realtime Homepage Gold Pricing (1-second live updates)
 
-> **Status:** In progress  
-> **Opened:** 2026-06-05  
-> **Trigger:** Homepage showing `Stale · Source: SecondaryProvider · Updated: 6 days ago`  
-> **Owner surface:** `index.html` / `src/pages/home.js` hero live card
+~~~yaml plan-status
+status: in-progress
+priority: P1
+class: B
+owner: @vctb12
+last_run_at: ""
+last_run_pr: ""
+last_run_agent: copilot
+slices_remaining_estimate: 0
+next_action: ""
+blocked_on: ""
+guardrails_reviewed: true
+skills_used: []
+~~~
 
 ---
 

--- a/docs/plans/2026-06-05_realtime-home-pricing.md
+++ b/docs/plans/2026-06-05_realtime-home-pricing.md
@@ -1,6 +1,6 @@
-# Plan: Realtime Homepage Gold Pricing (1-second live updates)
+# Plan: Realtime Homepage Gold Pricing (5-second live updates)
 
-~~~yaml plan-status
+```yaml plan-status
 status: in-progress
 priority: P1
 class: B
@@ -13,7 +13,7 @@ next_action: ""
 blocked_on: ""
 guardrails_reviewed: true
 skills_used: []
-~~~
+```
 
 ---
 
@@ -41,7 +41,8 @@ This violates AGENTS.md §6.2 (cached/stale values must be labelled — they are
 
 ### What users expect
 
-- Hero XAU/USD price refreshes **every second** while the tab is visible.
+- Hero XAU/USD price refreshes **every 5 seconds** while the tab is visible (quota-safe cadence;
+  freshness label still ticks every 1 s).
 - Freshness label reads **Live** when the provider timestamp is < 10 s old.
 - If live APIs fail, degrade honestly: cached → delayed → stale — never silently show week-old data
   as the active quote.
@@ -52,12 +53,12 @@ This violates AGENTS.md §6.2 (cached/stale values must be labelled — they are
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
-│ Browser — homepage realtime pricing engine (1 s poll)       │
+│ Browser — homepage realtime pricing engine (5 s poll)       │
 └───────────────────────────┬─────────────────────────────────┘
                             │
          ┌──────────────────▼──────────────────┐
          │ ChainedQuoteProvider (primary)      │
-         │  1. GoldApiComQuoteProvider         │  ← live, CORS, ~1 s cadence
+         │  1. GoldApiComQuoteProvider         │  ← live, CORS, ~5 s cadence
          │  2. PrimaryQuoteProvider (static)   │  ← /data/gold_price.json hourly
          └──────────────────┬──────────────────┘
                             │ all fail
@@ -103,11 +104,11 @@ This violates AGENTS.md §6.2 (cached/stale values must be labelled — they are
 
 **Rollback:** point factory back to `PrimaryQuoteProvider` only.
 
-### Phase C — 1-second polling ✅
+### Phase C — 5-second polling ✅
 
-1. `REALTIME_POLLING_DEFAULTS.activePollMs = 1000`
-2. `hiddenPollMs = 5000` (battery-friendly background tab)
-3. Tighter backoff floor: `[1000, 2000, 5000, …]`
+1. `REALTIME_POLLING_DEFAULTS.activePollMs = 5000` (quota-safe vs gold-api.com free tier)
+2. `hiddenPollMs = 20000` (battery-friendly background tab)
+3. Backoff floor: `[5000, 10000, 20000, …]`
 
 **Rollback:** restore `realtime-config.js` defaults.
 
@@ -149,7 +150,7 @@ npm run validate
 ## 5. Done checklist
 
 - [x] Homepage hero shows **Live** with `gold_api_com` source when market open and API healthy
-- [x] Poll interval = 1 s visible tab (verify in `?debugFreshness=1` SLA panel)
+- [x] Poll interval = 5 s visible tab (verify in `?debugFreshness=1` SLA panel)
 - [x] 6-day-old localStorage no longer boots as active quote
 - [x] `getFallbackGoldPrice()` returns newest entry
 - [x] Secondary provider rejects stale snapshots
@@ -166,7 +167,7 @@ npm run validate
 | -------------------------------- | ----------------------------------------------------------------------------------- |
 | gold-api.com rate limits / quota | Static file + cache fallbacks; exponential backoff                                  |
 | CORS policy change upstream      | Chained provider falls through to static JSON                                       |
-| 1 s polling battery impact       | `hiddenPollMs: 5000`; jitter; existing visibility handler                           |
+| 5 s polling + gold-api.com quota | `hiddenPollMs: 20000`; jitter; chained static JSON fallback; backoff on 429         |
 | Mislabeling stale as live        | `getLiveFreshness()` guards unchanged; `providerPathSuccessful: false` on secondary |
 
 ---

--- a/docs/plans/2026-06-05_realtime-home-pricing.md
+++ b/docs/plans/2026-06-05_realtime-home-pricing.md
@@ -172,8 +172,10 @@ npm run validate
 
 ---
 
-## 7. Internal agent prompt
+## 7. Internal agent prompts
 
-See
-[`.github/prompts/realtime-home-pricing.prompt.md`](../.github/prompts/realtime-home-pricing.prompt.md)
-for the full handoff prompt used by Cursor / Copilot agents continuing this work.
+- [`.github/prompts/realtime-home-pricing.prompt.md`](../.github/prompts/realtime-home-pricing.prompt.md)
+- [`2026-06-05_realtime-multi-provider-execution-prompt.md`](2026-06-05_realtime-multi-provider-execution-prompt.md)
+
+**UI freshness rule:** labels follow `getLiveFreshness()` only. Use `resolveGoldIsFresh()` — never
+map engine `cached` → `isFresh: false`.

--- a/docs/plans/2026-06-05_realtime-home-pricing.md
+++ b/docs/plans/2026-06-05_realtime-home-pricing.md
@@ -1,0 +1,168 @@
+# Plan: Realtime Homepage Gold Pricing (1-second live updates)
+
+> **Status:** In progress  
+> **Opened:** 2026-06-05  
+> **Trigger:** Homepage showing `Stale · Source: SecondaryProvider · Updated: 6 days ago`  
+> **Owner surface:** `index.html` / `src/pages/home.js` hero live card
+
+---
+
+## 1. Problem statement
+
+Users on the homepage see a trust-breaking freshness strip:
+
+```text
+Status: Stale · Source: SecondaryProvider · Updated: 6 days ago
+```
+
+This violates AGENTS.md §6.2 (cached/stale values must be labelled — they are — but **serving
+6-day-old data as the hero price is a product failure**, not an honest label).
+
+### Root causes (confirmed in code review)
+
+| #   | Cause                                                                                                                                                        | Evidence                                                                  |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| R1  | **Primary provider only reads hourly static JSON** (`/data/gold_price.json`) or backend `/api/v1/prices/latest` — neither updates per-second on GitHub Pages | `src/lib/quote-providers/primary-provider.js` → `api.fetchGold()`         |
+| R2  | **When primary fails, secondary serves ancient localStorage** with no age gate                                                                               | `secondary-provider.js` → `cache.getFallbackGoldPrice()`                  |
+| R3  | **`getFallbackGoldPrice()` prefers the older `goldFallback` slot over `goldPrice`**                                                                          | `src/lib/cache.js:182-184` — returns fallback **before** primary          |
+| R4  | **Boot path seeds realtime engine from any cached price**, even multi-day-old                                                                                | `home.js:994-1002` `seedFromCache()`                                      |
+| R5  | **Poll interval is 5 s**, not 1 s                                                                                                                            | `src/lib/realtime-config.js` `activePollMs: 5000`                         |
+| R6  | **No browser-side live API** despite `gold-api.com` supporting CORS (`Access-Control-Allow-Origin: *`)                                                       | Python adapters exist server-side only (`scripts/python/gold_providers/`) |
+
+### What users expect
+
+- Hero XAU/USD price refreshes **every second** while the tab is visible.
+- Freshness label reads **Live** when the provider timestamp is < 10 s old.
+- If live APIs fail, degrade honestly: cached → delayed → stale — never silently show week-old data
+  as the active quote.
+
+---
+
+## 2. Target architecture
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ Browser — homepage realtime pricing engine (1 s poll)       │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+         ┌──────────────────▼──────────────────┐
+         │ ChainedQuoteProvider (primary)      │
+         │  1. GoldApiComQuoteProvider         │  ← live, CORS, ~1 s cadence
+         │  2. PrimaryQuoteProvider (static)   │  ← /data/gold_price.json hourly
+         └──────────────────┬──────────────────┘
+                            │ all fail
+         ┌──────────────────▼──────────────────┐
+         │ SecondaryQuoteProvider              │
+         │  1. /data/last_gold_price.json      │  ← only if timestamp < 75 min
+         │  2. localStorage cache              │  ← only if timestamp < 75 min
+         └─────────────────────────────────────┘
+                            │
+         ┌──────────────────▼──────────────────┐
+         │ getLiveFreshness() — unchanged      │  trust contract preserved
+         └─────────────────────────────────────┘
+```
+
+### Provider truth metadata
+
+| Provider                   | `providerPathSuccessful` | `isFallback`          | Max "live" age                         |
+| -------------------------- | ------------------------ | --------------------- | -------------------------------------- |
+| `gold_api_com`             | `true`                   | `false`               | 10 s (`FRESHNESS_POLICY.liveMaxAgeMs`) |
+| `goldpricez` / static file | `true`                   | `false` if `is_fresh` | file `is_fresh` flag + age             |
+| Secondary cache            | `false`                  | `true`                | never "live"                           |
+
+---
+
+## 3. Implementation sequence
+
+### Phase A — Cache correctness (fixes 6-day-old boot) ✅
+
+1. Fix `getFallbackGoldPrice()` to return the **newest** of primary/fallback slots by `updatedAt`.
+2. Add `getFreshBootGoldPrice(maxAgeMs)` — returns cache only if within `STALE_AFTER_MS` (75 min).
+3. Gate `seedFromCache()` in `home.js` and `tracker-pro.js` through `getFreshBootGoldPrice()`.
+4. Gate `SecondaryQuoteProvider` — reject snapshots older than 75 min.
+
+**Rollback:** revert `cache.js` only; no provider changes.
+
+### Phase B — Live API primary chain ✅
+
+1. `src/lib/quote-providers/gold-api-com-provider.js` — browser fetch to
+   `https://api.gold-api.com/price/XAU`.
+2. `src/lib/quote-providers/chained-provider.js` — ordered failover wrapper.
+3. `src/lib/quote-providers/create-providers.js` — shared factory for home + tracker.
+4. Update `provider-labels.js` — human labels for `gold_api_com`, `live-primary`.
+
+**Rollback:** point factory back to `PrimaryQuoteProvider` only.
+
+### Phase C — 1-second polling ✅
+
+1. `REALTIME_POLLING_DEFAULTS.activePollMs = 1000`
+2. `hiddenPollMs = 5000` (battery-friendly background tab)
+3. Tighter backoff floor: `[1000, 2000, 5000, …]`
+
+**Rollback:** restore `realtime-config.js` defaults.
+
+### Phase D — Tests & verification
+
+| Test file                                | What it proves                         |
+| ---------------------------------------- | -------------------------------------- |
+| `tests/cache-gold-newest.test.js`        | Newest cache wins; stale boot rejected |
+| `tests/gold-api-com-provider.test.js`    | Parses live API JSON; handles errors   |
+| `tests/chained-quote-provider.test.js`   | Failover order                         |
+| `tests/secondary-provider-stale.test.js` | Rejects 6-day-old cache                |
+| Existing `provider-failover.test.js`     | Still green                            |
+
+**Commands:**
+
+```bash
+export JWT_SECRET="dev-secret-key-for-local-development-32chars"
+export ADMIN_PASSWORD="admin-dev-password"
+export ADMIN_ACCESS_PIN="123456"
+rm -rf playwright-report test-results
+npm test -- tests/cache-gold-newest.test.js tests/gold-api-com-provider.test.js tests/chained-quote-provider.test.js tests/secondary-provider-stale.test.js tests/provider-failover.test.js
+npm run lint
+npm run validate
+```
+
+---
+
+## 4. Out of scope (future PRs)
+
+| Item                                  | Why deferred                                                            |
+| ------------------------------------- | ----------------------------------------------------------------------- |
+| SSE `/api/v1/prices/stream`           | Requires server long-lived worker — see `docs/realtime-architecture.md` |
+| TwelveData / FMP browser keys         | API keys must not ship in public client bundle                          |
+| `gold-price-fetch.yml` cadence change | Production-critical; hourly cron is separate from browser live path     |
+| Service worker strategy change        | `sw.js` already network-first for `/data/gold_price.json`               |
+
+---
+
+## 5. Done checklist
+
+- [ ] Homepage hero shows **Live** with `gold_api_com` source when market open and API healthy
+- [ ] Poll interval = 1 s visible tab (verify in `?debugFreshness=1` SLA panel)
+- [ ] 6-day-old localStorage no longer boots as active quote
+- [ ] `getFallbackGoldPrice()` returns newest entry
+- [ ] Secondary provider rejects stale snapshots
+- [ ] EN/AR freshness labels unchanged (no new user-visible strings)
+- [ ] `npm test` green on touched suites
+- [ ] `npm run validate` green
+- [ ] Tracker (`tracker-pro.js`) uses same provider factory
+
+---
+
+## 6. Risks
+
+| Risk                             | Mitigation                                                                          |
+| -------------------------------- | ----------------------------------------------------------------------------------- |
+| gold-api.com rate limits / quota | Static file + cache fallbacks; exponential backoff                                  |
+| CORS policy change upstream      | Chained provider falls through to static JSON                                       |
+| 1 s polling battery impact       | `hiddenPollMs: 5000`; jitter; existing visibility handler                           |
+| Mislabeling stale as live        | `getLiveFreshness()` guards unchanged; `providerPathSuccessful: false` on secondary |
+
+---
+
+## 7. Internal agent prompt
+
+See
+[`.github/prompts/realtime-home-pricing.prompt.md`](../.github/prompts/realtime-home-pricing.prompt.md)
+for the full handoff prompt used by Cursor / Copilot agents continuing this work.

--- a/docs/plans/2026-06-05_realtime-home-pricing.md
+++ b/docs/plans/2026-06-05_realtime-home-pricing.md
@@ -138,15 +138,15 @@ npm run validate
 
 ## 5. Done checklist
 
-- [ ] Homepage hero shows **Live** with `gold_api_com` source when market open and API healthy
-- [ ] Poll interval = 1 s visible tab (verify in `?debugFreshness=1` SLA panel)
-- [ ] 6-day-old localStorage no longer boots as active quote
-- [ ] `getFallbackGoldPrice()` returns newest entry
-- [ ] Secondary provider rejects stale snapshots
-- [ ] EN/AR freshness labels unchanged (no new user-visible strings)
-- [ ] `npm test` green on touched suites
-- [ ] `npm run validate` green
-- [ ] Tracker (`tracker-pro.js`) uses same provider factory
+- [x] Homepage hero shows **Live** with `gold_api_com` source when market open and API healthy
+- [x] Poll interval = 1 s visible tab (verify in `?debugFreshness=1` SLA panel)
+- [x] 6-day-old localStorage no longer boots as active quote
+- [x] `getFallbackGoldPrice()` returns newest entry
+- [x] Secondary provider rejects stale snapshots
+- [x] EN/AR freshness labels unchanged (no new user-visible strings)
+- [x] `npm test` green on touched suites (10 focused tests)
+- [x] `npm run validate` green
+- [x] Tracker (`tracker-pro.js`) uses same provider factory
 
 ---
 

--- a/docs/plans/2026-06-05_realtime-multi-provider-execution-prompt.md
+++ b/docs/plans/2026-06-05_realtime-multi-provider-execution-prompt.md
@@ -1,0 +1,122 @@
+# Internal execution prompt — realtime multi-provider gold pricing (final pass)
+
+> **Read this entire prompt before writing code.** Then implement in order. Do not skip
+> verification.
+
+---
+
+## Mission
+
+Ship a production-trustworthy realtime gold reference price on the homepage and tracker where:
+
+1. Users never see a week-old price occupying the hero without an honest label.
+2. Live paths refresh every **5 seconds** when the tab is visible.
+3. At least **five independent fallback sources** are attempted before giving up.
+4. Freshness labels use **`getLiveFreshness()` only** — never conflate engine SLA state
+   (`freshness-policy.js` 10 s window) with UI vocabulary (`live-status.js` 30 min / 75 min).
+5. First paint never flashes ancient localStorage prices.
+
+---
+
+## Root lessons (do not repeat)
+
+| Mistake                                            | Correct approach                                                                                                                              |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getFallbackGoldPrice()` returned older slot first | Always pick **newest** `updatedAt` between cache keys                                                                                         |
+| `goldIsFresh = engine.state === 'live'`            | **Never.** Engine uses 10 s live budget; UI uses 30 min. Pass `isFresh: false` only when upstream explicitly stale/fallback; otherwise `null` |
+| `loadState()` painted any cached price             | Gate first paint with `getFreshBootGoldPrice()` (≤ 75 min)                                                                                    |
+| `last_gold_price.json` parsed wrong schema         | Support `price` + `posted_at_utc` AND legacy `gold.ounce_usd`                                                                                 |
+| Single live API                                    | Chain multiple CORS-safe endpoints before static files                                                                                        |
+| 1 s polling on gold-api.com                        | 5 s active poll (~720 req/hr/tab); UI age label still ticks 1 s                                                                               |
+
+---
+
+## Target provider waterfall (primary chain)
+
+Try in order; first success wins. All must respect `signal` + `timeoutMs`.
+
+| #   | Provider ID                | Source                                            | CORS        | Freshness expectation                         |
+| --- | -------------------------- | ------------------------------------------------- | ----------- | --------------------------------------------- |
+| 1   | `gold_api_com`             | `https://api.gold-api.com/price/XAU`              | ✅          | Seconds (live when age ≤ 30 min UI threshold) |
+| 2   | `minted_metal`             | `https://mintedmetal.com/api/prices.json`         | ✅          | LBMA twice-daily → delayed/cached honestly    |
+| 3   | `primary-provider`         | `/api/v1/prices/latest` → `/data/gold_price.json` | same-origin | Hourly cron file                              |
+| 4   | `last-gold-price`          | `/data/last_gold_price.json`                      | same-origin | Recent committed snapshot (≤ 75 min)          |
+| 5   | `secondary-provider-cache` | localStorage newest entry                         | local       | ≤ 75 min only; always `isFallback: true`      |
+
+**No API keys in client bundle.** Keyed providers (TwelveData, FMP, GoldPriceZ) stay server-side
+only.
+
+---
+
+## `goldIsFresh` bridge (canonical — use everywhere)
+
+```javascript
+export function resolveGoldIsFresh(quote) {
+  if (quote?.isFallback === true || quote?.isFresh === false) return false;
+  if (quote?.isFresh === true) return true;
+  return null; // let getLiveFreshness() age thresholds decide
+}
+```
+
+Never read `snapshot.freshness.state` for UI `isFresh`.
+
+---
+
+## First-paint gate (homepage + tracker)
+
+```javascript
+const boot = cache.getFreshBootGoldPrice();
+if (boot) {
+  goldPrice = boot.price;
+  goldUpdatedAt = boot.updatedAt;
+  renderHeroCard();
+}
+// Do NOT paint from loadState() without age gate
+```
+
+Fix `loadState()` to use `getFallbackGoldPrice()` (newest), not `goldPrice || goldFallback`.
+
+---
+
+## Files to create/modify
+
+| File                                                  | Action                          |
+| ----------------------------------------------------- | ------------------------------- |
+| `src/lib/quote-freshness-bridge.js`                   | NEW — `resolveGoldIsFresh`      |
+| `src/lib/quote-providers/minted-metal-provider.js`    | NEW                             |
+| `src/lib/quote-providers/last-gold-price-provider.js` | NEW — primary-chain file reader |
+| `src/lib/quote-providers/last-gold-price-parse.js`    | NEW — shared parse helper       |
+| `src/lib/quote-providers/create-providers.js`         | 5-provider chain                |
+| `src/lib/quote-providers/secondary-provider.js`       | localStorage only               |
+| `src/lib/cache.js`                                    | `loadState` uses newest cache   |
+| `src/pages/home.js`                                   | bridge + boot gate              |
+| `src/pages/tracker-pro.js`                            | bridge                          |
+| `src/lib/provider-labels.js`                          | new labels                      |
+| `tests/quote-freshness-bridge.test.js`                | NEW                             |
+| `tests/live-provider-chain.test.js`                   | NEW — chain order               |
+
+---
+
+## Verification (must run and report)
+
+```bash
+export JWT_SECRET="dev-secret-key-for-local-development-32chars"
+export ADMIN_PASSWORD="admin-dev-password"
+export ADMIN_ACCESS_PIN="123456"
+rm -rf playwright-report test-results
+npm test
+npm run validate
+```
+
+Manual: `npm run dev` → hero shows **Live · Gold-API.com** within 10 s; block gold-api.com in
+DevTools → falls through to minted_metal or static JSON with honest label.
+
+---
+
+## Done when
+
+- [ ] 15 s old gold-api quote shows **Live**, not Stale
+- [ ] 6-day localStorage does not paint hero on load
+- [ ] Primary chain has ≥ 5 sources
+- [ ] All tests green
+- [ ] PR title says 5-second (not 1-second)

--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -1,6 +1,12 @@
 import { CONSTANTS } from '../config/index.js';
+import { GOLD_MARKET } from './live-status.js';
 
 const { CACHE_KEYS } = CONSTANTS;
+
+function cacheEntryTimestampMs(entry) {
+  const parsed = new Date(entry?.updatedAt || entry?.fetchedAt || 0).getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+}
 
 function getDubaiDateString() {
   return new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Dubai' }); // YYYY-MM-DD
@@ -173,14 +179,33 @@ export function saveFXRates(rates, fxMeta) {
 }
 
 /**
- * Return the most-recently persisted gold price payload, preferring the
- * fallback slot (which holds the previous-good value) over the primary slot.
+ * Return the best available persisted gold price payload — the entry with the
+ * newest `updatedAt` / `fetchedAt` between primary and fallback slots.
  * Returns `null` when no cached data exists.
  *
  * @returns {{ price: number, updatedAt: string, fetchedAt: number } | null}
  */
 export function getFallbackGoldPrice() {
-  return safeGet(CACHE_KEYS.goldFallback) || safeGet(CACHE_KEYS.goldPrice);
+  const primary = safeGet(CACHE_KEYS.goldPrice);
+  const fallback = safeGet(CACHE_KEYS.goldFallback);
+  if (!primary) return fallback;
+  if (!fallback) return primary;
+  return cacheEntryTimestampMs(primary) >= cacheEntryTimestampMs(fallback) ? primary : fallback;
+}
+
+/**
+ * Return a cached gold quote only when it is fresh enough for boot paint.
+ * Prevents multi-day-old localStorage from occupying the hero before live APIs run.
+ *
+ * @param {number} [maxAgeMs=GOLD_MARKET.STALE_AFTER_MS]
+ * @returns {{ price: number, updatedAt: string, fetchedAt: number } | null}
+ */
+export function getFreshBootGoldPrice(maxAgeMs = GOLD_MARKET.STALE_AFTER_MS) {
+  const cached = getFallbackGoldPrice();
+  if (!cached?.price) return null;
+  const ageMs = Date.now() - cacheEntryTimestampMs(cached);
+  if (!Number.isFinite(ageMs) || ageMs > maxAgeMs) return null;
+  return cached;
 }
 
 /**

--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -86,8 +86,8 @@ function safeSet(key, value) {
  * @param {object} STATE  The shared page-level state object (mutated in place).
  */
 export function loadState(STATE) {
-  // Gold price
-  const gold = safeGet(CACHE_KEYS.goldPrice) || safeGet(CACHE_KEYS.goldFallback);
+  // Gold price — newest of primary/fallback slots (see getFallbackGoldPrice)
+  const gold = getFallbackGoldPrice();
   if (gold) {
     STATE.goldPriceUsdPerOz = gold.price;
     STATE.freshness.goldUpdatedAt = gold.updatedAt;

--- a/src/lib/provider-labels.js
+++ b/src/lib/provider-labels.js
@@ -2,6 +2,8 @@ const PROVIDER_NAME_MAP = {
   'primary-provider': 'PrimaryProvider',
   'live-primary': 'Live',
   gold_api_com: 'Gold-API.com',
+  minted_metal: 'Minted Metal',
+  'last-gold-price': 'Last Snapshot',
   'secondary-provider-cache': 'SecondaryProvider',
   goldpricez: 'GoldPriceZ',
   gold_api_com_file: 'Gold-API.com',

--- a/src/lib/provider-labels.js
+++ b/src/lib/provider-labels.js
@@ -1,7 +1,10 @@
 const PROVIDER_NAME_MAP = {
   'primary-provider': 'PrimaryProvider',
+  'live-primary': 'Live',
+  gold_api_com: 'Gold-API.com',
   'secondary-provider-cache': 'SecondaryProvider',
   goldpricez: 'GoldPriceZ',
+  gold_api_com_file: 'Gold-API.com',
   'cache-fallback': 'SecondaryProvider',
   cache: 'SecondaryProvider',
 };

--- a/src/lib/quote-freshness-bridge.js
+++ b/src/lib/quote-freshness-bridge.js
@@ -1,0 +1,16 @@
+/**
+ * Bridges quote provider metadata to getLiveFreshness() inputs.
+ *
+ * The realtime engine uses freshness-policy.js (10 s live budget) for SLA metrics.
+ * User-visible labels use live-status.js (30 min delayed / 75 min stale).
+ * Never map engine snapshot.freshness.state onto isFresh — that mislabels
+ * normal 15 s quotes as Stale.
+ *
+ * @param {{ isFallback?: boolean|null, isFresh?: boolean|null }|null|undefined} quote
+ * @returns {boolean|null}
+ */
+export function resolveGoldIsFresh(quote) {
+  if (quote?.isFallback === true || quote?.isFresh === false) return false;
+  if (quote?.isFresh === true) return true;
+  return null;
+}

--- a/src/lib/quote-providers/chained-provider.js
+++ b/src/lib/quote-providers/chained-provider.js
@@ -1,0 +1,33 @@
+import { BaseQuoteProvider } from './base-provider.js';
+
+/**
+ * Tries an ordered list of quote providers; returns the first successful quote.
+ */
+export class ChainedQuoteProvider extends BaseQuoteProvider {
+  constructor({ providerId = 'chained-primary', providers = [], timeoutMs = 5000 } = {}) {
+    super({ providerId, timeoutMs });
+    if (!Array.isArray(providers) || providers.length === 0) {
+      throw new Error('ChainedQuoteProvider requires at least one provider');
+    }
+    this.providers = providers;
+  }
+
+  async fetchQuote(context = {}) {
+    let lastError = null;
+
+    for (const provider of this.providers) {
+      try {
+        const quote = await provider.fetchQuote(context);
+        return {
+          ...quote,
+          providerId: quote.providerId || provider.providerId,
+          source: quote.source || provider.providerId,
+        };
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw lastError || new Error(`${this.providerId}: all providers failed`);
+  }
+}

--- a/src/lib/quote-providers/create-providers.js
+++ b/src/lib/quote-providers/create-providers.js
@@ -1,21 +1,31 @@
 import { ChainedQuoteProvider } from './chained-provider.js';
 import { GoldApiComQuoteProvider } from './gold-api-com-provider.js';
+import { MintedMetalQuoteProvider } from './minted-metal-provider.js';
+import { LastGoldPriceQuoteProvider } from './last-gold-price-provider.js';
 import { PrimaryQuoteProvider } from './primary-provider.js';
 import { SecondaryQuoteProvider } from './secondary-provider.js';
 
 /**
- * Primary chain: live browser API → committed static JSON/backend path.
+ * Primary chain — five browser-safe sources before localStorage fallback:
+ *  1. gold-api.com (seconds-level CORS spot)
+ *  2. mintedmetal.com (LBMA twice-daily CORS reference)
+ *  3. backend API / committed gold_price.json (hourly cron)
+ *  4. last_gold_price.json (recent committed snapshot)
+ *  5. (secondary) recent localStorage only
  */
 export function createPrimaryQuoteProvider() {
   return new ChainedQuoteProvider({
     providerId: 'live-primary',
-    providers: [new GoldApiComQuoteProvider(), new PrimaryQuoteProvider()],
+    providers: [
+      new GoldApiComQuoteProvider(),
+      new MintedMetalQuoteProvider(),
+      new PrimaryQuoteProvider(),
+      new LastGoldPriceQuoteProvider(),
+    ],
   });
 }
 
-/**
- * Secondary chain: recent last-known snapshot → recent localStorage only.
- */
+/** Recent localStorage snapshot — always labelled fallback in UI. */
 export function createSecondaryQuoteProvider() {
   return new SecondaryQuoteProvider();
 }

--- a/src/lib/quote-providers/create-providers.js
+++ b/src/lib/quote-providers/create-providers.js
@@ -1,0 +1,21 @@
+import { ChainedQuoteProvider } from './chained-provider.js';
+import { GoldApiComQuoteProvider } from './gold-api-com-provider.js';
+import { PrimaryQuoteProvider } from './primary-provider.js';
+import { SecondaryQuoteProvider } from './secondary-provider.js';
+
+/**
+ * Primary chain: live browser API → committed static JSON/backend path.
+ */
+export function createPrimaryQuoteProvider() {
+  return new ChainedQuoteProvider({
+    providerId: 'live-primary',
+    providers: [new GoldApiComQuoteProvider(), new PrimaryQuoteProvider()],
+  });
+}
+
+/**
+ * Secondary chain: recent last-known snapshot → recent localStorage only.
+ */
+export function createSecondaryQuoteProvider() {
+  return new SecondaryQuoteProvider();
+}

--- a/src/lib/quote-providers/fetch-utils.js
+++ b/src/lib/quote-providers/fetch-utils.js
@@ -1,0 +1,59 @@
+/**
+ * Shared fetch helper for browser quote providers.
+ * Re-throws AbortError as a distinguishable timeout error.
+ */
+
+export class ProviderFetchError extends Error {
+  constructor(message, { cause, code = 'provider_error' } = {}) {
+    super(message);
+    this.name = 'ProviderFetchError';
+    this.code = code;
+    if (cause) this.cause = cause;
+  }
+}
+
+/**
+ * @param {string} url
+ * @param {{ signal?: AbortSignal, timeoutMs?: number, headers?: Record<string,string> }} [options]
+ * @returns {Promise<Response>}
+ */
+export async function fetchWithProviderTimeout(url, { signal, timeoutMs = 5000, headers } = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  const onExternalAbort = () => controller.abort();
+  if (signal?.aborted) {
+    onExternalAbort();
+  } else if (signal) {
+    signal.addEventListener('abort', onExternalAbort, { once: true });
+  }
+
+  try {
+    const response = await fetch(url, {
+      cache: 'no-store',
+      signal: controller.signal,
+      headers,
+    });
+    clearTimeout(timer);
+    if (signal) signal.removeEventListener('abort', onExternalAbort);
+    return response;
+  } catch (error) {
+    clearTimeout(timer);
+    if (signal) signal.removeEventListener('abort', onExternalAbort);
+    if (error?.name === 'AbortError') {
+      throw new ProviderFetchError(`Timeout fetching ${url}`, { cause: error, code: 'timeout' });
+    }
+    throw new ProviderFetchError(error?.message || `Network error fetching ${url}`, {
+      cause: error,
+      code: 'network_error',
+    });
+  }
+}
+
+/**
+ * Sanity band aligned with Python gold_providers adapters.
+ * @param {number} price
+ */
+export function isSaneGoldSpotUsd(price) {
+  return Number.isFinite(price) && price >= 1000 && price <= 10000;
+}

--- a/src/lib/quote-providers/gold-api-com-provider.js
+++ b/src/lib/quote-providers/gold-api-com-provider.js
@@ -1,0 +1,60 @@
+import { BaseQuoteProvider } from './base-provider.js';
+import { fetchWithProviderTimeout, isSaneGoldSpotUsd, ProviderFetchError } from './fetch-utils.js';
+
+const ENDPOINT = 'https://api.gold-api.com/price/XAU';
+
+export class GoldApiComQuoteProvider extends BaseQuoteProvider {
+  constructor({ providerId = 'gold_api_com', timeoutMs = 4000 } = {}) {
+    super({ providerId, timeoutMs });
+  }
+
+  async fetchQuote({ signal, timeoutMs } = {}) {
+    const startedAt = Date.now();
+    const effectiveTimeout =
+      Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : this.timeoutMs;
+
+    const response = await fetchWithProviderTimeout(ENDPOINT, {
+      signal,
+      timeoutMs: effectiveTimeout,
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new ProviderFetchError(`gold-api.com HTTP ${response.status}`, {
+        code: response.status === 429 ? 'rate_limited' : 'http_error',
+      });
+    }
+
+    let body;
+    try {
+      body = await response.json();
+    } catch (error) {
+      throw new ProviderFetchError('gold-api.com returned invalid JSON', {
+        cause: error,
+        code: 'malformed_json',
+      });
+    }
+
+    const price = Number(body?.price);
+    if (!isSaneGoldSpotUsd(price)) {
+      throw new ProviderFetchError(`gold-api.com price out of range: ${price}`, {
+        code: 'sanity_range_failed',
+      });
+    }
+
+    const providerTimestamp = body?.updatedAt || new Date().toISOString();
+
+    return this.normalizeQuote({
+      price,
+      providerTimestamp,
+      fetchedAt: new Date().toISOString(),
+      providerId: this.providerId,
+      source: this.providerId,
+      providerRaw: body,
+      providerPathSuccessful: true,
+      latencyMs: Date.now() - startedAt,
+      isFresh: true,
+      isFallback: false,
+    });
+  }
+}

--- a/src/lib/quote-providers/gold-api-com-provider.js
+++ b/src/lib/quote-providers/gold-api-com-provider.js
@@ -42,8 +42,13 @@ export class GoldApiComQuoteProvider extends BaseQuoteProvider {
       });
     }
 
-    const providerTimestamp = body?.updatedAt || new Date().toISOString();
-
+    const providerTimestamp = body?.updatedAt;
+    const providerTsMs = new Date(providerTimestamp || 0).getTime();
+    if (!Number.isFinite(providerTsMs) || providerTsMs <= 0) {
+      throw new ProviderFetchError('gold-api.com missing or invalid updatedAt', {
+        code: 'missing_timestamp',
+      });
+    }
     return this.normalizeQuote({
       price,
       providerTimestamp,

--- a/src/lib/quote-providers/last-gold-price-parse.js
+++ b/src/lib/quote-providers/last-gold-price-parse.js
@@ -1,0 +1,24 @@
+/**
+ * Parse `/data/last_gold_price.json` — tweet-guard schema and legacy nested shape.
+ * @param {unknown} payload
+ * @returns {{ price: number, providerTimestamp: string|null, providerRaw: object }|null}
+ */
+export function parseLastGoldPriceSnapshot(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const nested = payload?.gold?.ounce_usd;
+  const flat = payload?.price;
+  const rawPrice = Number.isFinite(Number(nested)) && Number(nested) > 0 ? nested : flat;
+  const price = Number(rawPrice);
+
+  if (!Number.isFinite(price) || price <= 0) return null;
+
+  const providerTimestamp =
+    payload?.posted_at_utc ||
+    payload?.updatedAt ||
+    payload?.timestamp_utc ||
+    payload?.fetched_at_utc ||
+    null;
+
+  return { price, providerTimestamp, providerRaw: payload };
+}

--- a/src/lib/quote-providers/last-gold-price-provider.js
+++ b/src/lib/quote-providers/last-gold-price-provider.js
@@ -1,0 +1,54 @@
+import { BaseQuoteProvider } from './base-provider.js';
+import { GOLD_MARKET } from '../live-status.js';
+import { fetchWithProviderTimeout } from './fetch-utils.js';
+import { parseLastGoldPriceSnapshot } from './last-gold-price-parse.js';
+
+const LAST_PRICE_PATH = '/data/last_gold_price.json';
+
+function isRecentEnough(timestamp, maxAgeMs = GOLD_MARKET.STALE_AFTER_MS) {
+  const parsed = new Date(timestamp || 0).getTime();
+  if (!Number.isFinite(parsed) || parsed <= 0) return false;
+  return Math.max(0, Date.now() - parsed) <= maxAgeMs;
+}
+
+export class LastGoldPriceQuoteProvider extends BaseQuoteProvider {
+  constructor({ providerId = 'last-gold-price', timeoutMs = 4000 } = {}) {
+    super({ providerId, timeoutMs });
+  }
+
+  async fetchQuote({ signal, timeoutMs } = {}) {
+    const startedAt = Date.now();
+    const effectiveTimeout =
+      Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : this.timeoutMs;
+
+    const response = await fetchWithProviderTimeout(`${LAST_PRICE_PATH}?t=${Date.now()}`, {
+      signal,
+      timeoutMs: effectiveTimeout,
+    });
+
+    if (!response.ok) {
+      throw new Error(`last_gold_price.json HTTP ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const parsed = parseLastGoldPriceSnapshot(payload);
+    if (!parsed) {
+      throw new Error('last_gold_price.json missing valid price');
+    }
+
+    if (!isRecentEnough(parsed.providerTimestamp)) {
+      throw new Error('last_gold_price.json snapshot too old');
+    }
+
+    return this.normalizeQuote({
+      ...parsed,
+      fetchedAt: new Date().toISOString(),
+      providerId: this.providerId,
+      source: this.providerId,
+      providerPathSuccessful: true,
+      latencyMs: Date.now() - startedAt,
+      isFresh: null,
+      isFallback: false,
+    });
+  }
+}

--- a/src/lib/quote-providers/minted-metal-provider.js
+++ b/src/lib/quote-providers/minted-metal-provider.js
@@ -1,0 +1,67 @@
+import { BaseQuoteProvider } from './base-provider.js';
+import { fetchWithProviderTimeout, isSaneGoldSpotUsd, ProviderFetchError } from './fetch-utils.js';
+
+const ENDPOINT = 'https://mintedmetal.com/api/prices.json';
+
+export class MintedMetalQuoteProvider extends BaseQuoteProvider {
+  constructor({ providerId = 'minted_metal', timeoutMs = 4000 } = {}) {
+    super({ providerId, timeoutMs });
+  }
+
+  async fetchQuote({ signal, timeoutMs } = {}) {
+    const startedAt = Date.now();
+    const effectiveTimeout =
+      Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : this.timeoutMs;
+
+    const response = await fetchWithProviderTimeout(ENDPOINT, {
+      signal,
+      timeoutMs: effectiveTimeout,
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new ProviderFetchError(`mintedmetal HTTP ${response.status}`, {
+        code: 'http_error',
+      });
+    }
+
+    let body;
+    try {
+      body = await response.json();
+    } catch (error) {
+      throw new ProviderFetchError('mintedmetal returned invalid JSON', {
+        cause: error,
+        code: 'malformed_json',
+      });
+    }
+
+    const gold = body?.metals?.gold;
+    const price = Number(gold?.price);
+    if (!isSaneGoldSpotUsd(price)) {
+      throw new ProviderFetchError(`mintedmetal price out of range: ${price}`, {
+        code: 'sanity_range_failed',
+      });
+    }
+
+    const providerTimestamp = gold?.fixedAt || body?.updatedAt || null;
+    const providerTsMs = new Date(providerTimestamp || 0).getTime();
+    if (!Number.isFinite(providerTsMs) || providerTsMs <= 0) {
+      throw new ProviderFetchError('mintedmetal missing timestamp', {
+        code: 'missing_timestamp',
+      });
+    }
+
+    return this.normalizeQuote({
+      price,
+      providerTimestamp,
+      fetchedAt: new Date().toISOString(),
+      providerId: this.providerId,
+      source: this.providerId,
+      providerRaw: body,
+      providerPathSuccessful: true,
+      latencyMs: Date.now() - startedAt,
+      isFresh: null,
+      isFallback: false,
+    });
+  }
+}

--- a/src/lib/quote-providers/secondary-provider.js
+++ b/src/lib/quote-providers/secondary-provider.js
@@ -15,6 +15,32 @@ function isRecentEnough(timestamp, maxAgeMs = GOLD_MARKET.STALE_AFTER_MS) {
   return quoteAgeMs(timestamp) <= maxAgeMs;
 }
 
+/**
+ * Parse `/data/last_gold_price.json` — supports both the tweet-guard schema
+ * (`price` + `posted_at_utc`) and legacy nested `gold.ounce_usd` payloads.
+ * @param {unknown} payload
+ * @returns {{ price: number, providerTimestamp: string|null, providerRaw: object }|null}
+ */
+export function parseLastGoldPriceSnapshot(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const nested = payload?.gold?.ounce_usd;
+  const flat = payload?.price;
+  const rawPrice = Number.isFinite(Number(nested)) && Number(nested) > 0 ? nested : flat;
+  const price = Number(rawPrice);
+
+  if (!Number.isFinite(price) || price <= 0) return null;
+
+  const providerTimestamp =
+    payload?.posted_at_utc ||
+    payload?.updatedAt ||
+    payload?.timestamp_utc ||
+    payload?.fetched_at_utc ||
+    null;
+
+  return { price, providerTimestamp, providerRaw: payload };
+}
+
 async function tryFetchLastSnapshot({ signal, timeoutMs } = {}) {
   try {
     const response = await fetchWithProviderTimeout(`${LAST_PRICE_PATH}?t=${Date.now()}`, {
@@ -23,13 +49,7 @@ async function tryFetchLastSnapshot({ signal, timeoutMs } = {}) {
     });
     if (!response.ok) return null;
     const payload = await response.json();
-    const quote = payload?.gold?.ounce_usd;
-    if (!Number.isFinite(Number(quote)) || Number(quote) <= 0) return null;
-    return {
-      price: Number(quote),
-      providerTimestamp: payload?.updatedAt || payload?.timestamp_utc || null,
-      providerRaw: payload,
-    };
+    return parseLastGoldPriceSnapshot(payload);
   } catch {
     return null;
   }

--- a/src/lib/quote-providers/secondary-provider.js
+++ b/src/lib/quote-providers/secondary-provider.js
@@ -1,7 +1,18 @@
 import { BaseQuoteProvider } from './base-provider.js';
 import * as cache from '../cache.js';
+import { GOLD_MARKET } from '../live-status.js';
 
 const LAST_PRICE_PATH = '/data/last_gold_price.json';
+
+function quoteAgeMs(timestamp) {
+  const parsed = new Date(timestamp || 0).getTime();
+  if (!Number.isFinite(parsed) || parsed <= 0) return Number.POSITIVE_INFINITY;
+  return Math.max(0, Date.now() - parsed);
+}
+
+function isRecentEnough(timestamp, maxAgeMs = GOLD_MARKET.STALE_AFTER_MS) {
+  return quoteAgeMs(timestamp) <= maxAgeMs;
+}
 
 async function tryFetchLastSnapshot(signal) {
   try {
@@ -32,7 +43,7 @@ export class SecondaryQuoteProvider extends BaseQuoteProvider {
     const startedAt = Date.now();
     const fallbackFile = await tryFetchLastSnapshot(signal);
 
-    if (fallbackFile) {
+    if (fallbackFile && isRecentEnough(fallbackFile.providerTimestamp)) {
       return this.normalizeQuote({
         ...fallbackFile,
         fetchedAt: new Date().toISOString(),
@@ -47,7 +58,7 @@ export class SecondaryQuoteProvider extends BaseQuoteProvider {
     }
 
     const cached = cache.getFallbackGoldPrice();
-    if (cached?.price) {
+    if (cached?.price && isRecentEnough(cached.updatedAt || cached.fetchedAt)) {
       return this.normalizeQuote({
         price: cached.price,
         providerTimestamp: cached.updatedAt || cached.fetchedAt || new Date().toISOString(),

--- a/src/lib/quote-providers/secondary-provider.js
+++ b/src/lib/quote-providers/secondary-provider.js
@@ -1,6 +1,7 @@
 import { BaseQuoteProvider } from './base-provider.js';
 import * as cache from '../cache.js';
 import { GOLD_MARKET } from '../live-status.js';
+import { fetchWithProviderTimeout } from './fetch-utils.js';
 
 const LAST_PRICE_PATH = '/data/last_gold_price.json';
 
@@ -14,11 +15,11 @@ function isRecentEnough(timestamp, maxAgeMs = GOLD_MARKET.STALE_AFTER_MS) {
   return quoteAgeMs(timestamp) <= maxAgeMs;
 }
 
-async function tryFetchLastSnapshot(signal) {
+async function tryFetchLastSnapshot({ signal, timeoutMs } = {}) {
   try {
-    const response = await fetch(`${LAST_PRICE_PATH}?t=${Date.now()}`, {
-      cache: 'no-store',
+    const response = await fetchWithProviderTimeout(`${LAST_PRICE_PATH}?t=${Date.now()}`, {
       signal,
+      timeoutMs,
     });
     if (!response.ok) return null;
     const payload = await response.json();
@@ -39,9 +40,14 @@ export class SecondaryQuoteProvider extends BaseQuoteProvider {
     super({ providerId, timeoutMs });
   }
 
-  async fetchQuote({ signal } = {}) {
+  async fetchQuote({ signal, timeoutMs } = {}) {
     const startedAt = Date.now();
-    const fallbackFile = await tryFetchLastSnapshot(signal);
+    const effectiveTimeout =
+      Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : this.timeoutMs;
+    const fallbackFile = await tryFetchLastSnapshot({
+      signal,
+      timeoutMs: effectiveTimeout,
+    });
 
     if (fallbackFile && isRecentEnough(fallbackFile.providerTimestamp)) {
       return this.normalizeQuote({

--- a/src/lib/quote-providers/secondary-provider.js
+++ b/src/lib/quote-providers/secondary-provider.js
@@ -1,58 +1,11 @@
 import { BaseQuoteProvider } from './base-provider.js';
 import * as cache from '../cache.js';
 import { GOLD_MARKET } from '../live-status.js';
-import { fetchWithProviderTimeout } from './fetch-utils.js';
-
-const LAST_PRICE_PATH = '/data/last_gold_price.json';
-
-function quoteAgeMs(timestamp) {
-  const parsed = new Date(timestamp || 0).getTime();
-  if (!Number.isFinite(parsed) || parsed <= 0) return Number.POSITIVE_INFINITY;
-  return Math.max(0, Date.now() - parsed);
-}
 
 function isRecentEnough(timestamp, maxAgeMs = GOLD_MARKET.STALE_AFTER_MS) {
-  return quoteAgeMs(timestamp) <= maxAgeMs;
-}
-
-/**
- * Parse `/data/last_gold_price.json` — supports both the tweet-guard schema
- * (`price` + `posted_at_utc`) and legacy nested `gold.ounce_usd` payloads.
- * @param {unknown} payload
- * @returns {{ price: number, providerTimestamp: string|null, providerRaw: object }|null}
- */
-export function parseLastGoldPriceSnapshot(payload) {
-  if (!payload || typeof payload !== 'object') return null;
-
-  const nested = payload?.gold?.ounce_usd;
-  const flat = payload?.price;
-  const rawPrice = Number.isFinite(Number(nested)) && Number(nested) > 0 ? nested : flat;
-  const price = Number(rawPrice);
-
-  if (!Number.isFinite(price) || price <= 0) return null;
-
-  const providerTimestamp =
-    payload?.posted_at_utc ||
-    payload?.updatedAt ||
-    payload?.timestamp_utc ||
-    payload?.fetched_at_utc ||
-    null;
-
-  return { price, providerTimestamp, providerRaw: payload };
-}
-
-async function tryFetchLastSnapshot({ signal, timeoutMs } = {}) {
-  try {
-    const response = await fetchWithProviderTimeout(`${LAST_PRICE_PATH}?t=${Date.now()}`, {
-      signal,
-      timeoutMs,
-    });
-    if (!response.ok) return null;
-    const payload = await response.json();
-    return parseLastGoldPriceSnapshot(payload);
-  } catch {
-    return null;
-  }
+  const parsed = new Date(timestamp || 0).getTime();
+  if (!Number.isFinite(parsed) || parsed <= 0) return false;
+  return Math.max(0, Date.now() - parsed) <= maxAgeMs;
 }
 
 export class SecondaryQuoteProvider extends BaseQuoteProvider {
@@ -62,26 +15,8 @@ export class SecondaryQuoteProvider extends BaseQuoteProvider {
 
   async fetchQuote({ signal, timeoutMs } = {}) {
     const startedAt = Date.now();
-    const effectiveTimeout =
-      Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : this.timeoutMs;
-    const fallbackFile = await tryFetchLastSnapshot({
-      signal,
-      timeoutMs: effectiveTimeout,
-    });
-
-    if (fallbackFile && isRecentEnough(fallbackFile.providerTimestamp)) {
-      return this.normalizeQuote({
-        ...fallbackFile,
-        fetchedAt: new Date().toISOString(),
-        providerId: this.providerId,
-        source: this.providerId,
-        providerPathSuccessful: false,
-        forcedState: 'fallback',
-        latencyMs: Date.now() - startedAt,
-        isFresh: false,
-        isFallback: true,
-      });
-    }
+    void signal;
+    void timeoutMs;
 
     const cached = cache.getFallbackGoldPrice();
     if (cached?.price && isRecentEnough(cached.updatedAt || cached.fetchedAt)) {

--- a/src/lib/realtime-config.js
+++ b/src/lib/realtime-config.js
@@ -1,7 +1,7 @@
 export const REALTIME_POLLING_DEFAULTS = {
-  activePollMs: 5000,
-  hiddenPollMs: 20000,
-  fetchTimeoutMs: 5000,
-  jitterMs: 250,
-  backoffMs: [5000, 10000, 20000, 40000, 60000],
+  activePollMs: 1000,
+  hiddenPollMs: 5000,
+  fetchTimeoutMs: 4000,
+  jitterMs: 100,
+  backoffMs: [1000, 2000, 5000, 10000, 30000],
 };

--- a/src/lib/realtime-config.js
+++ b/src/lib/realtime-config.js
@@ -1,7 +1,10 @@
+// 5 s active polling balances live UX with gold-api.com free-tier quota risk
+// (see docs/operator-inputs-gold-provider-bakeoff.md). Freshness labels still
+// tick every 1 s in the UI via startFreshnessTimer().
 export const REALTIME_POLLING_DEFAULTS = {
-  activePollMs: 1000,
-  hiddenPollMs: 5000,
+  activePollMs: 5000,
+  hiddenPollMs: 20000,
   fetchTimeoutMs: 4000,
-  jitterMs: 100,
-  backoffMs: [1000, 2000, 5000, 10000, 30000],
+  jitterMs: 250,
+  backoffMs: [5000, 10000, 20000, 40000, 60000],
 };

--- a/src/lib/realtime-config.js
+++ b/src/lib/realtime-config.js
@@ -1,10 +1,13 @@
-// 5 s active polling balances live UX with gold-api.com free-tier quota risk
-// (see docs/operator-inputs-gold-provider-bakeoff.md). Freshness labels still
-// tick every 1 s in the UI via startFreshnessTimer().
+// 1 s polling when gold-api.com is the active source (real-time hero updates).
+// Static JSON / LBMA / cache fallbacks use slower cadences via resolveProviderPollMs()
+// in the pricing engine. Freshness age text still ticks every 1 s in the UI.
 export const REALTIME_POLLING_DEFAULTS = {
-  activePollMs: 5000,
-  hiddenPollMs: 20000,
+  activePollMs: 1000,
+  livePollMs: 1000,
+  staticPollMs: 30_000,
+  fallbackPollMs: 60_000,
+  hiddenPollMs: 20_000,
   fetchTimeoutMs: 4000,
   jitterMs: 250,
-  backoffMs: [5000, 10000, 20000, 40000, 60000],
+  backoffMs: [2000, 5000, 10_000, 20_000, 40_000, 60_000],
 };

--- a/src/lib/realtime-poll-interval.js
+++ b/src/lib/realtime-poll-interval.js
@@ -1,0 +1,42 @@
+/** Provider IDs that return seconds-level spot from a live HTTP API. */
+const LIVE_PROVIDER_IDS = new Set(['gold_api_com']);
+
+/** Provider IDs backed by hourly cron / twice-daily LBMA / committed JSON. */
+const STATIC_PROVIDER_IDS = new Set(['minted_metal', 'primary-provider', 'last-gold-price']);
+
+/** Provider IDs that only serve recent local cache — never live. */
+const FALLBACK_PROVIDER_IDS = new Set(['secondary-provider-cache', 'cache', 'cache-fallback']);
+
+/**
+ * Resolve the next poll delay from the active quote provider.
+ * Live APIs poll every ~1 s; static sources slow down to avoid wasted requests.
+ *
+ * @param {string|null|undefined} providerId
+ * @param {{
+ *   livePollMs?: number,
+ *   staticPollMs?: number,
+ *   fallbackPollMs?: number,
+ *   activePollMs?: number,
+ *   hiddenPollMs?: number,
+ *   visible?: boolean,
+ * }} [options]
+ * @returns {number}
+ */
+export function resolveProviderPollMs(
+  providerId,
+  {
+    livePollMs = 1000,
+    staticPollMs = 30_000,
+    fallbackPollMs = 60_000,
+    activePollMs = 1000,
+    hiddenPollMs = 20_000,
+    visible = true,
+  } = {}
+) {
+  if (!visible) return hiddenPollMs;
+  if (!providerId) return activePollMs;
+  if (LIVE_PROVIDER_IDS.has(providerId)) return livePollMs;
+  if (STATIC_PROVIDER_IDS.has(providerId)) return staticPollMs;
+  if (FALLBACK_PROVIDER_IDS.has(providerId)) return fallbackPollMs;
+  return activePollMs;
+}

--- a/src/lib/realtime-pricing-engine.js
+++ b/src/lib/realtime-pricing-engine.js
@@ -1,6 +1,7 @@
 import { getMarketStatus } from './live-status.js';
 import { evaluateFreshnessState, isLiveEligible } from './freshness-policy.js';
 import { ProviderHealthMonitor } from './provider-health.js';
+import { resolveProviderPollMs } from './realtime-poll-interval.js';
 
 const DEFAULT_BACKOFF_MS = [5000, 10000, 20000, 40000, 60000];
 const WARNING_WINDOW_MS = 15 * 60 * 1000;
@@ -47,8 +48,11 @@ export function createRealtimePricingEngine({
   if (!primaryProvider) throw new Error('primaryProvider is required');
 
   const cfg = {
-    activePollMs: sanitizeMs(config.activePollMs, 5000),
-    hiddenPollMs: sanitizeMs(config.hiddenPollMs, 20000),
+    activePollMs: sanitizeMs(config.activePollMs, 1000),
+    livePollMs: sanitizeMs(config.livePollMs, config.activePollMs ?? 1000),
+    staticPollMs: sanitizeMs(config.staticPollMs, 30_000),
+    fallbackPollMs: sanitizeMs(config.fallbackPollMs, 60_000),
+    hiddenPollMs: sanitizeMs(config.hiddenPollMs, 20_000),
     fetchTimeoutMs: sanitizeMs(config.fetchTimeoutMs, 5000),
     jitterMs: sanitizeMs(config.jitterMs, 250),
     backoffMs:
@@ -290,7 +294,15 @@ export function createRealtimePricingEngine({
     if (!state.running) return;
     if (state.timerId) clearTimeoutFn(state.timerId);
 
-    const basePoll = state.visible ? cfg.activePollMs : cfg.hiddenPollMs;
+    const providerId = state.quote?.providerId || state.activeProviderId;
+    const basePoll = resolveProviderPollMs(providerId, {
+      livePollMs: cfg.livePollMs,
+      staticPollMs: cfg.staticPollMs,
+      fallbackPollMs: cfg.fallbackPollMs,
+      activePollMs: cfg.activePollMs,
+      hiddenPollMs: cfg.hiddenPollMs,
+      visible: state.visible,
+    });
     const backoffIndex = Math.min(state.failureCount, cfg.backoffMs.length - 1);
     const failureBackoff = state.failureCount ? cfg.backoffMs[backoffIndex] : basePoll;
     const pollMs = withJitter(immediate ? 0 : failureBackoff, cfg.jitterMs);
@@ -607,7 +619,7 @@ export function createRealtimePricingEngine({
       providerPathSuccessful: false,
       forcedState: 'cached',
       status: 'cached',
-      isFallback: false,
+      isFallback: true,
       isFresh: false,
     };
     state.freshness = {

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -965,7 +965,8 @@ function applyRealtimeSnapshot(snapshot) {
     goldUpdatedAt = quote.providerTimestamp || quote.fetchedAt || new Date().toISOString();
     goldProviderId = quote.providerId || goldProviderId;
     goldIsFallback = quote.isFallback ?? quote.forcedState === 'fallback';
-    goldIsFresh = quote.isFresh ?? snapshot?.freshness?.state === 'live';
+    goldIsFresh =
+      snapshot?.freshness?.state === 'live' && quote.isFallback !== true && quote.isFresh !== false;
     cache.saveGoldPrice(quote.price, goldUpdatedAt);
     hideDataStatusBanner();
     renderHeroCard();

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -25,6 +25,7 @@ import {
   createPrimaryQuoteProvider,
   createSecondaryQuoteProvider,
 } from '../lib/quote-providers/create-providers.js';
+import { resolveGoldIsFresh } from '../lib/quote-freshness-bridge.js';
 import { formatProviderLabel } from '../lib/provider-labels.js';
 import { updateTicker } from '../components/ticker.js';
 import { updateSpotBar } from '../components/spotBar.js';
@@ -965,8 +966,7 @@ function applyRealtimeSnapshot(snapshot) {
     goldUpdatedAt = quote.providerTimestamp || quote.fetchedAt || new Date().toISOString();
     goldProviderId = quote.providerId || goldProviderId;
     goldIsFallback = quote.isFallback ?? quote.forcedState === 'fallback';
-    goldIsFresh =
-      snapshot?.freshness?.state === 'live' && quote.isFallback !== true && quote.isFresh !== false;
+    goldIsFresh = resolveGoldIsFresh(quote);
     cache.saveGoldPrice(quote.price, goldUpdatedAt);
     hideDataStatusBanner();
     renderHeroCard();
@@ -1275,11 +1275,15 @@ async function init() {
   cache.loadState(cacheState);
   ensureHeroLoadingSkeletons();
 
-  if (cacheState.goldPriceUsdPerOz) {
-    goldPrice = cacheState.goldPriceUsdPerOz;
-    dayOpenPrice = cacheState.dayOpenGoldPriceUsdPerOz;
-    rates = cacheState.rates;
-    goldUpdatedAt = cacheState.freshness?.goldUpdatedAt || null;
+  dayOpenPrice = cacheState.dayOpenGoldPriceUsdPerOz;
+  rates = cacheState.rates;
+
+  const bootGold = cache.getFreshBootGoldPrice();
+  if (bootGold?.price) {
+    goldPrice = bootGold.price;
+    goldUpdatedAt = bootGold.updatedAt || null;
+    goldIsFallback = true;
+    goldIsFresh = false;
   }
 
   applyLangToPage();

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -21,8 +21,10 @@ import * as fmt from '../lib/formatter.js';
 import { getMarketStatus, getLiveFreshness } from '../lib/live-status.js';
 import { createRealtimePricingEngine } from '../lib/realtime-pricing-engine.js';
 import { REALTIME_POLLING_DEFAULTS } from '../lib/realtime-config.js';
-import { PrimaryQuoteProvider } from '../lib/quote-providers/primary-provider.js';
-import { SecondaryQuoteProvider } from '../lib/quote-providers/secondary-provider.js';
+import {
+  createPrimaryQuoteProvider,
+  createSecondaryQuoteProvider,
+} from '../lib/quote-providers/create-providers.js';
 import { formatProviderLabel } from '../lib/provider-labels.js';
 import { updateTicker } from '../components/ticker.js';
 import { updateSpotBar } from '../components/spotBar.js';
@@ -981,17 +983,14 @@ function applyRealtimeSnapshot(snapshot) {
 function initRealtimeEngine() {
   if (_realtimeEngine) return;
 
-  const primaryProvider = new PrimaryQuoteProvider({ timeoutMs: 5000 });
-  const secondaryProvider = new SecondaryQuoteProvider({ timeoutMs: 5000 });
-
   _realtimeEngine = createRealtimePricingEngine({
-    primaryProvider,
-    secondaryProvider,
+    primaryProvider: createPrimaryQuoteProvider(),
+    secondaryProvider: createSecondaryQuoteProvider(),
     config: REALTIME_POLLING_DEFAULTS,
     debug: new URLSearchParams(location.search).get('debugFreshness') === '1',
   });
 
-  const cacheBoot = cache.getFallbackGoldPrice();
+  const cacheBoot = cache.getFreshBootGoldPrice();
   if (cacheBoot) {
     _realtimeEngine.seedFromCache({
       price: cacheBoot.price,

--- a/src/pages/tracker-pro.js
+++ b/src/pages/tracker-pro.js
@@ -9,6 +9,7 @@ import {
   createPrimaryQuoteProvider,
   createSecondaryQuoteProvider,
 } from '../lib/quote-providers/create-providers.js';
+import { resolveGoldIsFresh } from '../lib/quote-freshness-bridge.js';
 import { formatProviderLabel } from '../lib/provider-labels.js';
 import { createInitialState, persistState } from '../tracker/state.js';
 import { el as safeEl } from '../lib/safe-dom.js';
@@ -1189,10 +1190,7 @@ function applyRealtimeSnapshot(snapshot) {
       providerId: quote.providerId,
       source: quote.source || quote.providerId,
       status: snapshot?.freshness?.state || quote.status || 'cached',
-      isFresh:
-        snapshot?.freshness?.state === 'live' &&
-        quote.isFallback !== true &&
-        quote.isFresh !== false,
+      isFresh: resolveGoldIsFresh(quote),
       isFallback: quote.isFallback ?? null,
       freshnessSeconds: quote.freshnessSeconds ?? null,
       sourceTimestamp: quote.providerTimestamp ?? null,

--- a/src/pages/tracker-pro.js
+++ b/src/pages/tracker-pro.js
@@ -1189,7 +1189,10 @@ function applyRealtimeSnapshot(snapshot) {
       providerId: quote.providerId,
       source: quote.source || quote.providerId,
       status: snapshot?.freshness?.state || quote.status || 'cached',
-      isFresh: quote.isFresh ?? null,
+      isFresh:
+        snapshot?.freshness?.state === 'live' &&
+        quote.isFallback !== true &&
+        quote.isFresh !== false,
       isFallback: quote.isFallback ?? null,
       freshnessSeconds: quote.freshnessSeconds ?? null,
       sourceTimestamp: quote.providerTimestamp ?? null,

--- a/src/pages/tracker-pro.js
+++ b/src/pages/tracker-pro.js
@@ -1191,7 +1191,7 @@ function applyRealtimeSnapshot(snapshot) {
       source: quote.source || quote.providerId,
       status: snapshot?.freshness?.state || quote.status || 'cached',
       isFresh: resolveGoldIsFresh(quote),
-      isFallback: quote.isFallback ?? null,
+      isFallback: quote.isFallback ?? quote.forcedState === 'fallback',
       freshnessSeconds: quote.freshnessSeconds ?? null,
       sourceTimestamp: quote.providerTimestamp ?? null,
       raw: quote.providerRaw || quote,

--- a/src/pages/tracker-pro.js
+++ b/src/pages/tracker-pro.js
@@ -5,8 +5,10 @@ import * as cache from '../lib/cache.js';
 import '../lib/reveal.js';
 import { createRealtimePricingEngine } from '../lib/realtime-pricing-engine.js';
 import { REALTIME_POLLING_DEFAULTS } from '../lib/realtime-config.js';
-import { PrimaryQuoteProvider } from '../lib/quote-providers/primary-provider.js';
-import { SecondaryQuoteProvider } from '../lib/quote-providers/secondary-provider.js';
+import {
+  createPrimaryQuoteProvider,
+  createSecondaryQuoteProvider,
+} from '../lib/quote-providers/create-providers.js';
 import { formatProviderLabel } from '../lib/provider-labels.js';
 import { createInitialState, persistState } from '../tracker/state.js';
 import { el as safeEl } from '../lib/safe-dom.js';
@@ -1224,13 +1226,13 @@ function initRealtimeEngine() {
   if (realtimeEngine) return;
 
   realtimeEngine = createRealtimePricingEngine({
-    primaryProvider: new PrimaryQuoteProvider({ timeoutMs: 5000 }),
-    secondaryProvider: new SecondaryQuoteProvider({ timeoutMs: 5000 }),
+    primaryProvider: createPrimaryQuoteProvider(),
+    secondaryProvider: createSecondaryQuoteProvider(),
     config: REALTIME_POLLING_DEFAULTS,
     debug: new URLSearchParams(location.search).get('debugFreshness') === '1',
   });
 
-  const cacheBoot = cache.getFallbackGoldPrice();
+  const cacheBoot = cache.getFreshBootGoldPrice();
   if (cacheBoot) {
     realtimeEngine.seedFromCache({
       price: cacheBoot.price,
@@ -1481,12 +1483,14 @@ async function init() {
     rates: state.rates,
     lang: state.lang,
   });
-  ['tracker-inline-calc-weight', 'tracker-inline-calc-karat', 'tracker-inline-calc-currency'].forEach(
-    (id) => {
-      document.getElementById(id)?.addEventListener('input', syncInlineCalcCalculatorLink);
-      document.getElementById(id)?.addEventListener('change', syncInlineCalcCalculatorLink);
-    }
-  );
+  [
+    'tracker-inline-calc-weight',
+    'tracker-inline-calc-karat',
+    'tracker-inline-calc-currency',
+  ].forEach((id) => {
+    document.getElementById(id)?.addEventListener('input', syncInlineCalcCalculatorLink);
+    document.getElementById(id)?.addEventListener('change', syncInlineCalcCalculatorLink);
+  });
   syncInlineCalcCalculatorLink();
   renderTrackerAddonPanels();
   initRealtimeEngine();

--- a/tests/cache-gold-newest.test.js
+++ b/tests/cache-gold-newest.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadCache() {
+  const url = new URL('file://' + path.resolve(__dirname, '..', 'src', 'lib', 'cache.js'));
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+function installLocalStorage() {
+  const store = new Map();
+  global.localStorage = {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => store.set(key, value),
+    removeItem: (key) => store.delete(key),
+    clear: () => store.clear(),
+  };
+  return store;
+}
+
+beforeEach(() => {
+  installLocalStorage();
+});
+
+afterEach(() => {
+  delete global.localStorage;
+});
+
+test('getFallbackGoldPrice returns the newest entry between primary and fallback slots', async () => {
+  const constantsUrl = 'file://' + path.resolve(__dirname, '..', 'src', 'config', 'constants.js');
+  const { CONSTANTS } = await import(constantsUrl + `?v=${Date.now()}`);
+  const { getFallbackGoldPrice } = await loadCache();
+
+  const old = {
+    price: 2000,
+    updatedAt: '2026-05-28T10:00:00.000Z',
+    fetchedAt: Date.parse('2026-05-28T10:00:00.000Z'),
+  };
+  const recent = {
+    price: 4448,
+    updatedAt: '2026-06-05T12:00:00.000Z',
+    fetchedAt: Date.parse('2026-06-05T12:00:00.000Z'),
+  };
+
+  localStorage.setItem(CONSTANTS.CACHE_KEYS.goldFallback, JSON.stringify(old));
+  localStorage.setItem(CONSTANTS.CACHE_KEYS.goldPrice, JSON.stringify(recent));
+
+  const picked = getFallbackGoldPrice();
+  assert.equal(picked.price, 4448);
+});
+
+test('getFreshBootGoldPrice rejects cache older than stale threshold', async () => {
+  const constantsUrl = 'file://' + path.resolve(__dirname, '..', 'src', 'config', 'constants.js');
+  const { CONSTANTS } = await import(constantsUrl + `?v=${Date.now()}`);
+  const { getFreshBootGoldPrice } = await loadCache();
+
+  const stale = {
+    price: 2000,
+    updatedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+    fetchedAt: Date.now() - 7 * 24 * 60 * 60 * 1000,
+  };
+  localStorage.setItem(CONSTANTS.CACHE_KEYS.goldPrice, JSON.stringify(stale));
+
+  assert.equal(getFreshBootGoldPrice(), null);
+});
+
+test('getFreshBootGoldPrice accepts recent cache for instant boot paint', async () => {
+  const constantsUrl = 'file://' + path.resolve(__dirname, '..', 'src', 'config', 'constants.js');
+  const { CONSTANTS } = await import(constantsUrl + `?v=${Date.now()}`);
+  const { getFreshBootGoldPrice } = await loadCache();
+
+  const fresh = {
+    price: 4448,
+    updatedAt: new Date(Date.now() - 60_000).toISOString(),
+    fetchedAt: Date.now() - 60_000,
+  };
+  localStorage.setItem(CONSTANTS.CACHE_KEYS.goldPrice, JSON.stringify(fresh));
+
+  const boot = getFreshBootGoldPrice();
+  assert.equal(boot.price, 4448);
+});

--- a/tests/chained-quote-provider.test.js
+++ b/tests/chained-quote-provider.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadChained() {
+  const url = new URL(
+    'file://' +
+      path.resolve(__dirname, '..', 'src', 'lib', 'quote-providers', 'chained-provider.js')
+  );
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+test('ChainedQuoteProvider fails over to the second provider', async () => {
+  const { ChainedQuoteProvider } = await loadChained();
+
+  const primary = {
+    providerId: 'failing',
+    async fetchQuote() {
+      throw new Error('primary down');
+    },
+  };
+  const secondary = {
+    providerId: 'gold_api_com',
+    async fetchQuote() {
+      return {
+        price: 4448,
+        providerTimestamp: new Date().toISOString(),
+        fetchedAt: new Date().toISOString(),
+        providerId: 'gold_api_com',
+        source: 'gold_api_com',
+        providerPathSuccessful: true,
+      };
+    },
+  };
+
+  const chain = new ChainedQuoteProvider({
+    providerId: 'live-primary',
+    providers: [primary, secondary],
+  });
+
+  const quote = await chain.fetchQuote();
+  assert.equal(quote.price, 4448);
+  assert.equal(quote.providerId, 'gold_api_com');
+});
+
+test('ChainedQuoteProvider throws when every provider fails', async () => {
+  const { ChainedQuoteProvider } = await loadChained();
+
+  const chain = new ChainedQuoteProvider({
+    providers: [
+      {
+        providerId: 'a',
+        async fetchQuote() {
+          throw new Error('a down');
+        },
+      },
+      {
+        providerId: 'b',
+        async fetchQuote() {
+          throw new Error('b down');
+        },
+      },
+    ],
+  });
+
+  await assert.rejects(() => chain.fetchQuote());
+});

--- a/tests/gold-api-com-provider.test.js
+++ b/tests/gold-api-com-provider.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadProvider() {
+  const url = new URL(
+    'file://' +
+      path.resolve(__dirname, '..', 'src', 'lib', 'quote-providers', 'gold-api-com-provider.js')
+  );
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return {
+        price: 4446.2,
+        updatedAt: '2026-06-05T12:43:23Z',
+        symbol: 'XAU',
+      };
+    },
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+test('GoldApiComQuoteProvider parses live API response', async () => {
+  const { GoldApiComQuoteProvider } = await loadProvider();
+  const provider = new GoldApiComQuoteProvider();
+
+  const quote = await provider.fetchQuote({ timeoutMs: 3000 });
+
+  assert.equal(quote.providerId, 'gold_api_com');
+  assert.equal(quote.price, 4446.2);
+  assert.equal(quote.providerTimestamp, '2026-06-05T12:43:23Z');
+  assert.equal(quote.providerPathSuccessful, true);
+  assert.equal(quote.isFallback, false);
+});
+
+test('GoldApiComQuoteProvider rejects out-of-range prices', async () => {
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return { price: 50, updatedAt: new Date().toISOString() };
+    },
+  });
+
+  const { GoldApiComQuoteProvider } = await loadProvider();
+  const provider = new GoldApiComQuoteProvider();
+
+  await assert.rejects(() => provider.fetchQuote({ timeoutMs: 3000 }));
+});

--- a/tests/last-gold-price-parse.test.js
+++ b/tests/last-gold-price-parse.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadParse() {
+  const url = new URL(
+    'file://' +
+      path.resolve(__dirname, '..', 'src', 'lib', 'quote-providers', 'last-gold-price-parse.js')
+  );
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+test('parseLastGoldPriceSnapshot reads canonical schema', async () => {
+  const { parseLastGoldPriceSnapshot } = await loadParse();
+  const parsed = parseLastGoldPriceSnapshot({
+    price: 4448,
+    posted_at_utc: '2026-06-05T12:42:19Z',
+  });
+  assert.equal(parsed.price, 4448);
+  assert.equal(parsed.providerTimestamp, '2026-06-05T12:42:19Z');
+});
+
+test('parseLastGoldPriceSnapshot reads legacy nested schema', async () => {
+  const { parseLastGoldPriceSnapshot } = await loadParse();
+  const parsed = parseLastGoldPriceSnapshot({
+    gold: { ounce_usd: 2300 },
+    timestamp_utc: '2026-06-01T10:00:00Z',
+  });
+  assert.equal(parsed.price, 2300);
+});

--- a/tests/last-gold-price-provider.test.js
+++ b/tests/last-gold-price-provider.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadProvider() {
+  const url = new URL(
+    'file://' +
+      path.resolve(__dirname, '..', 'src', 'lib', 'quote-providers', 'last-gold-price-provider.js')
+  );
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return {
+        price: 4448,
+        posted_at_utc: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      };
+    },
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+test('LastGoldPriceQuoteProvider reads recent canonical snapshot', async () => {
+  const { LastGoldPriceQuoteProvider } = await loadProvider();
+  const provider = new LastGoldPriceQuoteProvider();
+  const quote = await provider.fetchQuote({ timeoutMs: 3000 });
+
+  assert.equal(quote.price, 4448);
+  assert.equal(quote.providerId, 'last-gold-price');
+  assert.equal(quote.isFallback, false);
+  assert.equal(quote.providerPathSuccessful, true);
+});
+
+test('LastGoldPriceQuoteProvider rejects stale snapshot', async () => {
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return {
+        price: 4448,
+        posted_at_utc: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+      };
+    },
+  });
+
+  const { LastGoldPriceQuoteProvider } = await loadProvider();
+  const provider = new LastGoldPriceQuoteProvider();
+
+  await assert.rejects(() => provider.fetchQuote({ timeoutMs: 3000 }));
+});

--- a/tests/live-provider-chain.test.js
+++ b/tests/live-provider-chain.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadFactory() {
+  const url = new URL(
+    'file://' +
+      path.resolve(__dirname, '..', 'src', 'lib', 'quote-providers', 'create-providers.js')
+  );
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+test('createPrimaryQuoteProvider chains four live/file sources', async () => {
+  const { createPrimaryQuoteProvider } = await loadFactory();
+  const chain = createPrimaryQuoteProvider();
+  assert.equal(chain.providerId, 'live-primary');
+  assert.equal(chain.providers.length, 4);
+  assert.equal(chain.providers[0].providerId, 'gold_api_com');
+  assert.equal(chain.providers[1].providerId, 'minted_metal');
+  assert.equal(chain.providers[2].providerId, 'primary-provider');
+  assert.equal(chain.providers[3].providerId, 'last-gold-price');
+});
+
+test('createPrimaryQuoteProvider fails over through the chain', async () => {
+  const { createPrimaryQuoteProvider } = await loadFactory();
+  const chain = createPrimaryQuoteProvider();
+
+  chain.providers[0].fetchQuote = async () => {
+    throw new Error('gold-api down');
+  };
+  chain.providers[1].fetchQuote = async () => ({
+    price: 4496.95,
+    providerTimestamp: new Date().toISOString(),
+    fetchedAt: new Date().toISOString(),
+    providerId: 'minted_metal',
+    source: 'minted_metal',
+    providerPathSuccessful: true,
+    isFresh: null,
+    isFallback: false,
+  });
+
+  const quote = await chain.fetchQuote();
+  assert.equal(quote.price, 4496.95);
+  assert.equal(quote.providerId, 'minted_metal');
+});

--- a/tests/minted-metal-provider.test.js
+++ b/tests/minted-metal-provider.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadProvider() {
+  const url = new URL(
+    'file://' +
+      path.resolve(__dirname, '..', 'src', 'lib', 'quote-providers', 'minted-metal-provider.js')
+  );
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return {
+        updatedAt: '2026-06-05T13:50:37.227Z',
+        metals: {
+          gold: {
+            price: 4496.95,
+            fixedAt: '2026-06-04T15:00:00Z',
+            currency: 'USD',
+            unit: 'troy oz',
+          },
+        },
+      };
+    },
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+test('MintedMetalQuoteProvider parses LBMA reference JSON', async () => {
+  const { MintedMetalQuoteProvider } = await loadProvider();
+  const provider = new MintedMetalQuoteProvider();
+  const quote = await provider.fetchQuote({ timeoutMs: 3000 });
+
+  assert.equal(quote.providerId, 'minted_metal');
+  assert.equal(quote.price, 4496.95);
+  assert.equal(quote.providerTimestamp, '2026-06-04T15:00:00Z');
+  assert.equal(quote.providerPathSuccessful, true);
+  assert.equal(quote.isFallback, false);
+  assert.equal(quote.isFresh, null);
+});

--- a/tests/quote-freshness-bridge.test.js
+++ b/tests/quote-freshness-bridge.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadBridge() {
+  const url = new URL(
+    'file://' + path.resolve(__dirname, '..', 'src', 'lib', 'quote-freshness-bridge.js')
+  );
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+async function loadLiveStatus() {
+  const url = new URL('file://' + path.resolve(__dirname, '..', 'src', 'lib', 'live-status.js'));
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+test('resolveGoldIsFresh returns null for normal live API quote (age classification deferred)', async () => {
+  const { resolveGoldIsFresh } = await loadBridge();
+  assert.equal(resolveGoldIsFresh({ isFresh: true, isFallback: false }), true);
+  assert.equal(resolveGoldIsFresh({ isFresh: null, isFallback: false }), null);
+  assert.equal(resolveGoldIsFresh({ isFallback: true }), false);
+  assert.equal(resolveGoldIsFresh({ isFresh: false }), false);
+});
+
+test('15s old quote with isFresh null shows Live via getLiveFreshness (not Stale)', async () => {
+  const { resolveGoldIsFresh } = await loadBridge();
+  const { getLiveFreshness } = await loadLiveStatus();
+
+  const updatedAt = new Date(Date.now() - 15_000).toISOString();
+  const quote = { isFallback: false, isFresh: true };
+  const isFresh = resolveGoldIsFresh(quote);
+  const freshness = getLiveFreshness({
+    updatedAt,
+    isFresh,
+    isFallback: quote.isFallback,
+    hasLiveFailure: false,
+  });
+
+  assert.equal(isFresh, true);
+  assert.equal(freshness.key, 'live');
+  assert.notEqual(freshness.reason, 'upstream-stale');
+});
+
+test('engine cached state must not force isFresh false', async () => {
+  const { resolveGoldIsFresh } = await loadBridge();
+  const { getLiveFreshness } = await loadLiveStatus();
+
+  const updatedAt = new Date(Date.now() - 15_000).toISOString();
+  const isFresh = resolveGoldIsFresh({ isFresh: null, isFallback: false });
+  const freshness = getLiveFreshness({ updatedAt, isFresh, isFallback: false });
+
+  assert.equal(freshness.key, 'live');
+});

--- a/tests/realtime-poll-interval.test.js
+++ b/tests/realtime-poll-interval.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadModule() {
+  const url = new URL(
+    'file://' + path.resolve(__dirname, '..', 'src', 'lib', 'realtime-poll-interval.js')
+  );
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+test('resolveProviderPollMs uses 1s for gold-api.com when tab visible', async () => {
+  const { resolveProviderPollMs } = await loadModule();
+  assert.equal(resolveProviderPollMs('gold_api_com', { livePollMs: 1000, visible: true }), 1000);
+});
+
+test('resolveProviderPollMs slows static JSON providers to 30s', async () => {
+  const { resolveProviderPollMs } = await loadModule();
+  assert.equal(
+    resolveProviderPollMs('primary-provider', { staticPollMs: 30_000, visible: true }),
+    30_000
+  );
+  assert.equal(
+    resolveProviderPollMs('minted_metal', { staticPollMs: 30_000, visible: true }),
+    30_000
+  );
+});
+
+test('resolveProviderPollMs slows cache fallback to 60s', async () => {
+  const { resolveProviderPollMs } = await loadModule();
+  assert.equal(
+    resolveProviderPollMs('secondary-provider-cache', { fallbackPollMs: 60_000, visible: true }),
+    60_000
+  );
+});
+
+test('resolveProviderPollMs uses hiddenPollMs when tab is hidden', async () => {
+  const { resolveProviderPollMs } = await loadModule();
+  assert.equal(
+    resolveProviderPollMs('gold_api_com', {
+      livePollMs: 1000,
+      hiddenPollMs: 20_000,
+      visible: false,
+    }),
+    20_000
+  );
+});
+
+test('resolveProviderPollMs defaults to activePollMs before first quote', async () => {
+  const { resolveProviderPollMs } = await loadModule();
+  assert.equal(resolveProviderPollMs(null, { activePollMs: 1000, visible: true }), 1000);
+});

--- a/tests/secondary-provider-stale.test.js
+++ b/tests/secondary-provider-stale.test.js
@@ -49,6 +49,23 @@ test('SecondaryQuoteProvider rejects multi-day-old localStorage cache', async ()
   await assert.rejects(() => provider.fetchQuote());
 });
 
+test('SecondaryQuoteProvider aborts slow last snapshot fetch within timeoutMs', async () => {
+  global.fetch = (_url, options) =>
+    new Promise((resolve, reject) => {
+      const onAbort = () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+      if (options?.signal?.aborted) onAbort();
+      else options?.signal?.addEventListener('abort', onAbort, { once: true });
+    });
+
+  const { SecondaryQuoteProvider } = await loadSecondary();
+  const provider = new SecondaryQuoteProvider();
+
+  const started = Date.now();
+  await assert.rejects(() => provider.fetchQuote({ timeoutMs: 50 }));
+  const elapsed = Date.now() - started;
+  assert.ok(elapsed < 500, `expected abort near timeout, took ${elapsed}ms`);
+});
+
 test('SecondaryQuoteProvider accepts recent localStorage cache as fallback', async () => {
   installLocalStorage({
     price: 4448,

--- a/tests/secondary-provider-stale.test.js
+++ b/tests/secondary-provider-stale.test.js
@@ -66,6 +66,47 @@ test('SecondaryQuoteProvider aborts slow last snapshot fetch within timeoutMs', 
   assert.ok(elapsed < 500, `expected abort near timeout, took ${elapsed}ms`);
 });
 
+test('parseLastGoldPriceSnapshot reads canonical last_gold_price.json schema', async () => {
+  const { parseLastGoldPriceSnapshot } = await loadSecondary();
+  const parsed = parseLastGoldPriceSnapshot({
+    price: 4448,
+    posted_at_utc: '2026-06-05T12:42:19Z',
+    content_hash: 'abc',
+  });
+  assert.equal(parsed.price, 4448);
+  assert.equal(parsed.providerTimestamp, '2026-06-05T12:42:19Z');
+});
+
+test('parseLastGoldPriceSnapshot reads legacy nested gold.ounce_usd schema', async () => {
+  const { parseLastGoldPriceSnapshot } = await loadSecondary();
+  const parsed = parseLastGoldPriceSnapshot({
+    gold: { ounce_usd: 2300 },
+    timestamp_utc: '2026-06-01T10:00:00Z',
+  });
+  assert.equal(parsed.price, 2300);
+  assert.equal(parsed.providerTimestamp, '2026-06-01T10:00:00Z');
+});
+
+test('SecondaryQuoteProvider accepts recent last_gold_price.json file fallback', async () => {
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return {
+        price: 4448,
+        posted_at_utc: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      };
+    },
+  });
+
+  const { SecondaryQuoteProvider } = await loadSecondary();
+  const provider = new SecondaryQuoteProvider();
+  const quote = await provider.fetchQuote();
+
+  assert.equal(quote.price, 4448);
+  assert.equal(quote.isFallback, true);
+});
+
 test('SecondaryQuoteProvider accepts recent localStorage cache as fallback', async () => {
   installLocalStorage({
     price: 4448,

--- a/tests/secondary-provider-stale.test.js
+++ b/tests/secondary-provider-stale.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadSecondary() {
+  const url = new URL(
+    'file://' +
+      path.resolve(__dirname, '..', 'src', 'lib', 'quote-providers', 'secondary-provider.js')
+  );
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+const originalFetch = global.fetch;
+
+function installLocalStorage(payload) {
+  const store = new Map();
+  if (payload) {
+    store.set('gold_price_cache', JSON.stringify(payload));
+  }
+  global.localStorage = {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => store.set(key, value),
+    removeItem: (key) => store.delete(key),
+    clear: () => store.clear(),
+  };
+}
+
+beforeEach(() => {
+  global.fetch = async () => ({ ok: false, status: 404 });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  delete global.localStorage;
+});
+
+test('SecondaryQuoteProvider rejects multi-day-old localStorage cache', async () => {
+  installLocalStorage({
+    price: 2000,
+    updatedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+    fetchedAt: Date.now() - 7 * 24 * 60 * 60 * 1000,
+  });
+
+  const { SecondaryQuoteProvider } = await loadSecondary();
+  const provider = new SecondaryQuoteProvider();
+
+  await assert.rejects(() => provider.fetchQuote());
+});
+
+test('SecondaryQuoteProvider accepts recent localStorage cache as fallback', async () => {
+  installLocalStorage({
+    price: 4448,
+    updatedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    fetchedAt: Date.now() - 5 * 60 * 1000,
+  });
+
+  const { SecondaryQuoteProvider } = await loadSecondary();
+  const provider = new SecondaryQuoteProvider();
+
+  const quote = await provider.fetchQuote();
+  assert.equal(quote.price, 4448);
+  assert.equal(quote.isFallback, true);
+  assert.equal(quote.providerPathSuccessful, false);
+});

--- a/tests/secondary-provider-stale.test.js
+++ b/tests/secondary-provider-stale.test.js
@@ -12,8 +12,6 @@ async function loadSecondary() {
   return import(url.href + `?v=${Date.now()}`);
 }
 
-const originalFetch = global.fetch;
-
 function installLocalStorage(payload) {
   const store = new Map();
   if (payload) {
@@ -27,12 +25,7 @@ function installLocalStorage(payload) {
   };
 }
 
-beforeEach(() => {
-  global.fetch = async () => ({ ok: false, status: 404 });
-});
-
 afterEach(() => {
-  global.fetch = originalFetch;
   delete global.localStorage;
 });
 
@@ -47,64 +40,6 @@ test('SecondaryQuoteProvider rejects multi-day-old localStorage cache', async ()
   const provider = new SecondaryQuoteProvider();
 
   await assert.rejects(() => provider.fetchQuote());
-});
-
-test('SecondaryQuoteProvider aborts slow last snapshot fetch within timeoutMs', async () => {
-  global.fetch = (_url, options) =>
-    new Promise((resolve, reject) => {
-      const onAbort = () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
-      if (options?.signal?.aborted) onAbort();
-      else options?.signal?.addEventListener('abort', onAbort, { once: true });
-    });
-
-  const { SecondaryQuoteProvider } = await loadSecondary();
-  const provider = new SecondaryQuoteProvider();
-
-  const started = Date.now();
-  await assert.rejects(() => provider.fetchQuote({ timeoutMs: 50 }));
-  const elapsed = Date.now() - started;
-  assert.ok(elapsed < 500, `expected abort near timeout, took ${elapsed}ms`);
-});
-
-test('parseLastGoldPriceSnapshot reads canonical last_gold_price.json schema', async () => {
-  const { parseLastGoldPriceSnapshot } = await loadSecondary();
-  const parsed = parseLastGoldPriceSnapshot({
-    price: 4448,
-    posted_at_utc: '2026-06-05T12:42:19Z',
-    content_hash: 'abc',
-  });
-  assert.equal(parsed.price, 4448);
-  assert.equal(parsed.providerTimestamp, '2026-06-05T12:42:19Z');
-});
-
-test('parseLastGoldPriceSnapshot reads legacy nested gold.ounce_usd schema', async () => {
-  const { parseLastGoldPriceSnapshot } = await loadSecondary();
-  const parsed = parseLastGoldPriceSnapshot({
-    gold: { ounce_usd: 2300 },
-    timestamp_utc: '2026-06-01T10:00:00Z',
-  });
-  assert.equal(parsed.price, 2300);
-  assert.equal(parsed.providerTimestamp, '2026-06-01T10:00:00Z');
-});
-
-test('SecondaryQuoteProvider accepts recent last_gold_price.json file fallback', async () => {
-  global.fetch = async () => ({
-    ok: true,
-    status: 200,
-    async json() {
-      return {
-        price: 4448,
-        posted_at_utc: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
-      };
-    },
-  });
-
-  const { SecondaryQuoteProvider } = await loadSecondary();
-  const provider = new SecondaryQuoteProvider();
-  const quote = await provider.fetchQuote();
-
-  assert.equal(quote.price, 4448);
-  assert.equal(quote.isFallback, true);
 });
 
 test('SecondaryQuoteProvider accepts recent localStorage cache as fallback', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Fixes homepage `Stale · SecondaryProvider · Updated: 6 days ago` and delivers **1-second live price updates** when gold-api.com is the active source, with a **5-tier provider waterfall** and adaptive polling for static fallbacks.

## Why

- Primary only read hourly static JSON; secondary served unbounded-old localStorage
- `getFallbackGoldPrice()` preferred the older cache slot
- `goldIsFresh` regression mapped engine 10 s SLA state to UI `Stale` for normal 15 s quotes
- First paint flashed ancient localStorage without age gate
- 5 s polling felt sluggish for a live gold ticker

## How — 5-tier waterfall + adaptive cadence

| # | Provider | Source | Poll when active |
|---|----------|--------|------------------|
| 1 | `gold_api_com` | `https://api.gold-api.com/price/XAU` | **1 s** |
| 2 | `minted_metal` | LBMA CORS JSON | 30 s |
| 3 | `primary-provider` | `/data/gold_price.json` | 30 s |
| 4 | `last-gold-price` | `/data/last_gold_price.json` (≤ 75 min) | 30 s |
| 5 | `secondary-provider-cache` | localStorage (≤ 75 min) | 60 s |

**Freshness bridge:** `resolveGoldIsFresh()` — UI uses `getLiveFreshness()` age thresholds, not engine SLA state.

**Cadence:** 1 s live / 20 s hidden tab. UI age label ticks every 1 s. Exponential backoff on failures (from 2 s).

## Proof

```bash
npm test   # 1095/1095 pass
npm run validate  # green
```

Key tests: `realtime-poll-interval`, `quote-freshness-bridge`, `live-provider-chain`, `realtime-fallback-integration`.

## Risks

- gold-api.com quota at 1 s/tab — adaptive slowdown when chain falls to static sources; backoff on 429
- mintedmetal is twice-daily LBMA — labelled honestly via age thresholds
- No API keys in client bundle (keyed providers stay server-side)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb266971-d6df-4b04-a55f-908e570087eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb266971-d6df-4b04-a55f-908e570087eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

