### PR TITLE
fix(i18n): preserve lang on country-page shops handoff

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,6 +67,7 @@ export default [
         crypto: 'readonly',
         requestIdleCallback: 'readonly',
         structuredClone: 'readonly',
+        CSS: 'readonly',
       },
     },
     rules: {

--- a/scripts/node/canonicalize-country-gold-price.js
+++ b/scripts/node/canonicalize-country-gold-price.js
@@ -29,7 +29,10 @@ function patchGoldPricePage(filePath, countrySlug) {
     '<meta name="robots" content="noindex,follow" />'
   );
   if (!/name=["']robots["']/i.test(html)) {
-    html = html.replace(/<meta charset="UTF-8"\s*\/?>/i, (m) => `${m}\n    <meta name="robots" content="noindex,follow" />`);
+    html = html.replace(
+      /<meta charset="UTF-8"\s*\/?>/i,
+      (m) => `${m}\n    <meta name="robots" content="noindex,follow" />`
+    );
   }
 
   html = html.replace(
@@ -75,7 +78,7 @@ walkCountries(path.join(ROOT, 'countries'));
 
 // Fix internal links in stub pages and other HTML under countries/
 function fixHtmlLinks(filePath) {
-  let html = fs.readFileSync(filePath, 'utf8');
+  const html = fs.readFileSync(filePath, 'utf8');
   const next = html.replace(/\/countries\/([a-z0-9-]+)\/gold-price\//g, '/countries/$1/');
   if (next !== html) {
     if (!dryRun) fs.writeFileSync(filePath, next, 'utf8');

--- a/src/lib/page-hydrator.js
+++ b/src/lib/page-hydrator.js
@@ -22,6 +22,7 @@ import '../lib/reveal.js';
 import { initPageEnter } from './page-enter.js';
 import { countUp } from './count-up.js';
 import { copyWithToast } from './copy-toast.js';
+import { buildShopsHref as buildShopsHandoffHref } from './cross-page-links.js';
 
 const _modUrl = new URL(import.meta.url);
 const _pageUrl = new URL(location.href);
@@ -235,8 +236,12 @@ function buildCalculatorHref({ country, currency, karat = '24', lang = 'en' }) {
   return withBase(`calculator.html?${params.toString()}`);
 }
 
-function buildShopsHref(country) {
-  return withBase(`shops.html?country=${encodeURIComponent(country.code)}`);
+function buildShopsHref(country, lang = 'en') {
+  return buildShopsHandoffHref({
+    countryCode: country.code,
+    lang,
+    base: withBase('shops.html'),
+  });
 }
 
 function getFeaturedKarats(countryData) {
@@ -683,7 +688,7 @@ function renderCountryContext({ country, lang }) {
         'a',
         {
           class: 'country-inline-link country-inline-link--cta',
-          href: safeHref(buildShopsHref(country)),
+          href: safeHref(buildShopsHref(country, lang)),
         },
         `${getCountryName(country, lang)} ${tx(lang, 'contextShops')} →`
       ),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Country gold-price pages now pass `lang` when linking to the shops directory.

## Why (bug)
`page-hydrator.js` had a local `buildShopsHref(country)` that only appended `?country=XX`. Arabic country pages (`lang=ar`) lost language context when users clicked the shops CTA — shops would open in English/default instead of RTL Arabic.

Calculator and tracker handoffs on the same page already passed `lang`; shops was inconsistent.

## How
- Import shared `buildShopsHref` from `cross-page-links.js` (validated ISO country codes + lang allowlist)
- Pass `lang` from `renderCountryContext` into the shops link builder

## Proof
- `npm run lint` — 0 errors (also fixed `CSS` global + prefer-const lint errors)
- `npm test` — 1112/1112 pass

## Risks
Low — URL shape change only adds `lang=ar` or `lang=en` query params that shops already supports.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da31f6f2-116c-4e1a-aa54-627b30924c40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da31f6f2-116c-4e1a-aa54-627b30924c40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

