### PR TITLE
fix(integration): silence three failing network calls on every page load

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -12,6 +12,26 @@ export const CONSTANTS = {
   GOLD_FETCH_TIMEOUT: 8000,
   FX_FETCH_TIMEOUT: 8000,
   HISTORY_DAYS: 90,
+
+  // ── Integration flags ───────────────────────────────────────────────────────
+  // Production is static GitHub Pages with no Express backend, so the versioned
+  // same-origin `/api/v1/*` endpoints always 404. Leave this false for static
+  // hosting; set true only where the Node server in `server/` actually serves
+  // `/api/v1/*` (self-hosted / Replit). Gates the backend price probe
+  // (`src/lib/api.js`) and the server-alerts capability probe
+  // (`src/pages/tracker-pro.js`) so neither fires a guaranteed-404 request on
+  // every page load. Does not affect pricing — static JSON remains the source
+  // of truth when this is off.
+  API_BACKEND_ENABLED: false,
+
+  // Client analytics are mirrored to the Supabase `analytics_events` table with
+  // the public anon key. That write returns 401 until an RLS policy grants the
+  // `anon` role INSERT (see PR notes and `docs/ANALYTICS_EVENTS.md`). Leave
+  // false so no request is sent at all — GA4 still receives every event via the
+  // gtag path. Flip to true only after the anon-insert RLS policy is live in
+  // the Supabase dashboard.
+  ANALYTICS_SUPABASE_ENABLED: false,
+
   CACHE_KEYS: {
     goldPrice: 'gold_price_cache',
     goldFallback: 'gold_price_fallback',

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -12,12 +12,15 @@
  *     replaced by its character length only.
  *   - Event payloads are validated against EVENT_SCHEMA (non-throwing).
  *   - price_view is sampled at PRICE_VIEW_SAMPLE_RATE to avoid volume noise.
- *   - Supabase write is best-effort / non-blocking (never throws).
+ *   - Supabase write is best-effort / non-blocking (never throws), and is gated
+ *     by CONSTANTS.ANALYTICS_SUPABASE_ENABLED (off until an anon-insert RLS
+ *     policy exists, so it never 401s on the client).
  *   - Local/dev debug mode can log event validation + dispatch details.
  *   - No new runtime dependency; uses the existing Supabase anon key.
  */
 
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from '../config/supabase.js';
+import { CONSTANTS } from '../config/index.js';
 
 // ── Event name catalog ────────────────────────────────────────────────────────
 
@@ -255,6 +258,13 @@ export function getEventInventory() {
  * @param {Record<string, unknown>} safeParams  Already-sanitized parameters.
  */
 function _persistToSupabase(name, safeParams) {
+  // The Supabase mirror needs an RLS policy that allows the `anon` role to
+  // INSERT into analytics_events; until that policy is live the POST returns 401
+  // and surfaces in the browser console/network log. Skip the request entirely
+  // while disabled — GA4 still receives every event via the gtag path in
+  // track(). Flip CONSTANTS.ANALYTICS_SUPABASE_ENABLED once the RLS policy
+  // exists (see docs/ANALYTICS_EVENTS.md and the PR notes).
+  if (!CONSTANTS.ANALYTICS_SUPABASE_ENABLED) return;
   const url = `${SUPABASE_URL}/rest/v1/analytics_events`;
   const body = JSON.stringify({
     event: name,

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -194,19 +194,24 @@ export async function fetchGold({ signal, timeoutMs } = {}) {
   const effectiveTimeoutMs =
     Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : CONSTANTS.GOLD_FETCH_TIMEOUT;
 
-  // Prefer backend API when available, then fall back to static JSON so
-  // GitHub Pages mode stays fully functional.
-  try {
-    const backendRes = await fetchWithTimeout(
-      GOLD_BACKEND_URL,
-      Math.min(effectiveTimeoutMs, 4000),
-      { signal }
-    );
-    const backendData = await backendRes.json();
-    const normalized = normalizeGoldResponse(backendData);
-    if (normalized) return normalized;
-  } catch {
-    // Backend unavailable or invalid; continue to static fallback.
+  // Prefer the versioned backend API when it is actually deployed (same-origin
+  // `/api/v1/*`), then fall back to static JSON. On static GitHub Pages there is
+  // no backend, so this probe is gated behind CONSTANTS.API_BACKEND_ENABLED to
+  // avoid a guaranteed 404 on every load; the committed JSON below is the source
+  // of truth there.
+  if (CONSTANTS.API_BACKEND_ENABLED) {
+    try {
+      const backendRes = await fetchWithTimeout(
+        GOLD_BACKEND_URL,
+        Math.min(effectiveTimeoutMs, 4000),
+        { signal }
+      );
+      const backendData = await backendRes.json();
+      const normalized = normalizeGoldResponse(backendData);
+      if (normalized) return normalized;
+    } catch {
+      // Backend unavailable or invalid; continue to static fallback.
+    }
   }
 
   try {

--- a/src/lib/quote-providers/create-providers.js
+++ b/src/lib/quote-providers/create-providers.js
@@ -10,6 +10,29 @@ const MINTED_FAILOVER_TIMEOUT_MS = 2000;
 const FALLBACK_JSON_TIMEOUT_MS = 1500;
 
 /**
+ * Wrap a provider so its own timeout cap can never be exceeded by the engine's
+ * inbound budget. The realtime engine calls the whole chain with a single
+ * ~5 s `fetchTimeoutMs` (`realtime-pricing-engine.js`), and the live providers
+ * otherwise prefer that inbound value over their constructor `timeoutMs` — which
+ * would let a slow live source burn the full budget before failover. Pinning the
+ * cap here restores the per-step 2 s caps the old parallel race enforced, while
+ * still honouring a tighter inbound budget if one is ever set. Only the wait
+ * window changes; quote data and freshness labelling are untouched.
+ * @param {{ providerId: string, fetchQuote: Function }} provider
+ * @param {number} capMs
+ */
+export function withTimeoutCap(provider, capMs) {
+  return {
+    providerId: provider.providerId,
+    fetchQuote(context = {}) {
+      const inbound = Number(context?.timeoutMs);
+      const timeoutMs = Number.isFinite(inbound) && inbound > 0 ? Math.min(inbound, capMs) : capMs;
+      return provider.fetchQuote({ ...context, timeoutMs });
+    },
+  };
+}
+
+/**
  * Primary chain — live source first, then sequential failovers:
  *  1. gold-api.com live spot (2 s cap)
  *  2. mintedmetal.com LBMA reference — failover only, reached when gold-api.com
@@ -20,10 +43,12 @@ const FALLBACK_JSON_TIMEOUT_MS = 1500;
  *  3. backend API / committed gold_price.json (1.5 s cap)
  *  4. last_gold_price.json
  *
- * Each provider keeps its own freshness gate (gold-api rejects >15 min,
- * mintedmetal rejects >4 h), so a failover quote is still age-checked and
- * labelled by the engine exactly as before — this change alters *when*
- * mintedmetal is fetched, not how its freshness is computed.
+ * The live providers are wrapped with `withTimeoutCap` so the engine's inbound
+ * fetch budget can't relax their 2 s caps. Each provider also keeps its own
+ * freshness gate (gold-api rejects >15 min, mintedmetal rejects >4 h), so a
+ * failover quote is still age-checked and labelled by the engine exactly as
+ * before — this change alters *when* mintedmetal is fetched, not how its
+ * freshness is computed.
  *
  * Secondary provider (localStorage) is wired separately on the engine.
  */
@@ -31,8 +56,14 @@ export function createPrimaryQuoteProvider() {
   return new ChainedQuoteProvider({
     providerId: 'live-primary',
     providers: [
-      new GoldApiComQuoteProvider({ timeoutMs: LIVE_PRIMARY_TIMEOUT_MS }),
-      new MintedMetalQuoteProvider({ timeoutMs: MINTED_FAILOVER_TIMEOUT_MS }),
+      withTimeoutCap(
+        new GoldApiComQuoteProvider({ timeoutMs: LIVE_PRIMARY_TIMEOUT_MS }),
+        LIVE_PRIMARY_TIMEOUT_MS
+      ),
+      withTimeoutCap(
+        new MintedMetalQuoteProvider({ timeoutMs: MINTED_FAILOVER_TIMEOUT_MS }),
+        MINTED_FAILOVER_TIMEOUT_MS
+      ),
       new PrimaryQuoteProvider({ timeoutMs: FALLBACK_JSON_TIMEOUT_MS }),
       new LastGoldPriceQuoteProvider(),
     ],

--- a/src/lib/quote-providers/create-providers.js
+++ b/src/lib/quote-providers/create-providers.js
@@ -2,34 +2,37 @@ import { ChainedQuoteProvider } from './chained-provider.js';
 import { GoldApiComQuoteProvider } from './gold-api-com-provider.js';
 import { MintedMetalQuoteProvider } from './minted-metal-provider.js';
 import { LastGoldPriceQuoteProvider } from './last-gold-price-provider.js';
-import { ParallelQuoteRaceProvider } from './parallel-race-provider.js';
 import { PrimaryQuoteProvider } from './primary-provider.js';
 import { SecondaryQuoteProvider } from './secondary-provider.js';
 
-const LIVE_RACE_TIMEOUT_MS = 2000;
-const LIVE_RACE_MASTER_MS = 5000;
+const LIVE_PRIMARY_TIMEOUT_MS = 2000;
+const MINTED_FAILOVER_TIMEOUT_MS = 2000;
 const FALLBACK_JSON_TIMEOUT_MS = 1500;
 
 /**
- * Primary chain — live lane first, then fast file fallbacks:
- *  1. Parallel race: gold-api.com + mintedmetal.com (2 s each, 5 s master budget)
- *  2. backend API / committed gold_price.json (1.5 s cap)
- *  3. last_gold_price.json
+ * Primary chain — live source first, then sequential failovers:
+ *  1. gold-api.com live spot (2 s cap)
+ *  2. mintedmetal.com LBMA reference — failover only, reached when gold-api.com
+ *     fails. Its data is twice-daily, so it is a backstop rather than a live
+ *     racer; fetching it lazily (only on primary failure) keeps it off the
+ *     network path on every page load while preserving it as the documented
+ *     Tier-2 source in `methodology.html`.
+ *  3. backend API / committed gold_price.json (1.5 s cap)
+ *  4. last_gold_price.json
+ *
+ * Each provider keeps its own freshness gate (gold-api rejects >15 min,
+ * mintedmetal rejects >4 h), so a failover quote is still age-checked and
+ * labelled by the engine exactly as before — this change alters *when*
+ * mintedmetal is fetched, not how its freshness is computed.
+ *
  * Secondary provider (localStorage) is wired separately on the engine.
  */
 export function createPrimaryQuoteProvider() {
   return new ChainedQuoteProvider({
     providerId: 'live-primary',
     providers: [
-      new ParallelQuoteRaceProvider({
-        providerId: 'live-race',
-        providers: [
-          new GoldApiComQuoteProvider({ timeoutMs: LIVE_RACE_TIMEOUT_MS }),
-          new MintedMetalQuoteProvider({ timeoutMs: LIVE_RACE_TIMEOUT_MS }),
-        ],
-        raceTimeoutMs: LIVE_RACE_TIMEOUT_MS,
-        masterTimeoutMs: LIVE_RACE_MASTER_MS,
-      }),
+      new GoldApiComQuoteProvider({ timeoutMs: LIVE_PRIMARY_TIMEOUT_MS }),
+      new MintedMetalQuoteProvider({ timeoutMs: MINTED_FAILOVER_TIMEOUT_MS }),
       new PrimaryQuoteProvider({ timeoutMs: FALLBACK_JSON_TIMEOUT_MS }),
       new LastGoldPriceQuoteProvider(),
     ],

--- a/src/pages/tracker-pro.js
+++ b/src/pages/tracker-pro.js
@@ -623,6 +623,12 @@ function updateServerAlertUiState() {
 }
 
 async function probeServerAlertsAvailability() {
+  // Static GitHub Pages has no `/api/v1/*` backend, so this capability probe
+  // would 404 on every tracker load. Skip it unless a backend is actually
+  // deployed (CONSTANTS.API_BACKEND_ENABLED). All server-alert UI and POSTs are
+  // gated on the returned value, so returning false here cleanly keeps the
+  // tracker on the local-alert path with no failed request.
+  if (!CONSTANTS.API_BACKEND_ENABLED) return false;
   try {
     const res = await fetch('/api/v1/config/public', {
       method: 'GET',

--- a/tests/live-provider-chain.test.js
+++ b/tests/live-provider-chain.test.js
@@ -12,27 +12,30 @@ async function loadFactory() {
   return import(url.href + `?v=${Date.now()}`);
 }
 
-test('createPrimaryQuoteProvider chains live race + file fallbacks', async () => {
+test('createPrimaryQuoteProvider chains live source + sequential failovers', async () => {
   const { createPrimaryQuoteProvider } = await loadFactory();
   const chain = createPrimaryQuoteProvider();
   assert.equal(chain.providerId, 'live-primary');
-  assert.equal(chain.providers.length, 3);
-  assert.equal(chain.providers[0].providerId, 'live-race');
-  assert.equal(chain.providers[0].providers.length, 2);
-  assert.equal(chain.providers[0].providers[0].providerId, 'gold_api_com');
-  assert.equal(chain.providers[0].providers[1].providerId, 'minted_metal');
-  assert.equal(chain.providers[1].providerId, 'primary-provider');
-  assert.equal(chain.providers[2].providerId, 'last-gold-price');
+  assert.equal(chain.providers.length, 4);
+  assert.equal(chain.providers[0].providerId, 'gold_api_com');
+  assert.equal(chain.providers[1].providerId, 'minted_metal');
+  assert.equal(chain.providers[2].providerId, 'primary-provider');
+  assert.equal(chain.providers[3].providerId, 'last-gold-price');
 });
 
 test('createPrimaryQuoteProvider fails over through the chain', async () => {
   const { createPrimaryQuoteProvider } = await loadFactory();
   const chain = createPrimaryQuoteProvider();
 
+  // gold-api.com (live) and the mintedmetal failover both down → the chain
+  // should fall through to the committed-JSON primary provider.
   chain.providers[0].fetchQuote = async () => {
-    throw new Error('live race down');
+    throw new Error('gold-api down');
   };
-  chain.providers[1].fetchQuote = async () => ({
+  chain.providers[1].fetchQuote = async () => {
+    throw new Error('mintedmetal down');
+  };
+  chain.providers[2].fetchQuote = async () => ({
     price: 4496.95,
     providerTimestamp: new Date().toISOString(),
     fetchedAt: new Date().toISOString(),
@@ -46,4 +49,29 @@ test('createPrimaryQuoteProvider fails over through the chain', async () => {
   const quote = await chain.fetchQuote();
   assert.equal(quote.price, 4496.95);
   assert.equal(quote.providerId, 'primary-provider');
+});
+
+test('createPrimaryQuoteProvider uses mintedmetal as a sequential failover', async () => {
+  const { createPrimaryQuoteProvider } = await loadFactory();
+  const chain = createPrimaryQuoteProvider();
+
+  // gold-api.com down → mintedmetal answers as the Tier-2 failover (it is no
+  // longer raced in parallel, so it is only fetched when the live source fails).
+  chain.providers[0].fetchQuote = async () => {
+    throw new Error('gold-api down');
+  };
+  chain.providers[1].fetchQuote = async () => ({
+    price: 4501.25,
+    providerTimestamp: new Date().toISOString(),
+    fetchedAt: new Date().toISOString(),
+    providerId: 'minted_metal',
+    source: 'minted_metal',
+    providerPathSuccessful: true,
+    isFresh: null,
+    isFallback: false,
+  });
+
+  const quote = await chain.fetchQuote();
+  assert.equal(quote.price, 4501.25);
+  assert.equal(quote.providerId, 'minted_metal');
 });

--- a/tests/live-provider-chain.test.js
+++ b/tests/live-provider-chain.test.js
@@ -75,3 +75,25 @@ test('createPrimaryQuoteProvider uses mintedmetal as a sequential failover', asy
   assert.equal(quote.price, 4501.25);
   assert.equal(quote.providerId, 'minted_metal');
 });
+
+test('withTimeoutCap clamps the engine budget to a provider cap', async () => {
+  const { withTimeoutCap } = await loadFactory();
+  const seen = [];
+  const fake = {
+    providerId: 'gold_api_com',
+    fetchQuote: async (ctx) => {
+      seen.push(ctx?.timeoutMs);
+      return { price: 2500, providerId: 'gold_api_com' };
+    },
+  };
+  const capped = withTimeoutCap(fake, 2000);
+
+  assert.equal(capped.providerId, 'gold_api_com');
+  // Engine's larger budget (5s) is clamped down to the 2s cap.
+  await capped.fetchQuote({ timeoutMs: 5000 });
+  // A tighter inbound budget is still honoured.
+  await capped.fetchQuote({ timeoutMs: 1200 });
+  // No inbound budget → the cap is used.
+  await capped.fetchQuote({});
+  assert.deepEqual(seen, [2000, 1200, 2000]);
+});


### PR DESCRIPTION
## What

Eliminates the three failing network calls observed on every page load, scoped strictly to the integration layer. **No change to pricing logic, historical data, sacred constants, or freshness-label correctness** — only *which* sources are called and *when*.

| # | Failure | Root cause | Fix |
|---|---------|-----------|-----|
| (a) | `404 GET /api/v1/config/public` (tracker) + sibling `404 GET /api/v1/prices/latest` (home/tracker/calculator) | Production is static GitHub Pages — there is no Express backend, so same-origin `/api/v1/*` always 404s | Gate both probes behind new flag `CONSTANTS.API_BACKEND_ENABLED` (default `false`) |
| (b) | `401 POST …/rest/v1/analytics_events` | **Server-side RLS**: the table's policies only grant the `authenticated` role INSERT — there is no `anon` INSERT policy, so anon-key writes are rejected. Client key/headers are correct. | Gate the write behind `CONSTANTS.ANALYTICS_SUPABASE_ENABLED` (default `false`) so nothing is sent until the policy exists. GA4 is unaffected. |
| (c) | `aborted/failed GET https://mintedmetal.com/api/prices.json` | It is a **real, reachable Tier-2 fallback** (verified `HTTP 200`, `ACAO: *`, valid twice-daily LBMA JSON), but it was *raced in parallel* with `gold-api.com` on every load, so the slower loser was aborted each time | Move it to a **sequential failover** in the primary chain — fetched only when `gold-api.com` fails |

## Why

The 404 and 401 are dead calls that only add console/network noise on a static deploy. mintedmetal is genuinely useful as a backstop, but racing a twice-daily source against a live one means it loses (and gets aborted) on essentially every load — and its data is >4h stale ~20h/day anyway, so it almost never wins. Making it a lazy failover keeps it as the documented Tier-2 source (`methodology.html`) while removing the per-load noise. The hard rule — never mislabel freshness — is preserved: per-provider age gates (gold-api >15 min, minted >4 h) and engine-side labelling are untouched; this PR only changes *when* minted is fetched, not how its quote is labelled.

## How

- `src/config/constants.js` — add two integration flags (`API_BACKEND_ENABLED`, `ANALYTICS_SUPABASE_ENABLED`), both `false`. No sacred constants changed.
- `src/lib/api.js` — gate the `/api/v1/prices/latest` backend probe behind `API_BACKEND_ENABLED`; static JSON path unchanged.
- `src/pages/tracker-pro.js` — `probeServerAlertsAvailability()` returns `false` early when the backend is disabled (all server-alert UI/POSTs are already gated on this result, so they cleanly stay on the local path).
- `src/lib/analytics.js` — `_persistToSupabase()` returns early when `ANALYTICS_SUPABASE_ENABLED` is off.
- `src/lib/quote-providers/create-providers.js` — replace the `gold-api ∥ minted` parallel race with a sequential chain `gold-api → minted → committed-JSON → last-gold`.
- `tests/live-provider-chain.test.js` — update the chain-structure assertions and add a test proving minted is reached only as a sequential failover.

## Proof

- `npm test` → **1085 pass / 0 fail** · `npm run lint` clean · `npm run validate` exit 0 · `npm run build` exit 0.
- **Headless-browser network capture** (built `dist/`, served via `vite preview`) on home, tracker, and calculator:

  | Page | config/public | prices/latest | analytics_events | mintedmetal |
  |------|:---:|:---:|:---:|:---:|
  | home | 0 | 0 | 0 | 0 |
  | tracker | 0 | 0 | 0 | 0 |
  | calculator | 0 | 0 | 0 | 0 |

  (with `gold-api.com` mocked to succeed — the normal case). A second run forcing `gold-api.com` to fail showed exactly **one** sequential `mintedmetal` failover request, confirming the chain works in both directions. No `401`/`404` console errors for any of the three targets.

> Verified locally in this environment; CI re-runs the same gates. The browser capture ran against headless Chromium through the sandbox proxy.

## Risks

- **Low.** Flags default to the production reality (static hosting, no anon-insert policy yet), so behaviour on goldtickerlive.com is strictly "stop sending requests that already failed." The static JSON + cache fallback paths are untouched, so displayed prices and freshness labels are unchanged.
- Removing the parallel race means a *slow* (not failed) `gold-api.com` now waits its 2s cap before trying minted, rather than racing. Negligible in practice since minted is almost always stale; chosen deliberately per task direction.

---

## ⚠️ Manual server-side change required (Supabase dashboard)

The analytics `401` is a **server-side RLS** issue, not a client bug. To re-enable the `analytics_events` mirror, add an `anon` INSERT policy in the Supabase SQL editor:

```sql
-- Allow anonymous (public anon key) INSERTs into analytics_events.
-- INSERT-only: anon still cannot read/update/delete (no SELECT policy for anon),
-- so only admins (authenticated) can read the table. Matches docs/ANALYTICS_EVENTS.md.
create policy "Public anon insert analytics events"
    on public.analytics_events for insert
    to anon
    with check (true);
```

Then flip `ANALYTICS_SUPABASE_ENABLED` to `true` in `src/config/constants.js`. (Optionally mirror the new policy into `supabase/schema.sql` for parity.)

**No server change is needed for (a) or (c).** If you ever deploy the Node/Express server in `server/` to serve same-origin `/api/v1/*` (e.g. self-hosted/Replit), set `API_BACKEND_ENABLED: true` to re-enable the live backend price probe and server-side email alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SS5HhoZGK7G4Kft5iPXkUg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defaults match static production; main behavioral nuance is minted is tried only after gold-api fails or times out (~2s) instead of racing in parallel.
> 
> **Overview**
> Stops three noisy failing network calls on static GitHub Pages without changing pricing math or freshness labeling.
> 
> **Integration flags** (`API_BACKEND_ENABLED`, `ANALYTICS_SUPABASE_ENABLED`, both default `false`) gate the `/api/v1/prices/latest` probe in `fetchGold`, the tracker `/api/v1/config/public` server-alerts probe, and Supabase `analytics_events` POSTs. GA4 and static `gold_price.json` behavior stay as before when flags are off.
> 
> **Quote chain** drops `ParallelQuoteRaceProvider` for a sequential chain: `gold-api.com` → `mintedmetal.com` (only on primary failure) → committed JSON → `last_gold_price.json`, so minted is not fetched/aborted on every successful live load. Tests assert the four-step chain and minted as Tier-2 failover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba60a5320f554d0bc3fe8ae85153209ac6912a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->