### PR TITLE
feat(ui): Tracker + Homepage visual redesign — Design System v4

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
             </div>
           </div>
           <div
-            class="hero-live-card spot-terminal"
+            class="hero-live-card spot-terminal ds-card"
             id="hero-live-card"
             aria-busy="true"
             aria-describedby="hlc-trust-line"
@@ -282,10 +282,10 @@
               <h2 class="home-section-title" id="home-chart-title">Gold Price Chart</h2>
               <p class="home-section-sub" id="home-chart-sub">XAU/USD spot price — LBMA baseline combined with live session data</p>
             </div>
-            <div class="home-chart-ranges" role="group" aria-label="Chart time range" id="home-chart-ranges">
-              <button type="button" class="home-chart-range-btn" data-range="1Y" id="home-chart-btn-1y">1Y</button>
-              <button type="button" class="home-chart-range-btn" data-range="3Y" id="home-chart-btn-3y">3Y</button>
-              <button type="button" class="home-chart-range-btn is-active" data-range="ALL" id="home-chart-btn-all">ALL</button>
+            <div class="home-chart-ranges ds-segmented" role="group" aria-label="Chart time range" id="home-chart-ranges">
+              <button type="button" class="home-chart-range-btn ds-segmented__btn" data-range="1Y" id="home-chart-btn-1y">1Y</button>
+              <button type="button" class="home-chart-range-btn ds-segmented__btn" data-range="3Y" id="home-chart-btn-3y">3Y</button>
+              <button type="button" class="home-chart-range-btn ds-segmented__btn is-active" data-range="ALL" id="home-chart-btn-all">ALL</button>
             </div>
           </div>
           <div class="home-chart-wrap" id="home-chart-wrap">

--- a/src/components/chart.js
+++ b/src/components/chart.js
@@ -55,6 +55,47 @@ const CUSTOM_RANGE_MS = {
   '1Y': 365 * 86400000,
 };
 
+function readChartTheme() {
+  const root = document.documentElement;
+  const styles = window.getComputedStyle(root);
+  const pick = (token, fallback) => styles.getPropertyValue(token).trim() || fallback;
+  return {
+    text: pick('--text-secondary', '#6a6050'),
+    grid: pick('--border-subtle', 'rgba(230,224,208,0.5)'),
+    border: pick('--border-default', 'rgba(230,224,208,0.8)'),
+    line: pick('--color-gold', '#c4902e'),
+    areaTop: pick('--color-gold-glow', 'rgba(196,144,46,0.22)'),
+    areaBottom: 'rgba(196,144,46,0.02)',
+  };
+}
+
+function applyChartTheme(chart, series) {
+  if (!chart || !series) return;
+  const theme = readChartTheme();
+  chart.applyOptions({
+    layout: {
+      background: { color: 'transparent' },
+      textColor: theme.text,
+    },
+    grid: {
+      vertLines: { color: theme.grid },
+      horzLines: { color: theme.grid },
+    },
+    rightPriceScale: {
+      borderColor: theme.border,
+      textColor: theme.text,
+    },
+    timeScale: {
+      borderColor: theme.border,
+    },
+  });
+  series.applyOptions({
+    lineColor: theme.line,
+    topColor: theme.areaTop,
+    bottomColor: theme.areaBottom,
+  });
+}
+
 export class GoldChart {
   constructor(containerId, lang = 'en') {
     this.containerId = containerId;
@@ -119,21 +160,21 @@ export class GoldChart {
       height: chartHeight,
       layout: {
         background: { color: 'transparent' },
-        textColor: '#6a6050',
+        textColor: readChartTheme().text,
         fontFamily: "'Cairo', system-ui, sans-serif",
       },
       grid: {
-        vertLines: { color: 'rgba(230,224,208,0.5)' },
-        horzLines: { color: 'rgba(230,224,208,0.5)' },
+        vertLines: { color: readChartTheme().grid },
+        horzLines: { color: readChartTheme().grid },
       },
       crosshair: { mode: 1 },
       rightPriceScale: {
-        borderColor: 'rgba(230,224,208,0.8)',
-        textColor: '#6a6050',
+        borderColor: readChartTheme().border,
+        textColor: readChartTheme().text,
         minimumWidth: 65,
       },
       timeScale: {
-        borderColor: 'rgba(230,224,208,0.8)',
+        borderColor: readChartTheme().border,
         timeVisible: true,
         secondsVisible: false,
         rightOffset: 5,
@@ -142,12 +183,21 @@ export class GoldChart {
       handleScale: true,
     });
 
+    const theme = readChartTheme();
     this._series = this._chart.addSeries(this._LW.AreaSeries, {
-      lineColor: '#c9a84c',
-      topColor: 'rgba(201,168,76,0.22)',
-      bottomColor: 'rgba(201,168,76,0.02)',
+      lineColor: theme.line,
+      topColor: theme.areaTop,
+      bottomColor: theme.areaBottom,
       lineWidth: 2,
       priceFormat: { type: 'price', precision: 2, minMove: 0.01 },
+    });
+
+    this._themeObserver = new MutationObserver(() => {
+      applyChartTheme(this._chart, this._series);
+    });
+    this._themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
     });
 
     const ro = new ResizeObserver(() => {
@@ -175,6 +225,7 @@ export class GoldChart {
     link.rel = 'noopener noreferrer';
     link.textContent = isAr ? 'مخططات من TradingView' : 'Charts by TradingView';
     container.appendChild(link);
+    applyChartTheme(this._chart, this._series);
   }
 
   _showFallback(reason) {

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -352,7 +352,7 @@ export function injectNav(lang = 'en', depth = 0) {
 
   const html = `
 <a class="nav-skip-link" href="#main-content">${lang === 'ar' ? 'تخطي إلى المحتوى' : 'Skip to main content'}</a>
-<nav class="site-nav" role="navigation" aria-label="${data.mainNav}" dir="${isRtl ? 'rtl' : 'ltr'}">
+<nav class="site-nav site-nav--premium" role="navigation" aria-label="${data.mainNav}" dir="${isRtl ? 'rtl' : 'ltr'}">
   <div class="nav-inner">
 
     <!-- Brand -->

--- a/src/pages/tracker-pro.js
+++ b/src/pages/tracker-pro.js
@@ -796,6 +796,108 @@ function flagForCurrency(code) {
   return country?.flag ? `${country.flag} ` : '';
 }
 
+function formatReadoutPrice(value, currency) {
+  if (value == null || !Number.isFinite(value)) return '—';
+  const formatted = value.toLocaleString(state.lang === 'ar' ? 'ar-AE' : 'en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  return currency ? `${formatted} ${currency}` : `$${formatted}`;
+}
+
+function syncHeroReadout() {
+  const spotEl = document.getElementById('tp-readout-spot-value');
+  const selectedEl = document.getElementById('tp-readout-selected-value');
+  const unitNoteEl = document.getElementById('tp-readout-unit-note');
+  const spotLabelEl = document.getElementById('tp-readout-spot-label');
+  const selectedLabelEl = document.getElementById('tp-readout-selected-label');
+  const metaHeading = document.getElementById('tp-command-meta-heading');
+
+  const spot = currentSpot();
+  const selectedPrice = priceFor({
+    currency: state.selectedCurrency,
+    karat: state.selectedKarat,
+    unit: state.selectedUnit,
+    spot,
+  });
+
+  if (spotLabelEl) spotLabelEl.textContent = trackerTx('readout.spotLabel') || 'XAU/USD spot';
+  if (selectedLabelEl) {
+    selectedLabelEl.textContent =
+      trackerTx('readout.selectedLabel', {
+        karat: state.selectedKarat,
+        currency: state.selectedCurrency,
+      }) || `${state.selectedKarat}K · ${state.selectedCurrency}`;
+  }
+  if (spotEl) {
+    spotEl.textContent = spot
+      ? `$${spot.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+      : '—';
+    spotEl.removeAttribute('aria-busy');
+  }
+  if (selectedEl) {
+    selectedEl.textContent = formatReadoutPrice(selectedPrice, state.selectedCurrency);
+    selectedEl.removeAttribute('aria-busy');
+  }
+  if (unitNoteEl) {
+    const unitKey =
+      state.selectedUnit === 'gram'
+        ? 'Gram'
+        : state.selectedUnit === 'oz'
+          ? 'Oz'
+          : state.selectedUnit === 'tola'
+            ? 'Tola'
+            : 'Kg';
+    unitNoteEl.textContent = trackerTx(`controls.unit${unitKey}`) || state.selectedUnit;
+  }
+  if (metaHeading) {
+    metaHeading.textContent = trackerTx('commandMeta.heading') || 'Quote context';
+  }
+}
+
+function syncUnitSegmented() {
+  const segmented = document.getElementById('tp-unit-segmented');
+  if (!segmented) return;
+  segmented.querySelectorAll('[data-unit]').forEach((btn) => {
+    const active = btn.dataset.unit === state.selectedUnit;
+    btn.classList.toggle('is-active', active);
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+}
+
+function wireUnitSegmentedControl() {
+  const segmented = document.getElementById('tp-unit-segmented');
+  if (!segmented || segmented.dataset.wired === 'true') return;
+  segmented.dataset.wired = 'true';
+  segmented.querySelectorAll('[data-unit]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const unit = btn.dataset.unit;
+      if (!unit || unit === state.selectedUnit) return;
+      state.selectedUnit = unit;
+      if (el.unit) {
+        el.unit.value = unit;
+        el.unit.dispatchEvent(new Event('change', { bubbles: true }));
+      } else {
+        persistState(state);
+        renderAll?.();
+        renderTrackerAddonPanels();
+      }
+      syncUnitSegmented();
+      syncHeroReadout();
+      track(EVENTS.UNIT_CHANGE, { surface: 'tracker', unit });
+    });
+  });
+  syncUnitSegmented();
+}
+
+function setChartLoading(isLoading) {
+  const wrap = el.chartWrap || document.querySelector('.tracker-chart-wrap');
+  if (!wrap) return;
+  wrap.classList.toggle('is-loading', Boolean(isLoading));
+  const skeleton = document.getElementById('tp-chart-skeleton');
+  if (skeleton) skeleton.setAttribute('aria-hidden', isLoading ? 'false' : 'true');
+}
+
 function getSelectedComparisonCountries() {
   return (state.compareCountries || [])
     .map((code) => COUNTRIES.find((country) => country.code === code))
@@ -1175,6 +1277,7 @@ function populateSelects() {
       button.classList.toggle('is-active', button.dataset.comparePreset === state.comparePreset);
     });
   }
+  syncUnitSegmented();
 }
 
 // ── Data fetch ────────────────────────────────────────────────────────────────
@@ -1213,6 +1316,7 @@ function applyRealtimeSnapshot(snapshot) {
 
   maybeTrackRealtimeSlo(snapshot, 'tracker');
   startCountdown();
+  syncHeroReadout();
   renderAll?.();
   renderTrackerAddonPanels();
 
@@ -1470,6 +1574,7 @@ async function init() {
       populateSelects();
       updateServerAlertUiState();
       renderAll();
+      syncHeroReadout();
       renderTrackerAddonPanels();
     }
   );
@@ -1496,6 +1601,7 @@ async function init() {
   serverAlertsAvailable = await probeServerAlertsAvailability();
   updateServerAlertUiState();
   bindCoreEvents();
+  wireUnitSegmentedControl();
   bindControlShortcuts({
     state,
     el,
@@ -1562,8 +1668,11 @@ async function init() {
 
   // Skip fetching the market wire during initial load to reduce critical path
   await refreshData(false, false);
+  setChartLoading(true);
   renderAll();
+  syncHeroReadout();
   renderTrackerAddonPanels();
+  setChartLoading(false);
   syncCurrentCountryPageLink();
   if (state.autoRefresh) startAutoRefresh();
   startCountdown();

--- a/styles/pages/home.css
+++ b/styles/pages/home.css
@@ -3435,3 +3435,118 @@
     height: 280px;
   }
 }
+
+/* ══════════════════════════════════════════════════════════════
+   Home — Design System v4 elevation
+   ══════════════════════════════════════════════════════════════ */
+
+.home-page main > section {
+  padding-block: var(--section-gap);
+}
+
+.home-page main > section + section {
+  border-block-start: 1px solid color-mix(in srgb, var(--color-gold) 8%, var(--border-subtle));
+}
+
+.hero-live-card.ds-card {
+  border: 1.5px solid color-mix(in srgb, var(--color-gold) 22%, var(--border-subtle));
+  box-shadow: var(--shadow-lg), var(--shadow-gold);
+  padding: var(--space-5);
+}
+
+.hlc-price {
+  font-family: var(--font-numeric);
+  font-size: var(--text-data-xl);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+.hlc-stat-value,
+.hlc-change,
+.kstrip-price {
+  font-family: var(--font-numeric);
+  font-variant-numeric: tabular-nums;
+}
+
+.hlc-stat-value--up,
+.hlc-direction--up,
+.hlc-change.badge-up {
+  color: var(--color-move-up);
+}
+
+.hlc-stat-value--down,
+.hlc-direction--down,
+.hlc-change.badge-down {
+  color: var(--color-move-down);
+}
+
+.home-chart-section,
+.home-price-trend,
+.home-tools,
+.karat-strip {
+  background: var(--gradient-section-alt);
+}
+
+.home-chart-wrap {
+  border-radius: var(--radius-xl);
+  border: 1.5px solid var(--border-subtle);
+  background: var(--surface-primary);
+  box-shadow: var(--shadow-sm);
+  min-height: 320px;
+}
+
+.home-chart-ranges.ds-segmented {
+  flex-shrink: 0;
+}
+
+.home-chart-range-btn.is-active {
+  background: var(--segmented-active-bg);
+  border-color: var(--segmented-active-border);
+  color: var(--text-accent);
+}
+
+.kstrip-unit-toggle {
+  display: inline-flex;
+  padding: 3px;
+  border-radius: var(--radius-pill);
+  background: var(--segmented-bg);
+  border: 1px solid var(--segmented-border);
+  gap: 0;
+}
+
+.kstrip-unit-btn {
+  min-height: var(--control-height-sm);
+  min-width: var(--control-height-sm);
+  padding: 0 0.85rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--text-ui-sm);
+  font-weight: var(--weight-bold);
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+
+.kstrip-unit-btn.is-active,
+.kstrip-unit-btn[aria-pressed='true'] {
+  background: var(--segmented-active-bg);
+  border-color: var(--segmented-active-border);
+  color: var(--text-accent);
+  font-weight: var(--weight-extrabold);
+}
+
+.karat-card__price {
+  font-size: var(--text-data-md);
+  font-family: var(--font-numeric);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (width <= 360px) {
+  .hlc-price {
+    font-size: var(--text-data-lg);
+  }
+}

--- a/styles/pages/tracker-pro-v4.css
+++ b/styles/pages/tracker-pro-v4.css
@@ -1,0 +1,491 @@
+/* tracker-pro-v4.css — Design System v4 elevation layer
+   Loaded via tracker-pro.css @import for maintainability. */
+
+/* ── Hero → workspace smooth transition ─────────────────────────────────── */
+
+.tracker-hero-wrap::after {
+  content: '';
+  position: absolute;
+  inset-inline: 0;
+  inset-block-end: 0;
+  block-size: var(--section-fade-height);
+  z-index: 2;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    color-mix(in srgb, var(--surface-canvas) 35%, transparent) 55%,
+    var(--surface-canvas) 100%
+  );
+}
+
+.tracker-mode-shell {
+  position: sticky;
+  top: calc(var(--nav-height) + 2px);
+  z-index: calc(var(--z-nav) - 1);
+  padding-block: var(--space-3);
+  margin-block-end: var(--space-4);
+  background: color-mix(in srgb, var(--surface-primary) 88%, transparent);
+  backdrop-filter: blur(18px) saturate(1.4);
+  border-block-end: 1px solid var(--border-subtle);
+  box-shadow: 0 8px 24px rgb(21 17 10 / 5%);
+}
+
+.tracker-modes-wrap {
+  width: var(--tp-shell);
+  margin-inline: auto;
+  padding-inline: var(--page-gutter);
+}
+
+/* ── Live price hero readout ─────────────────────────────────────────────── */
+
+.tracker-hero-readout {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-4);
+  align-items: center;
+  margin-block: var(--space-5) var(--space-6);
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--tp-hero-border);
+  background: var(--tp-hero-glass);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 7%),
+    var(--shadow-md);
+}
+
+.tracker-hero-readout__k {
+  display: block;
+  font-size: var(--text-ui-xs);
+  font-weight: var(--weight-extrabold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-caps);
+  color: var(--tp-hero-faint);
+  margin-block-end: 0.35rem;
+}
+
+.tracker-hero-readout__v {
+  display: block;
+  font-family: var(--font-numeric);
+  font-size: var(--text-data-xl);
+  font-weight: var(--weight-extrabold);
+  font-variant-numeric: tabular-nums;
+  color: var(--tp-hero-text);
+  line-height: var(--leading-tight);
+  letter-spacing: -0.02em;
+}
+
+.tracker-hero-readout__unit {
+  display: block;
+  margin-block-start: 0.25rem;
+  font-size: var(--text-ui-sm);
+  color: var(--tp-hero-muted);
+}
+
+.tracker-hero-readout__divider {
+  width: 1px;
+  align-self: stretch;
+  background: linear-gradient(
+    180deg,
+    transparent,
+    color-mix(in srgb, var(--color-gold) 35%, transparent) 50%,
+    transparent
+  );
+}
+
+.tracker-hero-readout__disclaimer {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding-block-start: var(--space-2);
+  border-block-start: 1px solid color-mix(in srgb, var(--color-gold) 18%, transparent);
+  font-size: var(--text-ui-sm);
+  color: var(--tp-hero-muted);
+  line-height: var(--leading-relaxed);
+}
+
+.tracker-hero-readout__disclaimer a {
+  color: var(--tp-gold-light);
+}
+
+/* ── Command center metadata card ──────────────────────────────────────── */
+
+.tracker-command-meta-card {
+  display: grid;
+  gap: var(--space-3);
+  margin-block: var(--space-4);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--color-gold) 16%, var(--tp-hero-border));
+  background: color-mix(in srgb, var(--tp-hero-glass) 90%, rgb(255 255 255 / 3%));
+  backdrop-filter: blur(10px);
+}
+
+.tracker-command-meta-card__heading {
+  margin: 0;
+  font-size: var(--text-ui-xs);
+  font-weight: var(--weight-extrabold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-caps);
+  color: var(--tp-hero-faint);
+}
+
+.tracker-command-meta-card .tracker-addon-slot {
+  margin: 0;
+}
+
+.tracker-command-meta-card .quote-meta-panel {
+  border: none;
+  background: transparent;
+  padding: 0;
+}
+
+.tracker-command-meta-card .quote-meta-panel__list {
+  grid-template-columns: minmax(120px, max-content) 1fr;
+  gap: var(--space-2) var(--space-4);
+}
+
+.tracker-command-meta-card .quote-meta-panel__label {
+  font-size: var(--text-ui-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.tracker-command-meta-card .quote-meta-panel__value {
+  font-size: var(--text-ui-sm);
+}
+
+/* ── Hero controls toolbar ───────────────────────────────────────────────── */
+
+.tracker-hero-controls {
+  padding: var(--space-4);
+  border-radius: var(--radius-xl);
+  border: 1px solid color-mix(in srgb, var(--color-gold) 14%, var(--tp-hero-border));
+  background: color-mix(in srgb, var(--tp-hero-glass) 85%, transparent);
+}
+
+.tracker-hero-field--unit .ds-segmented {
+  width: 100%;
+  justify-content: stretch;
+}
+
+.tracker-hero-field--unit .ds-segmented__btn {
+  flex: 1;
+}
+
+.tracker-hero-field--unit select.sr-only-focusable {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ── Toolbar card — breathable control band ─────────────────────────────── */
+
+.tracker-toolbar-card {
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-xl);
+  background: var(--gradient-card);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-sm);
+  margin-block-end: var(--section-gap);
+}
+
+.tracker-control-grid {
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-3);
+}
+
+.tracker-field span {
+  font-size: var(--text-ui-xs);
+}
+
+.tracker-field select,
+.tracker-field input,
+.tracker-search input {
+  font-size: var(--text-ui-sm);
+  min-height: var(--control-height);
+}
+
+/* ── Price matrix tables ─────────────────────────────────────────────────── */
+
+.tracker-ladder-table-wrap,
+.tracker-table-scroll {
+  border-radius: var(--radius-lg);
+  border: 1.5px solid var(--border-subtle);
+  box-shadow: var(--shadow-xs);
+}
+
+.tracker-table th,
+.tracker-table td {
+  padding: var(--table-cell-padding);
+  font-size: var(--table-body-size);
+}
+
+.tracker-table th {
+  font-size: var(--table-header-size);
+  background: linear-gradient(180deg, var(--surface-secondary), var(--surface-tertiary));
+  border-block-end: 1.5px solid color-mix(in srgb, var(--color-gold) 16%, var(--border-default));
+}
+
+.tracker-table td:nth-child(n + 3),
+.tracker-table th:nth-child(n + 3) {
+  text-align: end;
+  font-family: var(--font-numeric);
+  font-variant-numeric: tabular-nums;
+}
+
+.tracker-karat-table tbody tr:nth-child(even) {
+  background: color-mix(in srgb, var(--color-gold) 3%, var(--surface-primary));
+}
+
+.tracker-karat-table td[data-karat-price] {
+  font-size: var(--text-data-sm);
+  font-weight: var(--weight-bold);
+}
+
+td.tracker-chg-up {
+  color: var(--color-move-up);
+}
+
+td.tracker-chg-down {
+  color: var(--color-move-down);
+}
+
+.tracker-price-change-strip--up {
+  background: var(--color-move-up-bg);
+  color: var(--color-move-up);
+  border: 1px solid var(--color-move-up-border);
+}
+
+.tracker-price-change-strip--down {
+  background: var(--color-move-down-bg);
+  color: var(--color-move-down);
+  border: 1px solid var(--color-move-down-border);
+}
+
+.tracker-tag.up {
+  color: var(--color-move-up);
+  background: var(--color-move-up-bg);
+  border-color: var(--color-move-up-border);
+}
+
+.tracker-tag.down {
+  color: var(--color-move-down);
+  background: var(--color-move-down-bg);
+  border-color: var(--color-move-down-border);
+}
+
+/* ── Chart terminal + skeleton states ────────────────────────────────────── */
+
+.tracker-chart-wrap {
+  min-height: 420px;
+}
+
+.tracker-chart-skeleton {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.55rem;
+  padding: var(--space-5);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--tp-chart-bg) 70%, transparent),
+    var(--tp-chart-bg)
+  );
+  pointer-events: none;
+  transition: opacity var(--duration-normal) var(--ease-out);
+}
+
+.tracker-chart-wrap:not(.is-loading) .tracker-chart-skeleton {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.tracker-chart-skeleton__line {
+  block-size: 8px;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-gold) 8%, var(--surface-tertiary)) 0%,
+    color-mix(in srgb, var(--color-gold) 18%, var(--surface-secondary)) 50%,
+    color-mix(in srgb, var(--color-gold) 8%, var(--surface-tertiary)) 100%
+  );
+  background-size: 200% 100%;
+  animation: tp-chart-shimmer 1.4s ease-in-out infinite;
+}
+
+.tracker-chart-skeleton__line:nth-child(1) {
+  inline-size: 92%;
+}
+.tracker-chart-skeleton__line:nth-child(2) {
+  inline-size: 78%;
+}
+.tracker-chart-skeleton__line:nth-child(3) {
+  inline-size: 85%;
+}
+.tracker-chart-skeleton__line:nth-child(4) {
+  inline-size: 64%;
+}
+.tracker-chart-skeleton__line:nth-child(5) {
+  inline-size: 70%;
+}
+
+@keyframes tp-chart-shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
+}
+
+.tracker-chart-empty {
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-5);
+  text-align: center;
+  font-size: var(--text-ui-sm);
+  background: color-mix(in srgb, var(--surface-secondary) 60%, transparent);
+}
+
+.tracker-stat-k {
+  font-size: var(--text-ui-xs);
+}
+
+.tracker-stat-v {
+  font-size: var(--text-data-md);
+  font-family: var(--font-numeric);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Panel rhythm — reduce dead gaps ─────────────────────────────────────── */
+
+.tracker-main-shell {
+  padding-block-start: var(--space-2);
+}
+
+.tracker-panel {
+  margin-block-end: var(--section-gap);
+  padding: var(--space-5);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-subtle);
+  background: var(--gradient-card);
+  box-shadow: var(--shadow-sm);
+}
+
+.tracker-panel-head h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  letter-spacing: var(--tracking-tight);
+}
+
+.tracker-panel-head p {
+  font-size: var(--text-ui-base);
+  line-height: var(--leading-relaxed);
+  color: var(--text-secondary);
+  max-width: 68ch;
+}
+
+.tracker-command-note,
+.source-note {
+  font-size: var(--text-ui-sm);
+  line-height: var(--leading-relaxed);
+}
+
+/* ── RTL ─────────────────────────────────────────────────────────────────── */
+
+[dir='rtl'] .tracker-hero-readout__divider {
+  transform: scaleX(-1);
+}
+
+[dir='rtl'] .tracker-karat-table tbody tr.is-selected {
+  box-shadow: inset -3px 0 0 var(--tp-gold);
+}
+
+[dir='rtl'] .tracker-table td:nth-child(n + 3),
+[dir='rtl'] .tracker-table th:nth-child(n + 3) {
+  text-align: start;
+}
+
+[dir='rtl'] .chart-tv-attribution {
+  inset-inline-start: auto;
+  inset-inline-end: var(--space-2);
+}
+
+/* ── Dark theme parity ───────────────────────────────────────────────────── */
+
+[data-theme='dark'] .tracker-mode-shell {
+  background: color-mix(in srgb, var(--surface-primary) 90%, transparent);
+  box-shadow: 0 8px 28px rgb(0 0 0 / 28%);
+}
+
+[data-theme='dark'] .tracker-toolbar-card,
+[data-theme='dark'] .tracker-panel {
+  background: var(--gradient-card);
+  border-color: var(--border-default);
+}
+
+[data-theme='dark'] .tracker-ladder-table-wrap {
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 4%);
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+
+@media (width <= 1024px) {
+  .tracker-hero-readout {
+    grid-template-columns: 1fr;
+    gap: var(--space-3);
+  }
+
+  .tracker-hero-readout__divider {
+    width: 100%;
+    height: 1px;
+  }
+
+  .tracker-hero-selectors {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (width <= 640px) {
+  .tracker-hero-readout__v {
+    font-size: var(--text-data-lg);
+  }
+
+  .tracker-toolbar-card {
+    padding: var(--space-3);
+  }
+
+  .tracker-range-pills {
+    width: 100%;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    scrollbar-width: none;
+  }
+
+  .tracker-range-pills::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tracker-chart-skeleton__line {
+    animation: none;
+  }
+
+  .tracker-hero-readout,
+  .tracker-mode-shell {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}

--- a/styles/pages/tracker-pro.css
+++ b/styles/pages/tracker-pro.css
@@ -2,6 +2,7 @@
    Depends on styles/global.css design tokens only. Hero dark palette uses
    global gradient tokens; local hex only where compositor effects require it.
 */
+@import url('./tracker-pro-v4.css');
 
 /* ── Phase 1: Tracker token harmonization ─────────────────────────────────── */
 
@@ -78,9 +79,7 @@
 /* ── Page base ────────────────────────────────────────────────────────────── */
 
 body.tracker-pro-page {
-  background:
-    var(--gradient-section-alt),
-    var(--tp-bg);
+  background: var(--gradient-section-alt), var(--tp-bg);
   background-attachment: fixed;
 }
 
@@ -463,7 +462,11 @@ body.tracker-pro-page {
 /* Live badge — semantic green with soft glow */
 .tracker-badge-live {
   border-color: var(--tp-live-border);
-  background: linear-gradient(135deg, color-mix(in srgb, var(--tp-live) 16%, transparent), color-mix(in srgb, var(--tp-live) 6%, transparent));
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--tp-live) 16%, transparent),
+    color-mix(in srgb, var(--tp-live) 6%, transparent)
+  );
   color: var(--color-up);
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--tp-live) 12%, transparent) inset,
@@ -479,7 +482,11 @@ body.tracker-pro-page {
 
 .tracker-badge--stale {
   border-color: color-mix(in srgb, var(--tp-stale) 40%, transparent);
-  background: linear-gradient(135deg, color-mix(in srgb, var(--tp-stale) 14%, transparent), color-mix(in srgb, var(--tp-stale) 6%, transparent));
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--tp-stale) 14%, transparent),
+    color-mix(in srgb, var(--tp-stale) 6%, transparent)
+  );
   color: var(--tp-stale);
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--tp-stale) 10%, transparent) inset;
 }
@@ -523,12 +530,12 @@ body.tracker-pro-page {
   100% {
     transform: scale(1);
     opacity: 1;
-    box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 50%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in srgb, currentcolor 50%, transparent);
   }
   50% {
     transform: scale(1.2);
     opacity: 0.85;
-    box-shadow: 0 0 0 5px color-mix(in srgb, currentColor 0%, transparent);
+    box-shadow: 0 0 0 5px color-mix(in srgb, currentcolor 0%, transparent);
   }
 }
 
@@ -615,7 +622,9 @@ body.tracker-pro-page {
   color: var(--tp-gold-light);
   text-decoration: none;
   border-bottom: 1px solid color-mix(in srgb, var(--tp-gold) 35%, transparent);
-  transition: color var(--duration-fast) var(--ease-out), border-color var(--duration-fast) var(--ease-out);
+  transition:
+    color var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out);
 }
 
 .tracker-hero-description .tracker-inline-link:hover {
@@ -1114,7 +1123,11 @@ body.tracker-pro-page {
 
 .tracker-mode-tab.is-active,
 .tracker-mode-tab[aria-selected='true'] {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--tp-gold) 18%, transparent), color-mix(in srgb, var(--tp-gold) 8%, transparent));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--tp-gold) 18%, transparent),
+    color-mix(in srgb, var(--tp-gold) 8%, transparent)
+  );
   border-color: color-mix(in srgb, var(--tp-gold) 38%, transparent);
   color: var(--tp-accent);
   font-weight: var(--weight-bold);
@@ -1171,7 +1184,11 @@ body.tracker-pro-page {
   font-weight: var(--weight-semibold);
   padding: 0.45rem 0.9rem;
   min-height: 44px;
-  background: linear-gradient(135deg, color-mix(in srgb, var(--tp-gold) 10%, var(--surface-primary)), var(--surface-secondary));
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--tp-gold) 10%, var(--surface-primary)),
+    var(--surface-secondary)
+  );
   border: 1.5px solid color-mix(in srgb, var(--tp-gold) 28%, var(--tp-border));
   border-radius: var(--radius-lg);
   color: var(--tp-gold-strong);
@@ -1195,7 +1212,11 @@ body.tracker-pro-page {
 }
 
 .tracker-workspace-badge[aria-pressed='true'] {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--tp-gold) 18%, transparent), color-mix(in srgb, var(--tp-gold) 8%, transparent));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--tp-gold) 18%, transparent),
+    color-mix(in srgb, var(--tp-gold) 8%, transparent)
+  );
   border-color: color-mix(in srgb, var(--tp-gold) 48%, transparent);
   color: var(--tp-accent);
   font-weight: var(--weight-bold);
@@ -1620,7 +1641,11 @@ body.tracker-workspace-basic .tracker-advanced-only {
 
 .tracker-chip.is-active,
 .tracker-chip[aria-pressed='true'] {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--tp-gold) 16%, transparent), color-mix(in srgb, var(--tp-gold) 8%, transparent));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--tp-gold) 16%, transparent),
+    color-mix(in srgb, var(--tp-gold) 8%, transparent)
+  );
   border-color: color-mix(in srgb, var(--tp-gold) 42%, transparent);
   color: var(--tp-accent);
   font-weight: var(--weight-extrabold);
@@ -1770,7 +1795,11 @@ body.tracker-workspace-basic .tracker-advanced-only {
   border-radius: var(--radius-xl);
   border: 1.5px solid var(--tp-chart-border);
   background:
-    radial-gradient(ellipse 80% 60% at 50% 0%, color-mix(in srgb, var(--tp-gold) 6%, transparent), transparent 70%),
+    radial-gradient(
+      ellipse 80% 60% at 50% 0%,
+      color-mix(in srgb, var(--tp-gold) 6%, transparent),
+      transparent 70%
+    ),
     var(--tp-chart-bg);
   overflow: hidden;
   box-shadow:
@@ -4281,9 +4310,7 @@ td.tracker-chg-down {
    ═══════════════════════════════════════════════════════════════════════════ */
 
 [data-theme='dark'] body.tracker-pro-page {
-  background:
-    var(--gradient-section-alt),
-    var(--surface-canvas);
+  background: var(--gradient-section-alt), var(--surface-canvas);
 }
 
 [data-theme='dark'] .tracker-mode-shell {
@@ -4335,14 +4362,30 @@ td.tracker-chg-down {
   animation: none;
 }
 
-.tracker-hero-main > *:nth-child(1) { animation-delay: 0ms; }
-.tracker-hero-main > *:nth-child(2) { animation-delay: 40ms; }
-.tracker-hero-main > *:nth-child(3) { animation-delay: 80ms; }
-.tracker-hero-main > *:nth-child(4) { animation-delay: 120ms; }
-.tracker-hero-main > *:nth-child(5) { animation-delay: 160ms; }
-.tracker-hero-main > *:nth-child(6) { animation-delay: 200ms; }
-.tracker-hero-main > *:nth-child(7) { animation-delay: 240ms; }
-.tracker-hero-main > *:nth-child(8) { animation-delay: 280ms; }
+.tracker-hero-main > *:nth-child(1) {
+  animation-delay: 0ms;
+}
+.tracker-hero-main > *:nth-child(2) {
+  animation-delay: 40ms;
+}
+.tracker-hero-main > *:nth-child(3) {
+  animation-delay: 80ms;
+}
+.tracker-hero-main > *:nth-child(4) {
+  animation-delay: 120ms;
+}
+.tracker-hero-main > *:nth-child(5) {
+  animation-delay: 160ms;
+}
+.tracker-hero-main > *:nth-child(6) {
+  animation-delay: 200ms;
+}
+.tracker-hero-main > *:nth-child(7) {
+  animation-delay: 240ms;
+}
+.tracker-hero-main > *:nth-child(8) {
+  animation-delay: 280ms;
+}
 
 @media (prefers-reduced-motion: reduce) {
   .tracker-hero-main > * {
@@ -4768,7 +4811,11 @@ td.tracker-chg-down {
 
 [data-theme='dark'] .tracker-chart-wrap {
   background:
-    radial-gradient(ellipse 80% 60% at 50% 0%, color-mix(in srgb, var(--color-gold) 8%, transparent), transparent 70%),
+    radial-gradient(
+      ellipse 80% 60% at 50% 0%,
+      color-mix(in srgb, var(--color-gold) 8%, transparent),
+      transparent 70%
+    ),
     var(--tp-chart-bg);
 }
 

--- a/styles/partials/components.css
+++ b/styles/partials/components.css
@@ -65,6 +65,20 @@
   height: calc(var(--nav-height) - 8px);
 }
 
+.site-nav--premium {
+  background: color-mix(in srgb, var(--surface-primary) 90%, transparent);
+  box-shadow:
+    0 1px 0 0 var(--border-subtle),
+    0 6px 28px rgb(21 17 10 / 7%);
+}
+
+[data-theme='dark'] .site-nav--premium {
+  background: color-mix(in srgb, var(--surface-primary) 92%, transparent);
+  box-shadow:
+    0 1px 0 0 var(--border-default),
+    0 8px 32px rgb(0 0 0 / 32%);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .nav-inner {
     transition: none;
@@ -3252,19 +3266,18 @@ details[open] > .faq-q::after {
 
 .gold-ticker {
   position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  inset-inline: 0;
+  inset-block-end: 0;
   z-index: 200;
-  height: 38px;
-  background: rgb(12 8 2 / 94%);
-  backdrop-filter: blur(14px) saturate(1.4);
-  border-top: 1px solid rgb(176 138 62 / 20%);
-  box-shadow: 0 -2px 16px rgb(0 0 0 / 18%);
+  height: 40px;
+  background: color-mix(in srgb, var(--surface-primary) 92%, rgb(12 8 2 / 88%));
+  backdrop-filter: blur(16px) saturate(1.5);
+  border-block-start: 1px solid color-mix(in srgb, var(--color-gold) 22%, transparent);
+  box-shadow: 0 -4px 24px rgb(21 17 10 / 12%);
   display: flex;
   align-items: center;
   overflow: hidden;
-  transition: transform 0.3s ease;
+  transition: transform var(--duration-normal) var(--ease-out);
 }
 
 .gold-ticker.ticker-dismissed {
@@ -3299,30 +3312,31 @@ details[open] > .faq-q::after {
   gap: 0.45rem;
   padding: 0 1.25rem;
   text-decoration: none;
-  color: rgb(255 255 255 / 82%);
-  font-size: 0.78rem;
-  transition: color 0.15s ease;
-  height: 38px;
+  color: var(--text-primary);
+  font-size: var(--text-ui-sm);
+  transition: color var(--duration-fast) var(--ease-out);
+  height: 40px;
 }
 
 .ticker-item:hover {
-  color: var(--color-gold-light);
+  color: var(--color-gold-dark);
   text-decoration: none;
 }
 
 .ticker-label {
-  color: rgb(255 255 255 / 45%);
-  font-size: 0.72rem;
+  color: var(--text-secondary);
+  font-size: var(--text-ui-xs);
   font-weight: var(--weight-semibold);
   text-transform: uppercase;
   letter-spacing: var(--tracking-wider);
 }
 
 .ticker-value {
-  color: var(--color-gold-light, #e5c96e);
+  color: var(--color-gold-dark);
   font-weight: var(--weight-bold);
-  font-size: 0.82rem;
+  font-size: var(--text-ui-sm);
   letter-spacing: 0.01em;
+  font-family: var(--font-numeric);
   font-variant-numeric: tabular-nums;
 }
 
@@ -3362,13 +3376,13 @@ details[open] > .faq-q::after {
   gap: 0.4rem;
   flex-shrink: 0;
   padding: 0 0.75rem 0 0.85rem;
-  height: 38px;
-  font-size: 0.68rem;
+  height: 40px;
+  font-size: var(--text-2xs);
   font-weight: var(--weight-semibold);
   letter-spacing: var(--tracking-wider);
   text-transform: uppercase;
-  color: rgb(255 255 255 / 55%);
-  border-right: 1px solid rgb(176 138 62 / 15%);
+  color: var(--text-secondary);
+  border-inline-end: 1px solid var(--border-subtle);
   cursor: help;
 }
 
@@ -3382,14 +3396,14 @@ details[open] > .faq-q::after {
 }
 
 .gold-ticker[data-freshness='live'] .ticker-status {
-  color: rgb(74 222 128 / 95%);
+  color: var(--color-move-up);
 }
 
 .gold-ticker[data-freshness='live'] .ticker-status-dot {
-  background: #22c55e;
+  background: var(--color-move-up);
   box-shadow:
-    0 0 0 0 rgb(34 197 94 / 55%),
-    0 0 8px rgb(34 197 94 / 50%);
+    0 0 0 0 color-mix(in srgb, var(--color-move-up) 55%, transparent),
+    0 0 8px color-mix(in srgb, var(--color-move-up) 50%, transparent);
   animation: ticker-dot-live 2s ease-in-out infinite;
 }
 
@@ -3417,33 +3431,33 @@ details[open] > .faq-q::after {
 }
 
 .gold-ticker[data-freshness='cached'] .ticker-status {
-  color: rgb(250 204 21 / 90%);
+  color: var(--color-daily);
 }
 
 .gold-ticker[data-freshness='cached'] .ticker-status-dot {
-  background: #facc15;
+  background: var(--color-daily);
 }
 
 .gold-ticker[data-freshness='stale'] .ticker-status {
-  color: rgb(251 146 60 / 95%);
+  color: var(--color-warning);
 }
 
 .gold-ticker[data-freshness='stale'] .ticker-status-dot {
-  background: #f97316;
-  box-shadow: 0 0 6px rgb(249 115 22 / 40%);
+  background: var(--color-warning);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--color-warning) 40%, transparent);
 }
 
 .gold-ticker[data-freshness='unavailable'] .ticker-status {
-  color: rgb(248 113 113 / 90%);
+  color: var(--text-secondary);
 }
 
 .gold-ticker[data-freshness='unavailable'] .ticker-status-dot {
-  background: #f87171;
+  background: var(--text-tertiary);
 }
 
 /* Body padding when ticker is present */
 body.has-ticker {
-  padding-bottom: 38px;
+  padding-block-end: 40px;
 }
 
 /* prefers-reduced-motion */
@@ -4185,11 +4199,207 @@ button,
 /* Windows High Contrast / forced-colors mode:
    gradient text via -webkit-text-fill-color:transparent becomes invisible
    because the system ignores background images. Reset to system text color. */
+[data-theme='dark'] .gold-ticker {
+  background: color-mix(in srgb, var(--surface-primary) 94%, rgb(6 7 8 / 90%));
+  border-block-start-color: color-mix(in srgb, var(--color-gold) 28%, transparent);
+  box-shadow: 0 -4px 28px rgb(0 0 0 / 35%);
+}
+
+[data-theme='dark'] .ticker-item {
+  color: var(--text-primary);
+}
+
+[data-theme='dark'] .ticker-item:hover {
+  color: var(--color-gold-light);
+}
+
+[data-theme='dark'] .ticker-value {
+  color: var(--color-gold-light);
+}
+
 @media (forced-colors: active) {
   .home-stat-value {
     background: none;
     -webkit-text-fill-color: CanvasText;
     color: CanvasText;
     forced-color-adjust: auto;
+  }
+}
+
+/* ═══════════════════════════════════════════════
+   Design System v4 — shared UI primitives
+   Segmented controls, cards, badges, tables, selects
+   ═══════════════════════════════════════════════ */
+
+.ds-segmented {
+  display: inline-flex;
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: 0;
+  padding: 3px;
+  border-radius: var(--radius-pill);
+  background: var(--segmented-bg);
+  border: 1px solid var(--segmented-border);
+  box-shadow: inset 0 1px 2px rgb(21 17 10 / 4%);
+}
+
+.ds-segmented__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--control-height-sm);
+  min-width: var(--control-height-sm);
+  padding: 0 0.85rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: var(--text-ui-sm);
+  font-weight: var(--weight-bold);
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out);
+}
+
+.ds-segmented__btn:hover {
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--color-gold) 8%, transparent);
+}
+
+.ds-segmented__btn.is-active,
+.ds-segmented__btn[aria-pressed='true'] {
+  background: var(--segmented-active-bg);
+  border-color: var(--segmented-active-border);
+  color: var(--text-accent);
+  font-weight: var(--weight-extrabold);
+  box-shadow: var(--shadow-xs);
+}
+
+.ds-segmented__btn:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+}
+
+.ds-card {
+  border-radius: var(--radius-card);
+  border: 1px solid var(--border-subtle);
+  background: var(--gradient-card);
+  padding: var(--card-padding);
+  box-shadow: var(--shadow-sm);
+}
+
+.ds-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: var(--badge-height);
+  padding: 0.2rem 0.65rem;
+  border-radius: var(--radius-badge);
+  font-size: var(--text-ui-xs);
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+}
+
+.ds-badge--live {
+  color: var(--color-live);
+  background: var(--color-live-bg);
+  border-color: var(--color-live-border);
+}
+
+.ds-badge--move-up {
+  color: var(--color-move-up);
+  background: var(--color-move-up-bg);
+  border-color: var(--color-move-up-border);
+}
+
+.ds-badge--move-down {
+  color: var(--color-move-down);
+  background: var(--color-move-down-bg);
+  border-color: var(--color-move-down-border);
+}
+
+.ds-select {
+  width: 100%;
+  min-height: var(--control-height);
+  padding-inline: var(--space-3);
+  border-radius: var(--radius-control);
+  border: 1px solid var(--border-default);
+  background: var(--surface-primary);
+  color: var(--text-primary);
+  font-size: var(--text-ui-sm);
+  font-weight: var(--weight-semibold);
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out);
+}
+
+.ds-select:hover {
+  border-color: color-mix(in srgb, var(--color-gold) 45%, var(--border-default));
+}
+
+.ds-select:focus-visible {
+  outline: none;
+  border-color: var(--color-gold);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-gold) 22%, transparent);
+}
+
+.ds-table-wrap {
+  overflow: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-primary);
+}
+
+.ds-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--table-body-size);
+}
+
+.ds-table th,
+.ds-table td {
+  padding: var(--table-cell-padding);
+  border-block-end: 1px solid var(--border-subtle);
+  text-align: start;
+  vertical-align: middle;
+}
+
+.ds-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--surface-secondary);
+  font-size: var(--table-header-size);
+  font-weight: var(--weight-extrabold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+}
+
+.ds-table td.is-numeric,
+.ds-table th.is-numeric {
+  text-align: end;
+  font-family: var(--font-numeric);
+  font-variant-numeric: tabular-nums;
+}
+
+.ds-table tbody tr:nth-child(even) {
+  background: color-mix(in srgb, var(--color-gold) 3%, var(--surface-primary));
+}
+
+.ds-table tbody tr:hover {
+  background: color-mix(in srgb, var(--color-gold) 7%, var(--surface-primary));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ds-segmented__btn {
+    transition: none;
   }
 }

--- a/styles/partials/market-summary-ticker.css
+++ b/styles/partials/market-summary-ticker.css
@@ -84,18 +84,18 @@
 
 /* Change direction colours */
 .mst-item--up .mst-item__change {
-  color: #4ade80;
-  background: rgb(74 222 128 / 12%);
+  color: var(--color-move-up);
+  background: var(--color-move-up-bg);
 }
 
 .mst-item--down .mst-item__change {
-  color: #f87171;
-  background: rgb(248 113 113 / 12%);
+  color: var(--color-move-down);
+  background: var(--color-move-down-bg);
 }
 
 /* Market status indicator */
 .mst-item--open .mst-item__value {
-  color: #4ade80;
+  color: var(--color-move-up);
 }
 
 .mst-item--closed .mst-item__value {

--- a/styles/partials/tokens.css
+++ b/styles/partials/tokens.css
@@ -40,10 +40,16 @@
   --color-fixed-border: rgb(16 80 160 / 22%);
   --color-stale: #a84000;
   --color-stale-bg: rgb(168 64 0 / 9%);
-  --color-up: #176832;
-  --color-up-bg: rgb(23 104 50 / 8%);
-  --color-down: #b81428;
-  --color-down-bg: rgb(184 20 40 / 8%);
+  --color-move-up: #176832;
+  --color-move-down: #b81428;
+  --color-move-up-bg: rgb(23 104 50 / 8%);
+  --color-move-down-bg: rgb(184 20 40 / 8%);
+  --color-move-up-border: rgb(23 104 50 / 22%);
+  --color-move-down-border: rgb(184 20 40 / 22%);
+  --color-up: var(--color-move-up);
+  --color-down: var(--color-move-down);
+  --color-up-bg: var(--color-move-up-bg);
+  --color-down-bg: var(--color-move-down-bg);
   --color-error: #b81428;
   --color-error-bg: rgb(184 20 40 / 8%);
   --color-error-border: #f87171; /* error card / danger-zone border */
@@ -292,6 +298,35 @@
     var(--color-gold) 80%,
     transparent
   );
+
+  /* ── Design System v4 — unified movement + readable data scale ── */
+  --color-champagne: #d4b86a;
+  --color-champagne-soft: #f5ecd4;
+
+  /* Readable UI / data type scale — fixes tiny-text walls */
+  --text-ui-xs: 0.8125rem;
+  --text-ui-sm: 0.875rem;
+  --text-ui-base: 0.9375rem;
+  --text-ui-md: 1.0625rem;
+  --text-data-sm: 1rem;
+  --text-data-md: 1.25rem;
+  --text-data-lg: clamp(1.65rem, 3.6vw, 2.35rem);
+  --text-data-xl: clamp(2.1rem, 4.8vw, 3.15rem);
+
+  /* Component primitive tokens */
+  --control-height: 44px;
+  --control-height-sm: 36px;
+  --segmented-bg: var(--surface-secondary);
+  --segmented-border: var(--border-subtle);
+  --segmented-active-bg: var(--gradient-gold-subtle);
+  --segmented-active-border: color-mix(in srgb, var(--color-gold) 42%, transparent);
+  --card-padding: var(--space-4);
+  --table-cell-padding: 0.85rem 1rem;
+  --table-header-size: var(--text-ui-xs);
+  --table-body-size: var(--text-ui-sm);
+  --badge-height: 28px;
+  --section-fade-height: 48px;
+  --section-gap: var(--space-6);
 }
 
 /* ═══════════════════════════════════════════════
@@ -329,8 +364,16 @@
   --color-daily: #f0a350;
   --color-fixed: #6ba3f0;
   --color-stale: #f0a350;
-  --color-up: #5dd98b;
-  --color-down: #f87171;
+  --color-move-up: #5dd98b;
+  --color-move-down: #f87171;
+  --color-move-up-bg: rgb(93 217 139 / 12%);
+  --color-move-down-bg: rgb(248 113 113 / 12%);
+  --color-move-up-border: rgb(93 217 139 / 28%);
+  --color-move-down-border: rgb(248 113 113 / 28%);
+  --color-up: var(--color-move-up);
+  --color-down: var(--color-move-down);
+  --color-up-bg: var(--color-move-up-bg);
+  --color-down-bg: var(--color-move-down-bg);
   --color-error: #f87171;
   --color-warning: #e0b060;
   --color-warning-text: #e0b060;

--- a/tracker.html
+++ b/tracker.html
@@ -201,17 +201,44 @@
                 <span>Gold market</span>
               </span>
             </div>
-            <div id="tp-freshness-badge-slot" class="tracker-addon-slot"></div>
-            <p
-              id="tp-price-change-strip"
-              class="tracker-price-change-strip"
-              hidden
-              role="status"
-              aria-live="polite"
-            ></p>
-            <div id="tp-market-status-slot" class="tracker-addon-slot"></div>
-            <div id="tp-quote-meta-slot" class="tracker-addon-slot"></div>
-            <div id="tp-realtime-sla-slot" class="tracker-addon-slot"></div>
+
+            <!-- Primary live readout — spot + selected karat -->
+            <div class="tracker-hero-readout" id="tp-hero-readout" aria-live="polite">
+              <div class="tracker-hero-readout__spot">
+                <span class="tracker-hero-readout__k" id="tp-readout-spot-label">XAU/USD spot</span>
+                <strong class="tracker-hero-readout__v" id="tp-readout-spot-value">
+                  <span class="skeleton-inline shell-skeleton-price-lg" aria-busy="true"></span>
+                </strong>
+              </div>
+              <div class="tracker-hero-readout__divider" aria-hidden="true"></div>
+              <div class="tracker-hero-readout__selected">
+                <span class="tracker-hero-readout__k" id="tp-readout-selected-label">Selected reference</span>
+                <strong class="tracker-hero-readout__v" id="tp-readout-selected-value">
+                  <span class="skeleton-inline shell-skeleton-price-lg" aria-busy="true"></span>
+                </strong>
+                <span class="tracker-hero-readout__unit" id="tp-readout-unit-note"></span>
+              </div>
+              <p class="tracker-hero-readout__disclaimer" id="tp-readout-disclaimer">
+                Spot-linked reference prices before making charges and VAT ·
+                <a href="methodology.html#spot-vs-retail" class="tracker-inline-link">Spot vs retail</a>
+              </p>
+            </div>
+
+            <!-- Trust + metadata command band -->
+            <div class="tracker-command-meta-card" id="tp-command-meta" aria-label="Data trust and coverage">
+              <h2 class="tracker-command-meta-card__heading" id="tp-command-meta-heading">Quote context</h2>
+              <div id="tp-freshness-badge-slot" class="tracker-addon-slot"></div>
+              <p
+                id="tp-price-change-strip"
+                class="tracker-price-change-strip"
+                hidden
+                role="status"
+                aria-live="polite"
+              ></p>
+              <div id="tp-market-status-slot" class="tracker-addon-slot"></div>
+              <div id="tp-quote-meta-slot" class="tracker-addon-slot"></div>
+              <div id="tp-realtime-sla-slot" class="tracker-addon-slot"></div>
+            </div>
 
             <h1 id="tp-hero-title" class="tracker-hero-title">
               <span class="tracker-hero-kicker" id="tp-hero-kicker"></span>
@@ -267,9 +294,20 @@
                   <span class="tracker-field-label">Karat</span>
                   <select id="tp-karat" aria-label="Karat"></select>
                 </label>
-                <label class="tracker-hero-field">
+                <label class="tracker-hero-field tracker-hero-field--unit">
                   <span class="tracker-field-label">Unit</span>
-                  <select id="tp-unit" aria-label="Unit"></select>
+                  <div
+                    class="ds-segmented tracker-unit-segmented"
+                    id="tp-unit-segmented"
+                    role="group"
+                    aria-label="Unit"
+                  >
+                    <button type="button" class="ds-segmented__btn is-active" data-unit="gram" aria-pressed="true" title="Gram">g</button>
+                    <button type="button" class="ds-segmented__btn" data-unit="tola" aria-pressed="false" title="Tola">tola</button>
+                    <button type="button" class="ds-segmented__btn" data-unit="oz" aria-pressed="false" title="Troy ounce">oz</button>
+                    <button type="button" class="ds-segmented__btn" data-unit="kg" aria-pressed="false" title="Kilogram">kg</button>
+                  </div>
+                  <select id="tp-unit" class="sr-only-focusable" aria-label="Unit"></select>
                 </label>
               </div>
 
@@ -661,7 +699,7 @@
               making charges, dealer margin, and VAT.
             </p>
             <div class="tracker-ladder-table-wrap" aria-label="Karat ladder">
-              <table class="tracker-table tracker-karat-table table-interactive">
+              <table class="tracker-table tracker-karat-table table-interactive ds-table">
                 <caption class="sr-only">Karat ladder — spot-linked reference price per selected unit for the selected market</caption>
                 <thead>
                   <tr>
@@ -714,6 +752,13 @@
             </div>
 
             <div class="tracker-chart-wrap" aria-label="Gold price chart" role="group" aria-describedby="tp-chart-source-note">
+              <div class="tracker-chart-skeleton" id="tp-chart-skeleton" aria-hidden="true">
+                <div class="tracker-chart-skeleton__line"></div>
+                <div class="tracker-chart-skeleton__line"></div>
+                <div class="tracker-chart-skeleton__line"></div>
+                <div class="tracker-chart-skeleton__line"></div>
+                <div class="tracker-chart-skeleton__line"></div>
+              </div>
               <svg id="tp-chart" viewBox="0 0 1200 430" aria-hidden="true"></svg>
               <div
                 class="tracker-tooltip"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Premium visual/UX elevation for **Tracker** (primary), **Homepage**, and a shared **Design System v4** that lifts nav, ticker, chart, and component styling sitewide — visual layer only; no pricing logic changes.

## Why

The tracker felt unpolished: cramped control band, tiny table text, harsh dark↔light section transitions, and clashing red/orange/gold movement colors. This PR unifies tokens, typography, spacing, and reusable primitives so both pages read as one trustworthy, premium product.

## How

### Design System v4 (`styles/partials/tokens.css` + `styles/partials/components.css`)
- **One movement pair:** `--color-move-up` / `--color-move-down` (aliases `--color-up` / `--color-down`) used everywhere prices move
- **Champagne gold** palette refinements on warm parchment / rich dark surfaces
- **Readable data scale:** `--text-ui-*`, `--text-data-*`, tabular numerics on all prices
- **Shared primitives:** `.ds-segmented`, `.ds-card`, `.ds-badge`, `.ds-select`, `.ds-table`
- **Light + dark** token parity; theme-aware chart colors via CSS custom properties

### Tracker (`tracker.html`, `styles/pages/tracker-pro-v4.css`, `src/pages/tracker-pro.js`)
- **Hero readout:** confident XAU/USD + selected karat primary display with spot-vs-retail disclaimer
- **Command meta card:** grouped freshness / quote metadata (replaces wall-of-small-text layout)
- **Control band:** breathable toolbar, unit **segmented control** (g/tola/oz/kg) synced to `#tp-unit`
- **Price matrix:** sticky headers, zebra rows, right-aligned tabular numerics, larger cell padding
- **Chart:** skeleton loading state, theme-synced Lightweight Charts colors, refined terminal frame
- **Mode shell:** frosted sticky bar with smooth hero→workspace fade (no abrupt slam)

### Homepage (`index.html`, `styles/pages/home.css`)
- Hero spot card uses `ds-card`; chart range toggle uses `ds-segmented`
- Section rhythm, larger price typography, unified movement colors on change badges
- Karat strip unit toggle aligned to segmented primitive

### Shared components
- **`chart.js`:** reads design tokens; re-applies on `[data-theme]` change
- **`nav.js`:** `site-nav--premium` glass elevation
- **`components.css` ticker:** warm neutral bar (not harsh black/orange clash); logical RTL borders

## Proof

| Check | Result |
| --- | --- |
| `npm test` | **1090/1090 pass** |
| `npm run lint` | pass |
| `npm run validate` | pass |
| `npm run build` | pass |

### Visual verification (Playwright screenshots)

**Tracker — before (main @ f02948e) vs after (this branch)**

| Before | After |
| --- | --- |
| [Before tracker EN light 1440](https://cursor.com/agents/bc-351da7b8-908e-456a-a0bc-9134a22cd39c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbefore-tracker-en-light-1440.png) | [After tracker EN light 1440](https://cursor.com/agents/bc-351da7b8-908e-456a-a0bc-9134a22cd39c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-tracker-en-light-1440.png) |
| [Before tracker AR dark 1440](https://cursor.com/agents/bc-351da7b8-908e-456a-a0bc-9134a22cd39c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbefore-tracker-ar-dark-1440.png) | [After tracker AR dark 1440](https://cursor.com/agents/bc-351da7b8-908e-456a-a0bc-9134a22cd39c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-tracker-ar-dark-1440.png) |
| [Before tracker EN light 768](https://cursor.com/agents/bc-351da7b8-908e-456a-a0bc-9134a22cd39c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbefore-tracker-en-light-768.png) | [After tracker EN light 768](https://cursor.com/agents/bc-351da7b8-908e-456a-a0bc-9134a22cd39c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-tracker-en-light-768.png) |
| [Before tracker EN light 360](https://cursor.com/agents/bc-351da7b8-908e-456a-a0bc-9134a22cd39c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbefore-tracker-en-light-360.png) | [After tracker EN light 360](https://cursor.com/agents/bc-351da7b8-908e-456a-a0bc-9134a22cd39c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-tracker-en-light-360.png) |

**Homepage after (EN/AR × light/dark × 360–1440px):** 20 screenshots captured (`after-home-*`). Representative:

[After homepage EN light 1440](https://cursor.com/agents/bc-351da7b8-908e-456a-a0bc-9134a22cd39c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-home-en-light-1440.png)

Verified locally at 360 / 390 / 768 / 1024 / 1440px: no console errors observed during capture, tables/chart render, freshness badges unchanged in vocabulary, AED peg / pricing logic untouched.

## Risks

- **CSS specificity:** v4 layer imported at top of `tracker-pro.css`; existing rules still apply underneath — monitor for edge-case overrides on compare/archive modes
- **Ticker contrast:** bottom bar shifted from dark-only to theme-aware surface — verify on real devices with bottom nav + ticker stacked
- **No pricing/SEO changes:** `<head>` SEO, freshness semantics, and data layer intentionally untouched

## Out of scope (parallel SEO task)

- `shops.html`, `calculator.html`, country pages, `sitemap.xml`, all `<head>` SEO content

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-351da7b8-908e-456a-a0bc-9134a22cd39c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-351da7b8-908e-456a-a0bc-9134a22cd39c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

