### PR TITLE
fix(deps): align Dependabot labels with synced GitHub labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
-      - github-actions
+      - github_actions
     groups:
       github-actions:
         patterns:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -51,6 +51,10 @@
   color: '0366d6'
   description: Pull requests that update a dependency file
 
+- name: automated
+  color: bfdadc
+  description: Pull requests opened by Dependabot or other automation
+
 - name: github_actions
   color: '000000'
   description: Pull requests that update GitHub Actions code


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Adds the missing `automated` label to `.github/labels.yml`
- Fixes `.github/dependabot.yml` to use `github_actions` (underscore) instead of `github-actions` (hyphen), matching the existing label-sync convention

## Why
Dependabot warned on PRs #415–#417 that labels `automated` and `github-actions` could not be found. Only `dependencies` was applied.

## How
Labels are synced from `labels.yml` via `sync-labels.yml`; Dependabot config must reference exact label names.

## Proof
- PRs #415, #416, #417 merged successfully after rebase + chart v5 fix
- This is a config-only follow-up

## Risks
None — label metadata only; no runtime impact.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da31f6f2-116c-4e1a-aa54-627b30924c40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da31f6f2-116c-4e1a-aa54-627b30924c40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

