### PR TITLE
fix(tracker): normalize historical record dates before string ops

### DIFF
--- a/src/lib/historical-data.js
+++ b/src/lib/historical-data.js
@@ -59,13 +59,43 @@ function baselineToRecord(entry) {
 }
 
 /**
+ * Coerce a history record date to a sortable ISO key (YYYY-MM or YYYY-MM-DD).
+ * Accepts strings, Date objects, and numeric epoch ms/s values.
+ * @param {string|number|Date|null|undefined} value
+ * @returns {string}
+ */
+function toDateKey(value) {
+  if (value == null || value === '') return '';
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (/^\d{4}-\d{2}$/.test(trimmed)) return trimmed;
+    if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) return trimmed.slice(0, 10);
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const ms = value >= 1e12 ? value : value >= 1e9 ? value * 1000 : value;
+    const date = new Date(ms);
+    return Number.isFinite(date.getTime()) ? date.toISOString().slice(0, 10) : '';
+  }
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value.toISOString().slice(0, 10) : '';
+  }
+  const parsed = new Date(value);
+  if (Number.isFinite(parsed.getTime())) return parsed.toISOString().slice(0, 10);
+  return String(value).slice(0, 10);
+}
+
+function toMonthKey(value) {
+  const key = toDateKey(value);
+  return key.length >= 7 ? key.slice(0, 7) : key;
+}
+
+/**
  * Normalise a daily cached entry (from localStorage/STATE.history).
  * @param {{ date: string|Date, price?: number, spot?: number, timestamp?: number }} entry
  * @returns {HistoryRecord}
  */
 function normalizeCachedDate(entry) {
-  if (entry.date instanceof Date) return entry.date.toISOString().slice(0, 10);
-  return String(entry.date || '').slice(0, 10);
+  return toDateKey(entry.date);
 }
 
 function cachedToRecord(entry) {
@@ -121,8 +151,11 @@ export function getUnifiedHistory(cachedDaily = []) {
   }
 
   const injectDaily = (r) => {
-    const monthKey = r.date.slice(0, 7);
-    monthMap[r.date] = r;
+    const dateKey = toDateKey(r.date);
+    if (!dateKey) return;
+    const monthKey = toMonthKey(dateKey);
+    const normalized = { ...r, date: dateKey };
+    monthMap[dateKey] = normalized;
     if (monthMap[monthKey]?.granularity === 'monthly') {
       monthMap[monthKey].superseded = true;
     }
@@ -332,7 +365,7 @@ export function computeYoYChange(records) {
   const oneYearAgo = new Date();
   oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
   const yearAgoStr = oneYearAgo.toISOString().slice(0, 7);
-  const yearAgoEntry = [...records].reverse().find((r) => r.date.slice(0, 7) <= yearAgoStr);
+  const yearAgoEntry = [...records].reverse().find((r) => toMonthKey(r.date) <= yearAgoStr);
   if (!yearAgoEntry) return null;
   return ((latest - yearAgoEntry.price) / yearAgoEntry.price) * 100;
 }
@@ -353,7 +386,9 @@ export function getHistoryStats(records) {
 
   // YTD: compare to start of this year
   const yearStart = `${new Date().getFullYear()}-01`;
-  const ytdEntry = records.find((r) => r.date.slice(0, 7) === yearStart || r.date >= yearStart);
+  const ytdEntry = records.find(
+    (r) => toMonthKey(r.date) === yearStart || toDateKey(r.date) >= yearStart
+  );
   const ytdChange = ytdEntry ? ((latest - ytdEntry.price) / ytdEntry.price) * 100 : null;
 
   const yoyChange = computeYoYChange(records);

--- a/tests/historical-data-merge.test.js
+++ b/tests/historical-data-merge.test.js
@@ -1,0 +1,57 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadHistoricalData() {
+  const url = new URL(
+    'file://' + path.resolve(__dirname, '..', 'src', 'lib', 'historical-data.js')
+  );
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+describe('historical-data merge and stats date coercion', () => {
+  test('getUnifiedHistory merges cached daily rows with numeric epoch dates', async () => {
+    const { getUnifiedHistory } = await loadHistoricalData();
+    const epochMs = Date.parse('2025-06-15T12:00:00Z');
+    const unified = getUnifiedHistory([{ date: epochMs, price: 3350, timestamp: epochMs }]);
+    const daily = unified.filter((row) => row.granularity === 'daily');
+    assert.ok(daily.some((row) => row.date === '2025-06-15' && row.price === 3350));
+  });
+
+  test('getUnifiedHistory merges cached daily rows with Date object dates', async () => {
+    const { getUnifiedHistory } = await loadHistoricalData();
+    const unified = getUnifiedHistory([
+      { date: new Date('2025-08-01T00:00:00Z'), price: 3450, timestamp: Date.now() },
+    ]);
+    assert.ok(unified.some((row) => row.date === '2025-08-01' && row.price === 3450));
+  });
+
+  test('getHistoryStats accepts tracker rows with Date objects', async () => {
+    const { getHistoryStats } = await loadHistoricalData();
+    const year = new Date().getFullYear();
+    const records = [
+      { date: new Date(`${year}-01-01T00:00:00Z`), price: 2600, spot: 2600 },
+      { date: new Date(`${year}-06-01T00:00:00Z`), price: 3300, spot: 3300 },
+    ];
+    assert.doesNotThrow(() => getHistoryStats(records));
+    const stats = getHistoryStats(records);
+    assert.equal(stats.latest, 3300);
+    assert.ok(stats.ytdChange != null);
+    assert.equal(typeof stats.allTimeHigh, 'number');
+    assert.equal(typeof stats.allTimeLow, 'number');
+  });
+
+  test('computeYoYChange accepts Date objects without throwing', async () => {
+    const { computeYoYChange } = await loadHistoricalData();
+    const now = new Date();
+    const lastYear = new Date(now);
+    lastYear.setFullYear(lastYear.getFullYear() - 1);
+    const records = [
+      { date: lastYear, price: 2500 },
+      { date: now, price: 3000 },
+    ];
+    const change = computeYoYChange(records);
+    assert.equal(typeof change, 'number');
+    assert.ok(Number.isFinite(change));
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Add defensive date coercion in `src/lib/historical-data.js` so merge/stats helpers never call `.slice()` on non-string `date` values.

## Why
The tracker realtime subscriber re-renders chart stats via `getHistoryStats()` with rows whose `date` is a `Date` object (set in `ensureUnifiedHistory`). That caused `TypeError: e.date.slice is not a function`, breaking the pricing-engine subscriber and preventing reliable history/matrix rendering.

## How
- Introduced `toDateKey()` / `toMonthKey()` to normalize strings, `Date` objects, and numeric epoch ms/s into comparable ISO keys.
- Applied coercion in `injectDaily` (unified history merge), `computeYoYChange`, and `getHistoryStats`.
- Reused `toDateKey` in `normalizeCachedDate` so cached snapshots with epoch/Date inputs merge correctly.
- Added `tests/historical-data-merge.test.js` regression coverage.

## Proof
- `node --test --test-concurrency=1 tests/historical-data-merge.test.js` — 4/4 pass
- `npm test` — 1088/1088 pass (full suite)
- Manual load of `http://localhost:5000/tracker.html` — no `date.slice` console error; price matrix renders

## Risks
Low. Change is localized to date normalization before comparisons; pricing math, AED peg, karat factors, and freshness labeling are untouched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e749db84-020a-4f6f-9ad9-438d16963726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e749db84-020a-4f6f-9ad9-438d16963726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

