### PR TITLE
fix: code-review handoff regressions and pricing engine guards

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -57,6 +57,16 @@ export default [
         exports: 'writable',
         global: 'readonly',
         Buffer: 'readonly',
+        AbortController: 'readonly',
+        AbortSignal: 'readonly',
+        Blob: 'readonly',
+        FileReader: 'readonly',
+        FormData: 'readonly',
+        Node: 'readonly',
+        Notification: 'readonly',
+        crypto: 'readonly',
+        requestIdleCallback: 'readonly',
+        structuredClone: 'readonly',
       },
     },
     rules: {
@@ -84,6 +94,7 @@ export default [
     // Track A #6.
     files: ['src/**/*.js', 'src/**/*.mjs'],
     rules: {
+      'no-undef': 'error',
       'no-restricted-imports': [
         'error',
         {

--- a/src/lib/cross-page-links.js
+++ b/src/lib/cross-page-links.js
@@ -17,12 +17,17 @@ export function countryForCurrency(currency, countries = []) {
 }
 
 /**
- * @param {{ countryCode?: string }} [options]
+ * @param {{ countryCode?: string, lang?: 'en'|'ar', base?: string }} [options]
  * @returns {string}
  */
-export function buildShopsHref({ countryCode } = {}) {
-  if (!countryCode) return 'shops.html';
-  return `shops.html?country=${encodeURIComponent(countryCode)}`;
+export function buildShopsHref({ countryCode, lang, base = 'shops.html' } = {}) {
+  const params = new URLSearchParams();
+  const code = String(countryCode || '').trim();
+  if (code) params.set('country', code.toUpperCase());
+  if (lang === 'ar') params.set('lang', 'ar');
+  else if (lang === 'en' && code) params.set('lang', 'en');
+  const qs = params.toString();
+  return qs ? `${base}?${qs}` : base;
 }
 
 /**

--- a/src/lib/page-handoff.js
+++ b/src/lib/page-handoff.js
@@ -3,6 +3,8 @@
  * Keeps hash/query shapes consistent across surfaces.
  */
 
+import { buildShopsHref } from './cross-page-links.js';
+
 const ALLOWED_TRACKER_MODE = new Set(['live', 'compare', 'archive', 'exports', 'method']);
 const ALLOWED_K = new Set(['24', '22', '21', '20', '18', '16', '14']);
 const ALLOWED_U = new Set(['gram', 'tola', 'oz', 'kg']);
@@ -47,11 +49,7 @@ export function buildTrackerHandoffUrl({
  * @param {string} [options.base]
  */
 export function buildShopsHandoffUrl({ countryCode, lang, base = 'shops.html' } = {}) {
-  const params = new URLSearchParams();
-  if (countryCode) params.set('country', String(countryCode).toUpperCase());
-  if (lang === 'ar' || lang === 'en') params.set('lang', lang);
-  const qs = params.toString();
-  return qs ? `${base}?${qs}` : base;
+  return buildShopsHref({ countryCode, lang, base });
 }
 
 /** Homepage anchors that should inherit the default live-tracker handoff (unit + lang). */

--- a/src/lib/quote-providers/primary-provider.js
+++ b/src/lib/quote-providers/primary-provider.js
@@ -15,7 +15,7 @@ export class PrimaryQuoteProvider extends BaseQuoteProvider {
       price: data.price,
       providerTimestamp: data.sourceTimestamp || data.updatedAt,
       fetchedAt: data.updatedAt || new Date().toISOString(),
-      providerId: data.source || this.providerId,
+      providerId: this.providerId,
       source: data.source || this.providerId,
       providerRaw: data.raw || null,
       providerPathSuccessful: data.source !== 'cache-fallback',

--- a/src/lib/realtime-pricing-engine.js
+++ b/src/lib/realtime-pricing-engine.js
@@ -250,6 +250,14 @@ export function createRealtimePricingEngine({
       state.metrics.staleLivePrevented += 1;
       emit('STALE_LIVE_PREVENTED', { ageMs, providerId: state.activeProviderId }, 'warning');
       state.rolling.staleContradictions.push({ at: now, ageMs, prevented: true });
+      const providerStatus = health.getSnapshot(state.activeProviderId);
+      fresh = evaluateFreshnessState({
+        ageMs,
+        providerHealthy: providerStatus.healthy,
+        providerPathSuccessful: state.quote?.providerPathSuccessful !== false,
+        forcedState: state.quote?.forcedState || (state.quote?.isFallback ? 'fallback' : null),
+        marketOpen: isMarketOpen(),
+      });
     }
 
     state.freshness = fresh;

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -341,24 +341,42 @@ function buildCountryPageHref(country) {
   return country?.slug ? `countries/${country.slug}/` : 'countries/index.html';
 }
 
-function updateShopsLink({ currency = 'AED' } = {}) {
-  const link = document.getElementById('calc-find-shops-link');
-  if (!link) return;
+let _shopsHandoffListenersBound = false;
+
+function updateShopsHandoff({ currency = 'AED' } = {}) {
+  if (!_shopsHandoffListenersBound) {
+    _shopsHandoffListenersBound = true;
+    const bindCurrencySelect = (id) => {
+      const select = document.getElementById(id);
+      if (!select) return;
+      const handler = () => updateShopsHandoff({ currency: select.value || 'AED' });
+      select.addEventListener('change', handler);
+      select.addEventListener('input', handler);
+    };
+    ['val-currency', 'scrap-currency', 'zakat-currency', 'buy-currency'].forEach(
+      bindCurrencySelect
+    );
+  }
+
   const country = getSelectedCountryContext(currency);
-  link.href = buildShopsHref({ countryCode: country?.code });
-  const countryName = country
-    ? STATE.lang === 'ar'
-      ? country.nameAr
-      : country.nameEn
-    : '';
-  link.textContent = countryName
-    ? tGlobal('calc.findShopsLinkCountry').replace('{country}', countryName)
-    : tGlobal('calc.findShopsLink');
+  const href = buildShopsHref({
+    countryCode: country?.code || '',
+    lang: STATE.lang,
+  });
+  for (const id of ['calc-find-shops-link', 'calc-related-shops-link']) {
+    const link = document.getElementById(id);
+    if (link) link.href = href;
+  }
+  const findLink = document.getElementById('calc-find-shops-link');
+  if (findLink) {
+    const countryName = country ? (STATE.lang === 'ar' ? country.nameAr : country.nameEn) : '';
+    findLink.textContent = countryName
+      ? tGlobal('calc.findShopsLinkCountry').replace('{country}', countryName)
+      : tGlobal('calc.findShopsLink');
+  }
 }
 
 function updateTrackerHandoff({ karat = '22', currency = 'AED' } = {}) {
-  updateShopsHandoff({ currency });
-
   const handoff = document.getElementById('calc-tracker-handoff');
   const trackerLink = document.getElementById('calc-tracker-link');
   const countryLink = document.getElementById('calc-country-link');
@@ -378,7 +396,7 @@ function updateTrackerHandoff({ karat = '22', currency = 'AED' } = {}) {
   mobileTrackerLink.href = href;
   handoff.hidden = false;
 
-  updateShopsLink({ currency });
+  updateShopsHandoff({ currency });
 
   const selectedCountry = getSelectedCountryContext(currency);
   if (countryLink) {
@@ -990,7 +1008,7 @@ function applyLang() {
   set('val-currency-hint', t('val_currency_hint'));
   set('val-result-label', t('val_result_label'));
   set('val-disclaimer', t('val_disclaimer'));
-  updateShopsLink({
+  updateShopsHandoff({
     currency: document.getElementById('val-currency')?.value || 'AED',
   });
   set('calc-scrap-h2', t('scrap_title'));
@@ -1585,10 +1603,7 @@ function populateKaratSelects() {
     select.replaceChildren(
       ...KARATS.map((k) => {
         const pct = (k.purity * 100).toFixed(1);
-        const label =
-          STATE.lang === 'ar'
-            ? `عيار ${k.code} (${pct}%)`
-            : `${k.code}K (${pct}%)`;
+        const label = STATE.lang === 'ar' ? `عيار ${k.code} (${pct}%)` : `${k.code}K (${pct}%)`;
         const opt = document.createElement('option');
         opt.value = k.code;
         opt.textContent = label;

--- a/src/pages/calculator/shops-handoff.js
+++ b/src/pages/calculator/shops-handoff.js
@@ -1,13 +1,5 @@
 /**
- * Build shops directory href with optional country filter (Calculator → Shops handoff).
- * @param {{ countryCode?: string, lang?: 'en'|'ar' }} [options]
- * @returns {string}
+ * Calculator → Shops handoff (re-exports canonical builder from cross-page-links).
+ * @deprecated Import buildShopsHref from `../../lib/cross-page-links.js` directly.
  */
-export function buildShopsHandoffHref({ countryCode = '', lang = 'en' } = {}) {
-  const params = new URLSearchParams();
-  const code = String(countryCode || '').trim().toUpperCase();
-  if (code) params.set('country', code);
-  if (lang === 'ar') params.set('lang', 'ar');
-  const qs = params.toString();
-  return qs ? `shops.html?${qs}` : 'shops.html';
-}
+export { buildShopsHref as buildShopsHandoffHref } from '../../lib/cross-page-links.js';

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -936,6 +936,19 @@ function applyLangToPage() {
 async function fetchLiveData() {
   if (!navigator.onLine) return;
   try {
+    if (_realtimeEngine) {
+      const fx = await api.fetchFX();
+      if (fx?.rates) {
+        rates = fx.rates ?? {};
+        cache.saveFXRates(rates, {
+          lastUpdateUtc: fx.time_last_update_utc,
+          nextUpdateUtc: fx.time_next_update_utc,
+        });
+        renderGCCGrid();
+      }
+      return;
+    }
+
     const { gold, fx } = await api.fetchGoldAndFX();
     if (fx?.rates) {
       rates = fx.rates ?? {};

--- a/src/tracker/chart.js
+++ b/src/tracker/chart.js
@@ -1,6 +1,6 @@
 // tracker/chart.js — historical chart rendering
 import { _state, _el, _currentSpot, tx, formatUsd, formatPercent } from './_ctx.js';
-import { clear, el } from '../lib/safe-dom.js';
+import { clear, el, setText } from '../lib/safe-dom.js';
 import {
   buildHistorySummary,
   describeHistoryResolution,

--- a/tests/cross-page-links.test.js
+++ b/tests/cross-page-links.test.js
@@ -41,6 +41,14 @@ test('buildShopsHref adds country query when code present', async () => {
   const mod = await loadModule();
   assert.equal(mod.buildShopsHref(), 'shops.html');
   assert.equal(mod.buildShopsHref({ countryCode: 'AE' }), 'shops.html?country=AE');
+  assert.equal(
+    mod.buildShopsHref({ countryCode: 'ae', lang: 'ar' }),
+    'shops.html?country=AE&lang=ar'
+  );
+  assert.equal(
+    mod.buildShopsHref({ countryCode: 'AE', lang: 'en' }),
+    'shops.html?country=AE&lang=en'
+  );
 });
 
 test('countryForCurrency returns first matching country', async () => {

--- a/tests/realtime-pricing-engine.test.js
+++ b/tests/realtime-pricing-engine.test.js
@@ -57,12 +57,14 @@ test('realtime engine enforces monotonic quote guard', async () => {
 test('realtime engine snapshot never labels stale quotes as live', async () => {
   const { createRealtimePricingEngine } = await loadEngine();
 
-  const staleTs = new Date(Date.now() - 15_000).toISOString();
+  const fixedNow = Date.parse('2026-06-09T12:00:00Z');
+  const staleTs = new Date(fixedNow - 15_000).toISOString();
   const primary = providerFrom([{ price: 3300, providerTimestamp: staleTs }]);
 
   const engine = createRealtimePricingEngine({
     primaryProvider: primary,
     config: { activePollMs: 999999, hiddenPollMs: 999999, jitterMs: 0 },
+    nowFn: () => fixedNow,
   });
 
   engine.start();

--- a/tests/realtime-pricing-engine.test.js
+++ b/tests/realtime-pricing-engine.test.js
@@ -54,6 +54,26 @@ test('realtime engine enforces monotonic quote guard', async () => {
   assert.equal(snapshot.metrics.monotonicGuardBlocks, 1);
 });
 
+test('realtime engine snapshot never labels stale quotes as live', async () => {
+  const { createRealtimePricingEngine } = await loadEngine();
+
+  const staleTs = new Date(Date.now() - 15_000).toISOString();
+  const primary = providerFrom([{ price: 3300, providerTimestamp: staleTs }]);
+
+  const engine = createRealtimePricingEngine({
+    primaryProvider: primary,
+    config: { activePollMs: 999999, hiddenPollMs: 999999, jitterMs: 0 },
+  });
+
+  engine.start();
+  await engine.refreshNow('stale-live-guard');
+  const snapshot = engine.getSnapshot();
+  engine.stop();
+
+  assert.notEqual(snapshot.freshness.state, 'live');
+  assert.ok(['cached', 'delayed', 'estimated', 'fallback'].includes(snapshot.freshness.state));
+});
+
 test('realtime engine triggers immediate visibility recovery refresh path', async () => {
   const { createRealtimePricingEngine } = await loadEngine();
   const primary = providerFrom([{ price: 3300, providerTimestamp: '2026-05-19T16:00:00Z' }]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Fixes all issues surfaced in the code review of recent cross-page handoff and realtime pricing work.

## Why

- **Calculator crash:** `updateTrackerHandoff()` called undefined `updateShopsHandoff()` — a merge artifact that broke tracker handoff on every currency/karat change.
- **Shops handoff incomplete:** `lang=ar` and `calc-related-shops-link` country filter were lost; `shops-handoff.js` was orphaned.
- **Polling waste:** `PrimaryQuoteProvider` used upstream `data.source` as `providerId`, causing hourly static JSON to poll at 1s.
- **Trust guard gap:** `STALE_LIVE_PREVENTED` logged but did not re-evaluate freshness before emitting snapshot.
- **Redundant fetches:** Homepage polled gold via both realtime engine and `fetchGoldAndFX()` every 90s.

## How

- Restored unified `updateShopsHandoff()` in `calculator.js` (both shop link IDs + currency select listeners).
- Extended `buildShopsHref()` in `cross-page-links.js` with `lang` + country normalization; `page-handoff.js` and `shops-handoff.js` delegate to it.
- `PrimaryQuoteProvider` always reports `providerId: 'primary-provider'`; upstream source stays in `source`.
- Realtime engine re-runs `evaluateFreshnessState` when stale-live guard fires.
- `home.js` `fetchLiveData()` fetches FX only when realtime engine is active.
- ESLint `no-undef` enabled for `src/**` with browser globals; fixed missing `setText` import in `tracker/chart.js`.

## Proof

- `npm test` — 1096/1096 pass
- `npm run validate` — green
- `npm run lint` — green (1 pre-existing `prefer-const` in `scripts/node/`)

## Risks

- Low: shops URL shape unchanged for EN default; `lang=ar` now correctly appended for Arabic calculator → shops flows.
- Poll cadence for static JSON path slows from 1s → 30s when gold-api.com is unavailable (intended).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8306883-7ef5-4318-bac6-82f345e76973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8306883-7ef5-4318-bac6-82f345e76973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

