### PR TITLE
SEO: structured data, metadata limits & OG/Twitter QA for content pages

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -7,10 +7,10 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price Calculator UAE — Grams to AED | Gold Ticker Live</title>
+    <title>Gold Calculator — Value, Scrap, Zakat | Gold Ticker Live</title>
     <meta
       name="description"
-      content="Free gold price calculator for UAE. Convert any weight and karat to AED or USD instantly. Includes 24K, 22K, 21K, 18K, 14K, 10K."
+      content="Free gold calculator: value any weight and karat in AED or USD, plus scrap, Zakat (2.5%), buying power and unit conversion using live reference rates."
     />
     <link rel="canonical" href="https://goldtickerlive.com/calculator.html" />
     <link rel="alternate" hreflang="x-default" href="https://goldtickerlive.com/calculator.html" />
@@ -83,6 +83,40 @@
       "item": "https://goldtickerlive.com/calculator.html"
     }
   ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Gold Calculator",
+  "url": "https://goldtickerlive.com/calculator.html",
+  "description": "Free gold calculator: value any weight and karat in AED or USD, plus scrap, Zakat (2.5%), buying power and unit conversion using live reference rates.",
+  "applicationCategory": "FinanceApplication",
+  "operatingSystem": "Any (web browser)",
+  "browserRequirements": "Requires JavaScript",
+  "isAccessibleForFree": true,
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "featureList": [
+    "Gold value calculator (any weight and karat)",
+    "Scrap / melt gold value calculator",
+    "Zakat on gold calculator (2.5%)",
+    "Buying power calculator",
+    "Gold weight unit converter"
+  ],
+  "inLanguage": [
+    "en",
+    "ar"
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  }
 }
   </script>
   </head>

--- a/countries/algeria/index.html
+++ b/countries/algeria/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Algeria Today — DZD per Gram | Gold Ticker Live</title>
+    <title>Gold Price in Algeria Today — DZD | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Algeria in DZD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Algerian Dinar."
@@ -31,10 +31,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/algeria/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Algeria reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Algeria Today — DZD Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in Algerian Dinar (DZD). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#b08a3e" />
@@ -71,6 +76,27 @@
       "name": "Algeria",
       "item": "https://goldtickerlive.com/countries/algeria/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Algeria Today — DZD | Gold Ticker Live",
+  "description": "Live gold price in Algeria in DZD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Algerian Dinar.",
+  "url": "https://goldtickerlive.com/countries/algeria/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in DZD",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/bahrain/index.html
+++ b/countries/bahrain/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Bahrain Today — BHD per Gram | Gold Ticker Live</title>
+    <title>Gold Price in Bahrain Today — BHD | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Bahrain in BHD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Bahraini Dinar."
@@ -31,10 +31,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/bahrain/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Bahrain reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Bahrain Today — BHD Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in Bahraini Dinar (BHD). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -69,6 +74,27 @@
       "name": "Bahrain",
       "item": "https://goldtickerlive.com/countries/bahrain/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Bahrain Today — BHD | Gold Ticker Live",
+  "description": "Live gold price in Bahrain in BHD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Bahraini Dinar.",
+  "url": "https://goldtickerlive.com/countries/bahrain/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in BHD",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/egypt/index.html
+++ b/countries/egypt/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Egypt Today — EGP per Gram (عيار 21) | Gold Ticker Live</title>
+    <title>Gold Price in Egypt Today — EGP | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Egypt today in EGP per gram. Updated every 90 seconds. 24K (عيار 24), 21K, 18K gold rates in Egyptian Pound."
@@ -27,10 +27,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/egypt/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Egypt reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Egypt Today — EGP Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 21K, 18K gold prices in Egyptian Pound (EGP). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -65,6 +70,27 @@
       "name": "Egypt",
       "item": "https://goldtickerlive.com/countries/egypt/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Egypt Today — EGP | Gold Ticker Live",
+  "description": "Live gold price in Egypt today in EGP per gram. Updated every 90 seconds. 24K (عيار 24), 21K, 18K gold rates in Egyptian Pound.",
+  "url": "https://goldtickerlive.com/countries/egypt/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in EGP",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/india/index.html
+++ b/countries/india/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in India Today — INR per Gram (24K, 22K) | Gold Ticker Live</title>
+    <title>Gold Price in India Today — INR | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in India today in INR per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Indian Rupee."
@@ -27,10 +27,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/india/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="India reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in India Today — INR Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in Indian Rupee (INR). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -65,6 +70,27 @@
       "name": "India",
       "item": "https://goldtickerlive.com/countries/india/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in India Today — INR | Gold Ticker Live",
+  "description": "Live gold price in India today in INR per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Indian Rupee.",
+  "url": "https://goldtickerlive.com/countries/india/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in INR",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/iraq/index.html
+++ b/countries/iraq/index.html
@@ -7,9 +7,9 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <meta name="description" content="Today spot-linked reference gold price in Iraq, with 24K, 22K, 21K, 18K, and 14K rates in IQD per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
-    <meta property="og:title" content="Gold price today in Iraq — IQD reference rates | Gold Ticker Live" />
-    <meta property="og:description" content="Today spot-linked reference gold price in Iraq, with 24K, 22K, 21K, 18K, and 14K rates in IQD per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
+    <meta name="description" content="Spot-linked reference gold price in Iraq today — 24K, 22K, 21K, 18K and 14K rates in IQD per gram, with freshness labels and methodology." />
+    <meta property="og:title" content="Gold Price in Iraq Today — IQD per Gram" />
+    <meta property="og:description" content="Spot-linked reference gold price in Iraq today — 24K, 22K, 21K, 18K and 14K rates in IQD per gram, with freshness labels and methodology." />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:locale:alternate" content="ar_AE" />
@@ -19,14 +19,14 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Iraq reference gold prices on Gold Ticker Live" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Gold price today in Iraq — IQD reference rates | Gold Ticker Live" />
-    <meta name="twitter:description" content="Today spot-linked reference gold price in Iraq, with 24K, 22K, 21K, 18K, and 14K rates in IQD per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
+    <meta name="twitter:title" content="Gold Price in Iraq Today — IQD per Gram" />
+    <meta name="twitter:description" content="Spot-linked reference gold price in Iraq today — 24K, 22K, 21K, 18K and 14K rates in IQD per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="canonical" href="https://goldtickerlive.com/countries/iraq/" />
     <link rel="alternate" hreflang="x-default" href="https://goldtickerlive.com/countries/iraq/" />
     <link rel="alternate" hreflang="en" href="https://goldtickerlive.com/countries/iraq/" />
     <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/countries/iraq/?lang=ar" />
-    <title>Gold price today in Iraq — IQD reference rates | Gold Ticker Live</title>
+    <title>Gold Price in Iraq Today — IQD | Gold Ticker Live</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://open.er-api.com" />
@@ -60,6 +60,27 @@
       "name": "Iraq",
       "item": "https://goldtickerlive.com/countries/iraq/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Iraq Today — IQD | Gold Ticker Live",
+  "description": "Spot-linked reference gold price in Iraq today — 24K, 22K, 21K, 18K and 14K rates in IQD per gram, with freshness labels and methodology.",
+  "url": "https://goldtickerlive.com/countries/iraq/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in IQD",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/jordan/index.html
+++ b/countries/jordan/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Jordan Today — JOD per Gram | Gold Ticker Live</title>
+    <title>Gold Price in Jordan Today — JOD | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Jordan in JOD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Jordanian Dinar."
@@ -31,10 +31,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/jordan/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Jordan reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Jordan Today — JOD Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in Jordanian Dinar (JOD). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -69,6 +74,27 @@
       "name": "Jordan",
       "item": "https://goldtickerlive.com/countries/jordan/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Jordan Today — JOD | Gold Ticker Live",
+  "description": "Live gold price in Jordan in JOD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Jordanian Dinar.",
+  "url": "https://goldtickerlive.com/countries/jordan/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in JOD",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/kuwait/index.html
+++ b/countries/kuwait/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Kuwait Today — KWD per Gram (24K, 22K, 21K) | Gold Ticker Live</title>
+    <title>Gold Price in Kuwait Today — KWD | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Kuwait today in KWD per gram and troy oz. Updated every 90 seconds. 24K, 22K, 21K and 18K gold rates in Kuwaiti Dinar."
@@ -31,10 +31,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/kuwait/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Kuwait reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Kuwait Today — KWD Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in Kuwaiti Dinar (KWD). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -69,6 +74,27 @@
       "name": "Kuwait",
       "item": "https://goldtickerlive.com/countries/kuwait/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Kuwait Today — KWD | Gold Ticker Live",
+  "description": "Live gold price in Kuwait today in KWD per gram and troy oz. Updated every 90 seconds. 24K, 22K, 21K and 18K gold rates in Kuwaiti Dinar.",
+  "url": "https://goldtickerlive.com/countries/kuwait/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in KWD",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/lebanon/index.html
+++ b/countries/lebanon/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Lebanon Today — LBP per Gram | Gold Ticker Live</title>
+    <title>Gold Price in Lebanon Today — LBP | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Lebanon in LBP per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Lebanese Pound."
@@ -31,10 +31,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/lebanon/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Lebanon reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Lebanon Today — LBP Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in Lebanese Pound (LBP). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#b08a3e" />
@@ -71,6 +76,27 @@
       "name": "Lebanon",
       "item": "https://goldtickerlive.com/countries/lebanon/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Lebanon Today — LBP | Gold Ticker Live",
+  "description": "Live gold price in Lebanon in LBP per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Lebanese Pound.",
+  "url": "https://goldtickerlive.com/countries/lebanon/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in LBP",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/libya/index.html
+++ b/countries/libya/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Libya Today — LYD per Gram | Gold Ticker Live</title>
+    <title>Gold Price in Libya Today — LYD | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Libya in LYD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Libyan Dinar."
@@ -27,10 +27,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/libya/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Libya reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Libya Today — LYD Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in Libyan Dinar (LYD). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#b08a3e" />
@@ -67,6 +72,27 @@
       "name": "Libya",
       "item": "https://goldtickerlive.com/countries/libya/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Libya Today — LYD | Gold Ticker Live",
+  "description": "Live gold price in Libya in LYD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Libyan Dinar.",
+  "url": "https://goldtickerlive.com/countries/libya/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in LYD",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/morocco/index.html
+++ b/countries/morocco/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Morocco Today — MAD per Gram | Gold Ticker Live</title>
+    <title>Gold Price in Morocco Today — MAD | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Morocco in MAD per gram. Updated every 90 seconds. 24K, 22K, 18K gold rates in Moroccan Dirham."
@@ -31,10 +31,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/morocco/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Morocco reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Morocco Today — MAD Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 18K gold prices in Moroccan Dirham (MAD). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -69,6 +74,27 @@
       "name": "Morocco",
       "item": "https://goldtickerlive.com/countries/morocco/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Morocco Today — MAD | Gold Ticker Live",
+  "description": "Live gold price in Morocco in MAD per gram. Updated every 90 seconds. 24K, 22K, 18K gold rates in Moroccan Dirham.",
+  "url": "https://goldtickerlive.com/countries/morocco/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in MAD",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/oman/index.html
+++ b/countries/oman/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Oman Today — OMR per Gram | Gold Ticker Live</title>
+    <title>Gold Price in Oman Today — OMR | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Oman in OMR per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Omani Rial."
@@ -23,10 +23,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/oman/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Oman reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Oman Today — OMR Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in Omani Rial (OMR). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -61,6 +66,27 @@
       "name": "Oman",
       "item": "https://goldtickerlive.com/countries/oman/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Oman Today — OMR | Gold Ticker Live",
+  "description": "Live gold price in Oman in OMR per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Omani Rial.",
+  "url": "https://goldtickerlive.com/countries/oman/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in OMR",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/pakistan/index.html
+++ b/countries/pakistan/index.html
@@ -7,9 +7,9 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <meta name="description" content="Today spot-linked reference gold price in Pakistan, with 24K, 22K, 21K, 18K, and 14K rates in PKR per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
-    <meta property="og:title" content="Gold price today in Pakistan — PKR reference rates | Gold Ticker Live" />
-    <meta property="og:description" content="Today spot-linked reference gold price in Pakistan, with 24K, 22K, 21K, 18K, and 14K rates in PKR per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
+    <meta name="description" content="Spot-linked reference gold price in Pakistan today — 24K, 22K, 21K, 18K and 14K rates in PKR per gram, with freshness labels and methodology." />
+    <meta property="og:title" content="Gold Price in Pakistan Today — PKR per Gram" />
+    <meta property="og:description" content="Spot-linked reference gold price in Pakistan today — 24K, 22K, 21K, 18K and 14K rates in PKR per gram, with freshness labels and methodology." />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:locale:alternate" content="ar_AE" />
@@ -19,14 +19,14 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Pakistan reference gold prices on Gold Ticker Live" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Gold price today in Pakistan — PKR reference rates | Gold Ticker Live" />
-    <meta name="twitter:description" content="Today spot-linked reference gold price in Pakistan, with 24K, 22K, 21K, 18K, and 14K rates in PKR per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
+    <meta name="twitter:title" content="Gold Price in Pakistan Today — PKR per Gram" />
+    <meta name="twitter:description" content="Spot-linked reference gold price in Pakistan today — 24K, 22K, 21K, 18K and 14K rates in PKR per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="canonical" href="https://goldtickerlive.com/countries/pakistan/" />
     <link rel="alternate" hreflang="x-default" href="https://goldtickerlive.com/countries/pakistan/" />
     <link rel="alternate" hreflang="en" href="https://goldtickerlive.com/countries/pakistan/" />
     <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/countries/pakistan/?lang=ar" />
-    <title>Gold price today in Pakistan — PKR reference rates | Gold Ticker Live</title>
+    <title>Gold Price in Pakistan Today — PKR | Gold Ticker Live</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://open.er-api.com" />
@@ -60,6 +60,27 @@
       "name": "Pakistan",
       "item": "https://goldtickerlive.com/countries/pakistan/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Pakistan Today — PKR | Gold Ticker Live",
+  "description": "Spot-linked reference gold price in Pakistan today — 24K, 22K, 21K, 18K and 14K rates in PKR per gram, with freshness labels and methodology.",
+  "url": "https://goldtickerlive.com/countries/pakistan/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in PKR",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/palestine/index.html
+++ b/countries/palestine/index.html
@@ -7,9 +7,9 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <meta name="description" content="Today spot-linked reference gold price in Palestine, with 24K, 22K, 21K, 18K, and 14K rates in ILS per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
-    <meta property="og:title" content="Gold price today in Palestine — ILS reference rates | Gold Ticker Live" />
-    <meta property="og:description" content="Today spot-linked reference gold price in Palestine, with 24K, 22K, 21K, 18K, and 14K rates in ILS per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
+    <meta name="description" content="Spot-linked reference gold price in Palestine today — 24K, 22K, 21K, 18K and 14K rates in ILS per gram, with freshness labels and methodology." />
+    <meta property="og:title" content="Gold Price in Palestine Today — ILS per Gram" />
+    <meta property="og:description" content="Spot-linked reference gold price in Palestine today — 24K, 22K, 21K, 18K and 14K rates in ILS per gram, with freshness labels and methodology." />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:locale:alternate" content="ar_AE" />
@@ -19,14 +19,14 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Palestine reference gold prices on Gold Ticker Live" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Gold price today in Palestine — ILS reference rates | Gold Ticker Live" />
-    <meta name="twitter:description" content="Today spot-linked reference gold price in Palestine, with 24K, 22K, 21K, 18K, and 14K rates in ILS per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
+    <meta name="twitter:title" content="Gold Price in Palestine Today — ILS per Gram" />
+    <meta name="twitter:description" content="Spot-linked reference gold price in Palestine today — 24K, 22K, 21K, 18K and 14K rates in ILS per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="canonical" href="https://goldtickerlive.com/countries/palestine/" />
     <link rel="alternate" hreflang="x-default" href="https://goldtickerlive.com/countries/palestine/" />
     <link rel="alternate" hreflang="en" href="https://goldtickerlive.com/countries/palestine/" />
     <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/countries/palestine/?lang=ar" />
-    <title>Gold price today in Palestine — ILS reference rates | Gold Ticker Live</title>
+    <title>Gold Price in Palestine Today — ILS | Gold Ticker Live</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://open.er-api.com" />
@@ -60,6 +60,27 @@
       "name": "Palestine",
       "item": "https://goldtickerlive.com/countries/palestine/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Palestine Today — ILS | Gold Ticker Live",
+  "description": "Spot-linked reference gold price in Palestine today — 24K, 22K, 21K, 18K and 14K rates in ILS per gram, with freshness labels and methodology.",
+  "url": "https://goldtickerlive.com/countries/palestine/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in ILS",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/qatar/index.html
+++ b/countries/qatar/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Qatar Today — QAR per Gram (24K, 22K, 21K) | Gold Ticker Live</title>
+    <title>Gold Price in Qatar Today — QAR | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Qatar today in QAR per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Qatari Riyal."
@@ -27,10 +27,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/qatar/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Qatar reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Qatar Today — QAR Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in Qatari Riyal (QAR). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -65,6 +70,27 @@
       "name": "Qatar",
       "item": "https://goldtickerlive.com/countries/qatar/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Qatar Today — QAR | Gold Ticker Live",
+  "description": "Live gold price in Qatar today in QAR per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Qatari Riyal.",
+  "url": "https://goldtickerlive.com/countries/qatar/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in QAR",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/saudi-arabia/index.html
+++ b/countries/saudi-arabia/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Saudi Arabia Today — SAR per Gram (24K, 22K, 21K) | Gold Ticker Live</title>
+    <title>Gold Price in Saudi Arabia Today — SAR | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Saudi Arabia today in SAR per gram and troy oz. Updated every 90 seconds. View 24K, 22K, 21K and 18K gold rates in Saudi Riyal."
@@ -31,10 +31,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/saudi-arabia/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Saudi Arabia reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Saudi Arabia Today — SAR Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in Saudi Riyal (SAR). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -69,6 +74,27 @@
       "name": "Saudi Arabia",
       "item": "https://goldtickerlive.com/countries/saudi-arabia/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Saudi Arabia Today — SAR | Gold Ticker Live",
+  "description": "Live gold price in Saudi Arabia today in SAR per gram and troy oz. Updated every 90 seconds. View 24K, 22K, 21K and 18K gold rates in Saudi Riyal.",
+  "url": "https://goldtickerlive.com/countries/saudi-arabia/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in SAR",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/sudan/index.html
+++ b/countries/sudan/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Sudan Today — SDG per Gram | Gold Ticker Live</title>
+    <title>Gold Price in Sudan Today — SDG | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Sudan in SDG per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Sudanese Pound."
@@ -27,10 +27,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/sudan/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Sudan reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Sudan Today — SDG Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in Sudanese Pound (SDG). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#b08a3e" />
@@ -67,6 +72,27 @@
       "name": "Sudan",
       "item": "https://goldtickerlive.com/countries/sudan/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Sudan Today — SDG | Gold Ticker Live",
+  "description": "Live gold price in Sudan in SDG per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Sudanese Pound.",
+  "url": "https://goldtickerlive.com/countries/sudan/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in SDG",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/syria/index.html
+++ b/countries/syria/index.html
@@ -7,9 +7,9 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <meta name="description" content="Today spot-linked reference gold price in Syria, with 24K, 22K, 21K, 18K, and 14K rates in SYP per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
-    <meta property="og:title" content="Gold price today in Syria — SYP reference rates | Gold Ticker Live" />
-    <meta property="og:description" content="Today spot-linked reference gold price in Syria, with 24K, 22K, 21K, 18K, and 14K rates in SYP per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
+    <meta name="description" content="Spot-linked reference gold price in Syria today — 24K, 22K, 21K, 18K and 14K rates in SYP per gram, with freshness labels and methodology." />
+    <meta property="og:title" content="Gold Price in Syria Today — SYP per Gram" />
+    <meta property="og:description" content="Spot-linked reference gold price in Syria today — 24K, 22K, 21K, 18K and 14K rates in SYP per gram, with freshness labels and methodology." />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:locale:alternate" content="ar_AE" />
@@ -19,14 +19,14 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Syria reference gold prices on Gold Ticker Live" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Gold price today in Syria — SYP reference rates | Gold Ticker Live" />
-    <meta name="twitter:description" content="Today spot-linked reference gold price in Syria, with 24K, 22K, 21K, 18K, and 14K rates in SYP per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
+    <meta name="twitter:title" content="Gold Price in Syria Today — SYP per Gram" />
+    <meta name="twitter:description" content="Spot-linked reference gold price in Syria today — 24K, 22K, 21K, 18K and 14K rates in SYP per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="canonical" href="https://goldtickerlive.com/countries/syria/" />
     <link rel="alternate" hreflang="x-default" href="https://goldtickerlive.com/countries/syria/" />
     <link rel="alternate" hreflang="en" href="https://goldtickerlive.com/countries/syria/" />
     <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/countries/syria/?lang=ar" />
-    <title>Gold price today in Syria — SYP reference rates | Gold Ticker Live</title>
+    <title>Gold Price in Syria Today — SYP | Gold Ticker Live</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://open.er-api.com" />
@@ -60,6 +60,27 @@
       "name": "Syria",
       "item": "https://goldtickerlive.com/countries/syria/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Syria Today — SYP | Gold Ticker Live",
+  "description": "Spot-linked reference gold price in Syria today — 24K, 22K, 21K, 18K and 14K rates in SYP per gram, with freshness labels and methodology.",
+  "url": "https://goldtickerlive.com/countries/syria/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in SYP",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/tunisia/index.html
+++ b/countries/tunisia/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in Tunisia Today — TND per Gram | Gold Ticker Live</title>
+    <title>Gold Price in Tunisia Today — TND | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in Tunisia in TND per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Tunisian Dinar."
@@ -31,10 +31,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/tunisia/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="Tunisia reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in Tunisia Today — TND Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in Tunisian Dinar (TND). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#b08a3e" />
@@ -71,6 +76,27 @@
       "name": "Tunisia",
       "item": "https://goldtickerlive.com/countries/tunisia/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Tunisia Today — TND | Gold Ticker Live",
+  "description": "Live gold price in Tunisia in TND per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Tunisian Dinar.",
+  "url": "https://goldtickerlive.com/countries/tunisia/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in TND",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/turkey/index.html
+++ b/countries/turkey/index.html
@@ -7,9 +7,9 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <meta name="description" content="Today spot-linked reference gold price in Turkey, with 24K, 22K, 21K, 18K, and 14K rates in TRY per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
-    <meta property="og:title" content="Gold price today in Turkey — TRY reference rates | Gold Ticker Live" />
-    <meta property="og:description" content="Today spot-linked reference gold price in Turkey, with 24K, 22K, 21K, 18K, and 14K rates in TRY per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
+    <meta name="description" content="Spot-linked reference gold price in Turkey today — 24K, 22K, 21K, 18K and 14K rates in TRY per gram, with freshness labels and methodology." />
+    <meta property="og:title" content="Gold Price in Turkey Today — TRY per Gram" />
+    <meta property="og:description" content="Spot-linked reference gold price in Turkey today — 24K, 22K, 21K, 18K and 14K rates in TRY per gram, with freshness labels and methodology." />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:locale:alternate" content="ar_AE" />
@@ -19,14 +19,14 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Turkey reference gold prices on Gold Ticker Live" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Gold price today in Turkey — TRY reference rates | Gold Ticker Live" />
-    <meta name="twitter:description" content="Today spot-linked reference gold price in Turkey, with 24K, 22K, 21K, 18K, and 14K rates in TRY per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
+    <meta name="twitter:title" content="Gold Price in Turkey Today — TRY per Gram" />
+    <meta name="twitter:description" content="Spot-linked reference gold price in Turkey today — 24K, 22K, 21K, 18K and 14K rates in TRY per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="canonical" href="https://goldtickerlive.com/countries/turkey/" />
     <link rel="alternate" hreflang="x-default" href="https://goldtickerlive.com/countries/turkey/" />
     <link rel="alternate" hreflang="en" href="https://goldtickerlive.com/countries/turkey/" />
     <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/countries/turkey/?lang=ar" />
-    <title>Gold price today in Turkey — TRY reference rates | Gold Ticker Live</title>
+    <title>Gold Price in Turkey Today — TRY | Gold Ticker Live</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://open.er-api.com" />
@@ -60,6 +60,27 @@
       "name": "Turkey",
       "item": "https://goldtickerlive.com/countries/turkey/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Turkey Today — TRY | Gold Ticker Live",
+  "description": "Spot-linked reference gold price in Turkey today — 24K, 22K, 21K, 18K and 14K rates in TRY per gram, with freshness labels and methodology.",
+  "url": "https://goldtickerlive.com/countries/turkey/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in TRY",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/uae/index.html
+++ b/countries/uae/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Gold Price in UAE Today — AED per Gram (24K, 22K, 21K, 18K) | Gold Ticker Live</title>
+    <title>Gold Price in UAE Today — AED | Gold Ticker Live</title>
     <meta
       name="description"
       content="Live gold price in UAE today in AED per gram and troy oz. Updated every 90 seconds. See 24K, 22K, 21K and 18K gold rates in UAE Dirham."
@@ -23,10 +23,15 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://goldtickerlive.com/countries/uae/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ar_AE" />
+    <meta property="og:image:alt" content="UAE reference gold prices on Gold Ticker Live" />
     <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Price in UAE Today — AED Live Rates" />
+    <meta name="twitter:description" content="Live 24K, 22K, 21K, 18K gold prices in UAE Dirham (AED). Updated every 90 seconds." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#b08a3e" />
@@ -63,6 +68,27 @@
       "name": "Uae",
       "item": "https://goldtickerlive.com/countries/uae/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in UAE Today — AED | Gold Ticker Live",
+  "description": "Live gold price in UAE today in AED per gram and troy oz. Updated every 90 seconds. See 24K, 22K, 21K and 18K gold rates in UAE Dirham.",
+  "url": "https://goldtickerlive.com/countries/uae/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in AED",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/countries/yemen/index.html
+++ b/countries/yemen/index.html
@@ -7,9 +7,9 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <meta name="description" content="Today spot-linked reference gold price in Yemen, with 24K, 22K, 21K, 18K, and 14K rates in YER per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
-    <meta property="og:title" content="Gold price today in Yemen — YER reference rates | Gold Ticker Live" />
-    <meta property="og:description" content="Today spot-linked reference gold price in Yemen, with 24K, 22K, 21K, 18K, and 14K rates in YER per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
+    <meta name="description" content="Spot-linked reference gold price in Yemen today — 24K, 22K, 21K, 18K and 14K rates in YER per gram, with freshness labels and methodology." />
+    <meta property="og:title" content="Gold Price in Yemen Today — YER per Gram" />
+    <meta property="og:description" content="Spot-linked reference gold price in Yemen today — 24K, 22K, 21K, 18K and 14K rates in YER per gram, with freshness labels and methodology." />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:locale:alternate" content="ar_AE" />
@@ -19,14 +19,14 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Yemen reference gold prices on Gold Ticker Live" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Gold price today in Yemen — YER reference rates | Gold Ticker Live" />
-    <meta name="twitter:description" content="Today spot-linked reference gold price in Yemen, with 24K, 22K, 21K, 18K, and 14K rates in YER per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context." />
+    <meta name="twitter:title" content="Gold Price in Yemen Today — YER per Gram" />
+    <meta name="twitter:description" content="Spot-linked reference gold price in Yemen today — 24K, 22K, 21K, 18K and 14K rates in YER per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
     <link rel="canonical" href="https://goldtickerlive.com/countries/yemen/" />
     <link rel="alternate" hreflang="x-default" href="https://goldtickerlive.com/countries/yemen/" />
     <link rel="alternate" hreflang="en" href="https://goldtickerlive.com/countries/yemen/" />
     <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/countries/yemen/?lang=ar" />
-    <title>Gold price today in Yemen — YER reference rates | Gold Ticker Live</title>
+    <title>Gold Price in Yemen Today — YER | Gold Ticker Live</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://open.er-api.com" />
@@ -60,6 +60,27 @@
       "name": "Yemen",
       "item": "https://goldtickerlive.com/countries/yemen/"
     }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Gold Price in Yemen Today — YER | Gold Ticker Live",
+  "description": "Spot-linked reference gold price in Yemen today — 24K, 22K, 21K, 18K and 14K rates in YER per gram, with freshness labels and methodology.",
+  "url": "https://goldtickerlive.com/countries/yemen/",
+  "creator": {
+    "@type": "Organization",
+    "name": "Gold Ticker Live",
+    "url": "https://goldtickerlive.com"
+  },
+  "license": "https://goldtickerlive.com/terms.html",
+  "variableMeasured": "Gold price per gram in YER",
+  "isAccessibleForFree": true,
+  "inLanguage": [
+    "en",
+    "ar"
   ]
 }
   </script>

--- a/reports/seo/governance.json
+++ b/reports/seo/governance.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-06-25T13:02:01.954Z",
+  "generatedAt": "2026-06-25T15:39:09.654Z",
   "summary": {
     "groups": {
       "core": 63,
@@ -75,7 +75,7 @@
         },
         {
           "path": "countries/algeria/index.html",
-          "words": 35
+          "words": 33
         },
         {
           "path": "countries/algeria/oran/gold-rate/index.html",
@@ -87,7 +87,7 @@
         },
         {
           "path": "countries/bahrain/index.html",
-          "words": 35
+          "words": 33
         },
         {
           "path": "countries/bahrain/manama/gold-rate/index.html",
@@ -135,7 +135,7 @@
         },
         {
           "path": "countries/egypt/index.html",
-          "words": 37
+          "words": 33
         },
         {
           "path": "countries/india/chennai/gold-rate/index.html",
@@ -155,7 +155,7 @@
         },
         {
           "path": "countries/india/index.html",
-          "words": 37
+          "words": 33
         },
         {
           "path": "countries/india/mumbai/gold-rate/index.html",
@@ -179,7 +179,7 @@
         },
         {
           "path": "countries/iraq/index.html",
-          "words": 96
+          "words": 94
         },
         {
           "path": "countries/jordan/amman/gold-rate/index.html",
@@ -191,7 +191,7 @@
         },
         {
           "path": "countries/jordan/index.html",
-          "words": 35
+          "words": 33
         },
         {
           "path": "countries/jordan/irbid/gold-rate/index.html",
@@ -219,7 +219,7 @@
         },
         {
           "path": "countries/kuwait/index.html",
-          "words": 38
+          "words": 33
         },
         {
           "path": "countries/kuwait/kuwait-city/gold-rate/index.html",
@@ -247,7 +247,7 @@
         },
         {
           "path": "countries/lebanon/index.html",
-          "words": 35
+          "words": 33
         },
         {
           "path": "countries/lebanon/sidon/gold-rate/index.html",
@@ -275,7 +275,7 @@
         },
         {
           "path": "countries/libya/index.html",
-          "words": 35
+          "words": 33
         },
         {
           "path": "countries/libya/misrata/gold-rate/index.html",
@@ -303,7 +303,7 @@
         },
         {
           "path": "countries/morocco/index.html",
-          "words": 35
+          "words": 33
         },
         {
           "path": "countries/morocco/marrakech/gold-rate/index.html",
@@ -323,7 +323,7 @@
         },
         {
           "path": "countries/oman/index.html",
-          "words": 35
+          "words": 33
         },
         {
           "path": "countries/oman/muscat/gold-rate/index.html",
@@ -351,7 +351,7 @@
         },
         {
           "path": "countries/pakistan/index.html",
-          "words": 96
+          "words": 94
         },
         {
           "path": "countries/pakistan/islamabad/gold-shops/index.html",
@@ -371,7 +371,7 @@
         },
         {
           "path": "countries/palestine/index.html",
-          "words": 96
+          "words": 94
         },
         {
           "path": "countries/palestine/nablus/gold-shops/index.html",
@@ -403,7 +403,7 @@
         },
         {
           "path": "countries/qatar/index.html",
-          "words": 38
+          "words": 33
         },
         {
           "path": "countries/saudi-arabia/dammam/gold-rate/index.html",
@@ -415,7 +415,7 @@
         },
         {
           "path": "countries/saudi-arabia/index.html",
-          "words": 40
+          "words": 35
         },
         {
           "path": "countries/saudi-arabia/jeddah/gold-rate/index.html",
@@ -447,7 +447,7 @@
         },
         {
           "path": "countries/sudan/index.html",
-          "words": 35
+          "words": 33
         },
         {
           "path": "countries/sudan/khartoum/gold-rate/index.html",
@@ -487,11 +487,11 @@
         },
         {
           "path": "countries/syria/index.html",
-          "words": 96
+          "words": 94
         },
         {
           "path": "countries/tunisia/index.html",
-          "words": 35
+          "words": 33
         },
         {
           "path": "countries/tunisia/sfax/gold-rate/index.html",
@@ -523,7 +523,7 @@
         },
         {
           "path": "countries/turkey/index.html",
-          "words": 96
+          "words": 94
         },
         {
           "path": "countries/turkey/istanbul/gold-shops/index.html",
@@ -563,7 +563,7 @@
         },
         {
           "path": "countries/uae/index.html",
-          "words": 60
+          "words": 54
         },
         {
           "path": "countries/uae/ras-al-khaimah/gold-rate/index.html",
@@ -595,7 +595,7 @@
         },
         {
           "path": "countries/yemen/index.html",
-          "words": 96
+          "words": 94
         },
         {
           "path": "countries/yemen/sanaa/gold-shops/index.html",
@@ -1017,12 +1017,12 @@
       "path": "calculator.html",
       "group": "core",
       "noindex": false,
-      "title": "Gold Price Calculator UAE — Grams to AED | Gold Ticker Live",
-      "description": "Free gold price calculator for UAE. Convert any weight and karat to AED or USD instantly. Includes 24K, 22K, 21K, 18K, 14K, 10K.",
+      "title": "Gold Calculator — Value, Scrap, Zakat | Gold Ticker Live",
+      "description": "Free gold calculator: value any weight and karat in AED or USD, plus scrap, Zakat (2.5%), buying power and unit conversion using live reference rates.",
       "canonical": "https://goldtickerlive.com/calculator.html",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 722,
+      "wordCount": 720,
       "thinRisk": false,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -1947,12 +1947,12 @@
       "path": "countries/algeria/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Algeria Today — DZD per Gram | Gold Ticker Live",
+      "title": "Gold Price in Algeria Today — DZD | Gold Ticker Live",
       "description": "Live gold price in Algeria in DZD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Algerian Dinar.",
       "canonical": "https://goldtickerlive.com/countries/algeria/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 35,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -2022,12 +2022,12 @@
       "path": "countries/bahrain/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Bahrain Today — BHD per Gram | Gold Ticker Live",
+      "title": "Gold Price in Bahrain Today — BHD | Gold Ticker Live",
       "description": "Live gold price in Bahrain in BHD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Bahraini Dinar.",
       "canonical": "https://goldtickerlive.com/countries/bahrain/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 35,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -2352,12 +2352,12 @@
       "path": "countries/egypt/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Egypt Today — EGP per Gram (عيار 21) | Gold Ticker Live",
+      "title": "Gold Price in Egypt Today — EGP | Gold Ticker Live",
       "description": "Live gold price in Egypt today in EGP per gram. Updated every 90 seconds. 24K (عيار 24), 21K, 18K gold rates in Egyptian Pound.",
       "canonical": "https://goldtickerlive.com/countries/egypt/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 37,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -2517,12 +2517,12 @@
       "path": "countries/india/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in India Today — INR per Gram (24K, 22K) | Gold Ticker Live",
+      "title": "Gold Price in India Today — INR | Gold Ticker Live",
       "description": "Live gold price in India today in INR per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Indian Rupee.",
       "canonical": "https://goldtickerlive.com/countries/india/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 37,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -2727,12 +2727,12 @@
       "path": "countries/iraq/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold price today in Iraq — IQD reference rates | Gold Ticker Live",
-      "description": "Today spot-linked reference gold price in Iraq, with 24K, 22K, 21K, 18K, and 14K rates in IQD per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "title": "Gold Price in Iraq Today — IQD | Gold Ticker Live",
+      "description": "Spot-linked reference gold price in Iraq today — 24K, 22K, 21K, 18K and 14K rates in IQD per gram, with freshness labels and methodology.",
       "canonical": "https://goldtickerlive.com/countries/iraq/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 96,
+      "wordCount": 94,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -2802,12 +2802,12 @@
       "path": "countries/jordan/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Jordan Today — JOD per Gram | Gold Ticker Live",
+      "title": "Gold Price in Jordan Today — JOD | Gold Ticker Live",
       "description": "Live gold price in Jordan in JOD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Jordanian Dinar.",
       "canonical": "https://goldtickerlive.com/countries/jordan/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 35,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -2967,12 +2967,12 @@
       "path": "countries/kuwait/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Kuwait Today — KWD per Gram (24K, 22K, 21K) | Gold Ticker Live",
+      "title": "Gold Price in Kuwait Today — KWD | Gold Ticker Live",
       "description": "Live gold price in Kuwait today in KWD per gram and troy oz. Updated every 90 seconds. 24K, 22K, 21K and 18K gold rates in Kuwaiti Dinar.",
       "canonical": "https://goldtickerlive.com/countries/kuwait/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 38,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -3132,12 +3132,12 @@
       "path": "countries/lebanon/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Lebanon Today — LBP per Gram | Gold Ticker Live",
+      "title": "Gold Price in Lebanon Today — LBP | Gold Ticker Live",
       "description": "Live gold price in Lebanon in LBP per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Lebanese Pound.",
       "canonical": "https://goldtickerlive.com/countries/lebanon/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 35,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -3297,12 +3297,12 @@
       "path": "countries/libya/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Libya Today — LYD per Gram | Gold Ticker Live",
+      "title": "Gold Price in Libya Today — LYD | Gold Ticker Live",
       "description": "Live gold price in Libya in LYD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Libyan Dinar.",
       "canonical": "https://goldtickerlive.com/countries/libya/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 35,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -3462,12 +3462,12 @@
       "path": "countries/morocco/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Morocco Today — MAD per Gram | Gold Ticker Live",
+      "title": "Gold Price in Morocco Today — MAD | Gold Ticker Live",
       "description": "Live gold price in Morocco in MAD per gram. Updated every 90 seconds. 24K, 22K, 18K gold rates in Moroccan Dirham.",
       "canonical": "https://goldtickerlive.com/countries/morocco/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 35,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -3582,12 +3582,12 @@
       "path": "countries/oman/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Oman Today — OMR per Gram | Gold Ticker Live",
+      "title": "Gold Price in Oman Today — OMR | Gold Ticker Live",
       "description": "Live gold price in Oman in OMR per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Omani Rial.",
       "canonical": "https://goldtickerlive.com/countries/oman/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 35,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -3747,12 +3747,12 @@
       "path": "countries/pakistan/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold price today in Pakistan — PKR reference rates | Gold Ticker Live",
-      "description": "Today spot-linked reference gold price in Pakistan, with 24K, 22K, 21K, 18K, and 14K rates in PKR per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "title": "Gold Price in Pakistan Today — PKR | Gold Ticker Live",
+      "description": "Spot-linked reference gold price in Pakistan today — 24K, 22K, 21K, 18K and 14K rates in PKR per gram, with freshness labels and methodology.",
       "canonical": "https://goldtickerlive.com/countries/pakistan/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 96,
+      "wordCount": 94,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -3957,12 +3957,12 @@
       "path": "countries/palestine/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold price today in Palestine — ILS reference rates | Gold Ticker Live",
-      "description": "Today spot-linked reference gold price in Palestine, with 24K, 22K, 21K, 18K, and 14K rates in ILS per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "title": "Gold Price in Palestine Today — ILS | Gold Ticker Live",
+      "description": "Spot-linked reference gold price in Palestine today — 24K, 22K, 21K, 18K and 14K rates in ILS per gram, with freshness labels and methodology.",
       "canonical": "https://goldtickerlive.com/countries/palestine/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 96,
+      "wordCount": 94,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -4242,12 +4242,12 @@
       "path": "countries/qatar/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Qatar Today — QAR per Gram (24K, 22K, 21K) | Gold Ticker Live",
+      "title": "Gold Price in Qatar Today — QAR | Gold Ticker Live",
       "description": "Live gold price in Qatar today in QAR per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Qatari Riyal.",
       "canonical": "https://goldtickerlive.com/countries/qatar/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 38,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -4347,12 +4347,12 @@
       "path": "countries/saudi-arabia/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Saudi Arabia Today — SAR per Gram (24K, 22K, 21K) | Gold Ticker Live",
+      "title": "Gold Price in Saudi Arabia Today — SAR | Gold Ticker Live",
       "description": "Live gold price in Saudi Arabia today in SAR per gram and troy oz. Updated every 90 seconds. View 24K, 22K, 21K and 18K gold rates in Saudi Riyal.",
       "canonical": "https://goldtickerlive.com/countries/saudi-arabia/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 40,
+      "wordCount": 35,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -4557,12 +4557,12 @@
       "path": "countries/sudan/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Sudan Today — SDG per Gram | Gold Ticker Live",
+      "title": "Gold Price in Sudan Today — SDG | Gold Ticker Live",
       "description": "Live gold price in Sudan in SDG per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Sudanese Pound.",
       "canonical": "https://goldtickerlive.com/countries/sudan/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 35,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -4857,12 +4857,12 @@
       "path": "countries/syria/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold price today in Syria — SYP reference rates | Gold Ticker Live",
-      "description": "Today spot-linked reference gold price in Syria, with 24K, 22K, 21K, 18K, and 14K rates in SYP per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "title": "Gold Price in Syria Today — SYP | Gold Ticker Live",
+      "description": "Spot-linked reference gold price in Syria today — 24K, 22K, 21K, 18K and 14K rates in SYP per gram, with freshness labels and methodology.",
       "canonical": "https://goldtickerlive.com/countries/syria/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 96,
+      "wordCount": 94,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -4887,12 +4887,12 @@
       "path": "countries/tunisia/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in Tunisia Today — TND per Gram | Gold Ticker Live",
+      "title": "Gold Price in Tunisia Today — TND | Gold Ticker Live",
       "description": "Live gold price in Tunisia in TND per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Tunisian Dinar.",
       "canonical": "https://goldtickerlive.com/countries/tunisia/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 35,
+      "wordCount": 33,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -5097,12 +5097,12 @@
       "path": "countries/turkey/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold price today in Turkey — TRY reference rates | Gold Ticker Live",
-      "description": "Today spot-linked reference gold price in Turkey, with 24K, 22K, 21K, 18K, and 14K rates in TRY per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "title": "Gold Price in Turkey Today — TRY | Gold Ticker Live",
+      "description": "Spot-linked reference gold price in Turkey today — 24K, 22K, 21K, 18K and 14K rates in TRY per gram, with freshness labels and methodology.",
       "canonical": "https://goldtickerlive.com/countries/turkey/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 96,
+      "wordCount": 94,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -5442,12 +5442,12 @@
       "path": "countries/uae/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold Price in UAE Today — AED per Gram (24K, 22K, 21K, 18K) | Gold Ticker Live",
+      "title": "Gold Price in UAE Today — AED | Gold Ticker Live",
       "description": "Live gold price in UAE today in AED per gram and troy oz. Updated every 90 seconds. See 24K, 22K, 21K and 18K gold rates in UAE Dirham.",
       "canonical": "https://goldtickerlive.com/countries/uae/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 60,
+      "wordCount": 54,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -5682,12 +5682,12 @@
       "path": "countries/yemen/index.html",
       "group": "countries",
       "noindex": false,
-      "title": "Gold price today in Yemen — YER reference rates | Gold Ticker Live",
-      "description": "Today spot-linked reference gold price in Yemen, with 24K, 22K, 21K, 18K, and 14K rates in YER per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "title": "Gold Price in Yemen Today — YER | Gold Ticker Live",
+      "description": "Spot-linked reference gold price in Yemen today — 24K, 22K, 21K, 18K and 14K rates in YER per gram, with freshness labels and methodology.",
       "canonical": "https://goldtickerlive.com/countries/yemen/",
       "hreflangs": ["x-default", "en", "ar"],
       "hasSchema": true,
-      "wordCount": 96,
+      "wordCount": 94,
       "thinRisk": true,
       "missingCanonical": false,
       "missingHreflang": false,

--- a/reports/seo/inventory.json
+++ b/reports/seo/inventory.json
@@ -329,8 +329,8 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price Calculator UAE — Grams to AED | Gold Ticker Live",
-      "metaDescription": "Free gold price calculator for UAE. Convert any weight and karat to AED or USD instantly. Includes 24K, 22K, 21K, 18K, 14K, 10K.",
+      "title": "Gold Calculator — Value, Scrap, Zakat | Gold Ticker Live",
+      "metaDescription": "Free gold calculator: value any weight and karat in AED or USD, plus scrap, Zakat (2.5%), buying power and unit conversion using live reference rates.",
       "canonical": "https://goldtickerlive.com/calculator.html",
       "robots": null,
       "ogTitle": "Gold Calculator — Value, Scrap, Zakat | Gold Ticker Live",
@@ -355,7 +355,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "WebApplication"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -2492,7 +2493,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Algeria Today — DZD per Gram | Gold Ticker Live",
+      "title": "Gold Price in Algeria Today — DZD | Gold Ticker Live",
       "metaDescription": "Live gold price in Algeria in DZD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Algerian Dinar.",
       "canonical": "https://goldtickerlive.com/countries/algeria/",
       "robots": null,
@@ -2518,7 +2519,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -2675,7 +2677,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Bahrain Today — BHD per Gram | Gold Ticker Live",
+      "title": "Gold Price in Bahrain Today — BHD | Gold Ticker Live",
       "metaDescription": "Live gold price in Bahrain in BHD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Bahraini Dinar.",
       "canonical": "https://goldtickerlive.com/countries/bahrain/",
       "robots": null,
@@ -2701,7 +2703,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -3475,7 +3478,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Egypt Today — EGP per Gram (عيار 21) | Gold Ticker Live",
+      "title": "Gold Price in Egypt Today — EGP | Gold Ticker Live",
       "metaDescription": "Live gold price in Egypt today in EGP per gram. Updated every 90 seconds. 24K (عيار 24), 21K, 18K gold rates in Egyptian Pound.",
       "canonical": "https://goldtickerlive.com/countries/egypt/",
       "robots": null,
@@ -3501,7 +3504,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -3875,7 +3879,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in India Today — INR per Gram (24K, 22K) | Gold Ticker Live",
+      "title": "Gold Price in India Today — INR | Gold Ticker Live",
       "metaDescription": "Live gold price in India today in INR per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Indian Rupee.",
       "canonical": "https://goldtickerlive.com/countries/india/",
       "robots": null,
@@ -3901,7 +3905,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -4385,12 +4390,12 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold price today in Iraq — IQD reference rates | Gold Ticker Live",
-      "metaDescription": "Today spot-linked reference gold price in Iraq, with 24K, 22K, 21K, 18K, and 14K rates in IQD per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "title": "Gold Price in Iraq Today — IQD | Gold Ticker Live",
+      "metaDescription": "Spot-linked reference gold price in Iraq today — 24K, 22K, 21K, 18K and 14K rates in IQD per gram, with freshness labels and methodology.",
       "canonical": "https://goldtickerlive.com/countries/iraq/",
       "robots": null,
-      "ogTitle": "Gold price today in Iraq — IQD reference rates | Gold Ticker Live",
-      "ogDescription": "Today spot-linked reference gold price in Iraq, with 24K, 22K, 21K, 18K, and 14K rates in IQD per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "ogTitle": "Gold Price in Iraq Today — IQD per Gram",
+      "ogDescription": "Spot-linked reference gold price in Iraq today — 24K, 22K, 21K, 18K and 14K rates in IQD per gram, with freshness labels and methodology.",
       "ogImage": "https://goldtickerlive.com/assets/og-image.png",
       "ogUrl": "https://goldtickerlive.com/countries/iraq/",
       "ogType": "website",
@@ -4411,7 +4416,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -4568,7 +4574,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Jordan Today — JOD per Gram | Gold Ticker Live",
+      "title": "Gold Price in Jordan Today — JOD | Gold Ticker Live",
       "metaDescription": "Live gold price in Jordan in JOD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Jordanian Dinar.",
       "canonical": "https://goldtickerlive.com/countries/jordan/",
       "robots": null,
@@ -4594,7 +4600,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -4969,7 +4976,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Kuwait Today — KWD per Gram (24K, 22K, 21K) | Gold Ticker Live",
+      "title": "Gold Price in Kuwait Today — KWD | Gold Ticker Live",
       "metaDescription": "Live gold price in Kuwait today in KWD per gram and troy oz. Updated every 90 seconds. 24K, 22K, 21K and 18K gold rates in Kuwaiti Dinar.",
       "canonical": "https://goldtickerlive.com/countries/kuwait/",
       "robots": null,
@@ -4995,7 +5002,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -5370,7 +5378,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Lebanon Today — LBP per Gram | Gold Ticker Live",
+      "title": "Gold Price in Lebanon Today — LBP | Gold Ticker Live",
       "metaDescription": "Live gold price in Lebanon in LBP per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Lebanese Pound.",
       "canonical": "https://goldtickerlive.com/countries/lebanon/",
       "robots": null,
@@ -5396,7 +5404,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -5771,7 +5780,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Libya Today — LYD per Gram | Gold Ticker Live",
+      "title": "Gold Price in Libya Today — LYD | Gold Ticker Live",
       "metaDescription": "Live gold price in Libya in LYD per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Libyan Dinar.",
       "canonical": "https://goldtickerlive.com/countries/libya/",
       "robots": null,
@@ -5797,7 +5806,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -6172,7 +6182,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Morocco Today — MAD per Gram | Gold Ticker Live",
+      "title": "Gold Price in Morocco Today — MAD | Gold Ticker Live",
       "metaDescription": "Live gold price in Morocco in MAD per gram. Updated every 90 seconds. 24K, 22K, 18K gold rates in Moroccan Dirham.",
       "canonical": "https://goldtickerlive.com/countries/morocco/",
       "robots": null,
@@ -6198,7 +6208,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -6464,7 +6475,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Oman Today — OMR per Gram | Gold Ticker Live",
+      "title": "Gold Price in Oman Today — OMR | Gold Ticker Live",
       "metaDescription": "Live gold price in Oman in OMR per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Omani Rial.",
       "canonical": "https://goldtickerlive.com/countries/oman/",
       "robots": null,
@@ -6490,7 +6501,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -6865,12 +6877,12 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold price today in Pakistan — PKR reference rates | Gold Ticker Live",
-      "metaDescription": "Today spot-linked reference gold price in Pakistan, with 24K, 22K, 21K, 18K, and 14K rates in PKR per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "title": "Gold Price in Pakistan Today — PKR | Gold Ticker Live",
+      "metaDescription": "Spot-linked reference gold price in Pakistan today — 24K, 22K, 21K, 18K and 14K rates in PKR per gram, with freshness labels and methodology.",
       "canonical": "https://goldtickerlive.com/countries/pakistan/",
       "robots": null,
-      "ogTitle": "Gold price today in Pakistan — PKR reference rates | Gold Ticker Live",
-      "ogDescription": "Today spot-linked reference gold price in Pakistan, with 24K, 22K, 21K, 18K, and 14K rates in PKR per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "ogTitle": "Gold Price in Pakistan Today — PKR per Gram",
+      "ogDescription": "Spot-linked reference gold price in Pakistan today — 24K, 22K, 21K, 18K and 14K rates in PKR per gram, with freshness labels and methodology.",
       "ogImage": "https://goldtickerlive.com/assets/og-image.png",
       "ogUrl": "https://goldtickerlive.com/countries/pakistan/",
       "ogType": "website",
@@ -6891,7 +6903,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -7375,12 +7388,12 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold price today in Palestine — ILS reference rates | Gold Ticker Live",
-      "metaDescription": "Today spot-linked reference gold price in Palestine, with 24K, 22K, 21K, 18K, and 14K rates in ILS per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "title": "Gold Price in Palestine Today — ILS | Gold Ticker Live",
+      "metaDescription": "Spot-linked reference gold price in Palestine today — 24K, 22K, 21K, 18K and 14K rates in ILS per gram, with freshness labels and methodology.",
       "canonical": "https://goldtickerlive.com/countries/palestine/",
       "robots": null,
-      "ogTitle": "Gold price today in Palestine — ILS reference rates | Gold Ticker Live",
-      "ogDescription": "Today spot-linked reference gold price in Palestine, with 24K, 22K, 21K, 18K, and 14K rates in ILS per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "ogTitle": "Gold Price in Palestine Today — ILS per Gram",
+      "ogDescription": "Spot-linked reference gold price in Palestine today — 24K, 22K, 21K, 18K and 14K rates in ILS per gram, with freshness labels and methodology.",
       "ogImage": "https://goldtickerlive.com/assets/og-image.png",
       "ogUrl": "https://goldtickerlive.com/countries/palestine/",
       "ogType": "website",
@@ -7401,7 +7414,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -8066,7 +8080,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Qatar Today — QAR per Gram (24K, 22K, 21K) | Gold Ticker Live",
+      "title": "Gold Price in Qatar Today — QAR | Gold Ticker Live",
       "metaDescription": "Live gold price in Qatar today in QAR per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Qatari Riyal.",
       "canonical": "https://goldtickerlive.com/countries/qatar/",
       "robots": null,
@@ -8092,7 +8106,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -8321,7 +8336,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Saudi Arabia Today — SAR per Gram (24K, 22K, 21K) | Gold Ticker Live",
+      "title": "Gold Price in Saudi Arabia Today — SAR | Gold Ticker Live",
       "metaDescription": "Live gold price in Saudi Arabia today in SAR per gram and troy oz. Updated every 90 seconds. View 24K, 22K, 21K and 18K gold rates in Saudi Riyal.",
       "canonical": "https://goldtickerlive.com/countries/saudi-arabia/",
       "robots": null,
@@ -8347,7 +8362,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -8831,7 +8847,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Sudan Today — SDG per Gram | Gold Ticker Live",
+      "title": "Gold Price in Sudan Today — SDG | Gold Ticker Live",
       "metaDescription": "Live gold price in Sudan in SDG per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Sudanese Pound.",
       "canonical": "https://goldtickerlive.com/countries/sudan/",
       "robots": null,
@@ -8857,7 +8873,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -9559,12 +9576,12 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold price today in Syria — SYP reference rates | Gold Ticker Live",
-      "metaDescription": "Today spot-linked reference gold price in Syria, with 24K, 22K, 21K, 18K, and 14K rates in SYP per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "title": "Gold Price in Syria Today — SYP | Gold Ticker Live",
+      "metaDescription": "Spot-linked reference gold price in Syria today — 24K, 22K, 21K, 18K and 14K rates in SYP per gram, with freshness labels and methodology.",
       "canonical": "https://goldtickerlive.com/countries/syria/",
       "robots": null,
-      "ogTitle": "Gold price today in Syria — SYP reference rates | Gold Ticker Live",
-      "ogDescription": "Today spot-linked reference gold price in Syria, with 24K, 22K, 21K, 18K, and 14K rates in SYP per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "ogTitle": "Gold Price in Syria Today — SYP per Gram",
+      "ogDescription": "Spot-linked reference gold price in Syria today — 24K, 22K, 21K, 18K and 14K rates in SYP per gram, with freshness labels and methodology.",
       "ogImage": "https://goldtickerlive.com/assets/og-image.png",
       "ogUrl": "https://goldtickerlive.com/countries/syria/",
       "ogType": "website",
@@ -9585,7 +9602,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -9633,7 +9651,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in Tunisia Today — TND per Gram | Gold Ticker Live",
+      "title": "Gold Price in Tunisia Today — TND | Gold Ticker Live",
       "metaDescription": "Live gold price in Tunisia in TND per gram. Updated every 90 seconds. 24K, 22K, 21K, 18K gold rates in Tunisian Dinar.",
       "canonical": "https://goldtickerlive.com/countries/tunisia/",
       "robots": null,
@@ -9659,7 +9677,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -10143,12 +10162,12 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold price today in Turkey — TRY reference rates | Gold Ticker Live",
-      "metaDescription": "Today spot-linked reference gold price in Turkey, with 24K, 22K, 21K, 18K, and 14K rates in TRY per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "title": "Gold Price in Turkey Today — TRY | Gold Ticker Live",
+      "metaDescription": "Spot-linked reference gold price in Turkey today — 24K, 22K, 21K, 18K and 14K rates in TRY per gram, with freshness labels and methodology.",
       "canonical": "https://goldtickerlive.com/countries/turkey/",
       "robots": null,
-      "ogTitle": "Gold price today in Turkey — TRY reference rates | Gold Ticker Live",
-      "ogDescription": "Today spot-linked reference gold price in Turkey, with 24K, 22K, 21K, 18K, and 14K rates in TRY per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "ogTitle": "Gold Price in Turkey Today — TRY per Gram",
+      "ogDescription": "Spot-linked reference gold price in Turkey today — 24K, 22K, 21K, 18K and 14K rates in TRY per gram, with freshness labels and methodology.",
       "ogImage": "https://goldtickerlive.com/assets/og-image.png",
       "ogUrl": "https://goldtickerlive.com/countries/turkey/",
       "ogType": "website",
@@ -10169,7 +10188,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -10979,7 +10999,7 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold Price in UAE Today — AED per Gram (24K, 22K, 21K, 18K) | Gold Ticker Live",
+      "title": "Gold Price in UAE Today — AED | Gold Ticker Live",
       "metaDescription": "Live gold price in UAE today in AED per gram and troy oz. Updated every 90 seconds. See 24K, 22K, 21K and 18K gold rates in UAE Dirham.",
       "canonical": "https://goldtickerlive.com/countries/uae/",
       "robots": null,
@@ -11005,7 +11025,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -11561,12 +11582,12 @@
       "exempt": null,
       "lang": "en",
       "dir": "ltr",
-      "title": "Gold price today in Yemen — YER reference rates | Gold Ticker Live",
-      "metaDescription": "Today spot-linked reference gold price in Yemen, with 24K, 22K, 21K, 18K, and 14K rates in YER per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "title": "Gold Price in Yemen Today — YER | Gold Ticker Live",
+      "metaDescription": "Spot-linked reference gold price in Yemen today — 24K, 22K, 21K, 18K and 14K rates in YER per gram, with freshness labels and methodology.",
       "canonical": "https://goldtickerlive.com/countries/yemen/",
       "robots": null,
-      "ogTitle": "Gold price today in Yemen — YER reference rates | Gold Ticker Live",
-      "ogDescription": "Today spot-linked reference gold price in Yemen, with 24K, 22K, 21K, 18K, and 14K rates in YER per gram, freshness labels, and direct links to the tracker, calculator, methodology, and country market context.",
+      "ogTitle": "Gold Price in Yemen Today — YER per Gram",
+      "ogDescription": "Spot-linked reference gold price in Yemen today — 24K, 22K, 21K, 18K and 14K rates in YER per gram, with freshness labels and methodology.",
       "ogImage": "https://goldtickerlive.com/assets/og-image.png",
       "ogUrl": "https://goldtickerlive.com/countries/yemen/",
       "ogType": "website",
@@ -11587,7 +11608,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "Dataset"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -12388,7 +12410,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "ItemList"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null

--- a/scripts/node/inject-schema.js
+++ b/scripts/node/inject-schema.js
@@ -26,6 +26,34 @@ const SITE_URL = 'https://goldtickerlive.com';
 const SITE_NAME = 'Gold Ticker Live';
 const SITE_DESCRIPTION = 'Live gold prices for GCC, Arab world and global markets';
 
+// ── Trusted local config loaders ────────────────────────────────────────────
+// data/shops.js and src/config/countries.js are ES modules that can't be
+// require()'d from this CommonJS script, so we extract the exported array
+// literal and evaluate it in an isolated VM context (same pattern as
+// build/generateSitemap.js). These feed the shops ItemList and country-hub
+// Dataset schemas below. Failures degrade gracefully to an empty list — the
+// injector must never crash a build because a data file moved.
+const vm = require('vm');
+
+function evalArrayLiteral(src) {
+  return vm.runInNewContext(`(${src})`, Object.create(null), { timeout: 2000 });
+}
+
+function loadExportedArray(relPath, exportName) {
+  try {
+    const raw = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
+    const match = raw.match(new RegExp(`export const ${exportName}\\s*=\\s*(\\[[\\s\\S]*?\\]);`));
+    if (!match) return [];
+    return evalArrayLiteral(match[1]);
+  } catch {
+    return [];
+  }
+}
+
+const SHOPS = loadExportedArray('data/shops.js', 'SHOPS');
+const COUNTRIES = loadExportedArray('src/config/countries.js', 'COUNTRIES');
+const COUNTRY_BY_SLUG = new Map(COUNTRIES.filter((c) => c && c.slug).map((c) => [c.slug, c]));
+
 // ── Schema Templates ────────────────────────────────────────────────────────
 
 /**
@@ -181,6 +209,96 @@ function getDatasetSchema(options) {
     variableMeasured,
     isAccessibleForFree: true,
     inLanguage: ['en', 'ar'],
+  };
+}
+
+/**
+ * ItemList of gold-shop / gold-market directory listings for shops.html.
+ *
+ * Honesty contract (AGENTS.md "schema must match visible content"): the
+ * directory page explicitly frames most listings as "market areas or dealer
+ * clusters, not a single shop", and `data/shops.js` carries NO verified phone,
+ * website, opening hours, rating, or review data. We therefore emit ONLY the
+ * fields that are real and visible on each card — name, locality (city),
+ * country, and the served area — and deliberately omit telephone, geo,
+ * openingHours, aggregateRating, review, and any Offer/priceRange. This keeps
+ * the markup truthful and avoids a Google structured-data policy violation.
+ *
+ * @param {Array<Object>} shops - SHOPS from data/shops.js
+ */
+function getShopsDirectorySchema(shops) {
+  if (!Array.isArray(shops) || shops.length === 0) return null;
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'Gold Shops & Markets Directory',
+    description:
+      'Editorially listed gold shops and known gold markets across the GCC, Levant, North Africa, and India.',
+    url: `${SITE_URL}/shops.html`,
+    numberOfItems: shops.length,
+    itemListOrder: 'https://schema.org/ItemListUnordered',
+    itemListElement: shops.map((shop, index) => {
+      const area = [shop.market, shop.city].filter(Boolean).join(', ');
+      const descParts = [shop.category, shop.market].filter(Boolean);
+      const store = {
+        '@type': 'JewelryStore',
+        name: shop.name,
+        address: {
+          '@type': 'PostalAddress',
+          addressLocality: shop.city,
+          addressCountry: shop.countryCode,
+        },
+      };
+      if (area) store.areaServed = area;
+      if (descParts.length) store.description = descParts.join(' · ');
+      return {
+        '@type': 'ListItem',
+        position: index + 1,
+        item: store,
+      };
+    }),
+  };
+}
+
+/**
+ * WebApplication schema for the calculator tool page.
+ *
+ * featureList mirrors the five tabs that are actually rendered on the page
+ * (value, scrap, Zakat, buying power, unit converter), so the markup matches
+ * visible content. The tool is free and runs in the browser — represented with
+ * a zero-price Offer and isAccessibleForFree, no fabricated review/rating.
+ *
+ * @param {Object} options
+ */
+function getCalculatorAppSchema({ url, description }) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Gold Calculator',
+    url,
+    description,
+    applicationCategory: 'FinanceApplication',
+    operatingSystem: 'Any (web browser)',
+    browserRequirements: 'Requires JavaScript',
+    isAccessibleForFree: true,
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
+    featureList: [
+      'Gold value calculator (any weight and karat)',
+      'Scrap / melt gold value calculator',
+      'Zakat on gold calculator (2.5%)',
+      'Buying power calculator',
+      'Gold weight unit converter',
+    ],
+    inLanguage: ['en', 'ar'],
+    publisher: {
+      '@type': 'Organization',
+      name: SITE_NAME,
+      url: SITE_URL,
+    },
   };
 }
 
@@ -399,6 +517,40 @@ function generateSchemasForPage(filePath, content) {
         schemas.push(getFAQPageSchema(faqItems));
       }
     }
+  }
+
+  // Shops directory — ItemList of JewelryStore listings (from data/shops.js).
+  if (relativePath === 'shops.html') {
+    const itemList = getShopsDirectorySchema(SHOPS);
+    if (itemList) schemas.push(itemList);
+  }
+
+  // Calculator tool — WebApplication describing the five calculator tools.
+  if (relativePath === 'calculator.html') {
+    schemas.push(
+      getCalculatorAppSchema({
+        url: canonicalUrl || `${SITE_URL}${urlPath}`,
+        description: pageDescription || SITE_DESCRIPTION,
+      })
+    );
+  }
+
+  // Country hub (countries/{slug}/index.html, indexable) — add a Dataset for
+  // the reference price data the page displays. FAQPage is injected at runtime
+  // by country-page.js alongside the visible FAQ (parity-correct), so it is not
+  // duplicated here; BreadcrumbList is already added above. The deeper
+  // /{slug}/gold-price/ variant is noindex and skipped by the injector.
+  const hubMatch = relativePath.match(/^countries\/([^/]+)\/index\.html$/);
+  if (hubMatch && COUNTRY_BY_SLUG.has(hubMatch[1])) {
+    const country = COUNTRY_BY_SLUG.get(hubMatch[1]);
+    schemas.push(
+      getDatasetSchema({
+        name: pageTitle,
+        description: pageDescription,
+        url: canonicalUrl || `${SITE_URL}${urlPath}`,
+        variableMeasured: `Gold price per gram in ${country.currency}`,
+      })
+    );
   }
 
   return schemas;

--- a/shops.html
+++ b/shops.html
@@ -86,6 +86,424 @@
   ]
 }
   </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Gold Shops & Markets Directory",
+  "description": "Editorially listed gold shops and known gold markets across the GCC, Levant, North Africa, and India.",
+  "url": "https://goldtickerlive.com/shops.html",
+  "numberOfItems": 27,
+  "itemListOrder": "https://schema.org/ItemListUnordered",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Dubai Gold Souk Traders",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Dubai",
+          "addressCountry": "AE"
+        },
+        "areaServed": "Dubai Gold Souk (Deira), Dubai",
+        "description": "Jewellery & Bullion · Dubai Gold Souk (Deira)"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Deira Bullion Dealers",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Dubai",
+          "addressCountry": "AE"
+        },
+        "areaServed": "Dubai Gold Souk (Deira), Dubai",
+        "description": "Bullion · Dubai Gold Souk (Deira)"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Sharjah Gold Souk Shops",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Sharjah",
+          "addressCountry": "AE"
+        },
+        "areaServed": "Sharjah Central Souq, Sharjah",
+        "description": "Jewellery & Bullion · Sharjah Central Souq"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Madinat Zayed Gold Center",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Abu Dhabi",
+          "addressCountry": "AE"
+        },
+        "areaServed": "Madinat Zayed Gold Center, Abu Dhabi",
+        "description": "Jewellery Retail · Madinat Zayed Gold Center"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Hamdan Street Gold Traders",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Abu Dhabi",
+          "addressCountry": "AE"
+        },
+        "areaServed": "Hamdan Street Area, Abu Dhabi",
+        "description": "Jewellery Shops · Hamdan Street Area"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Taiba Gold Market Stores",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Riyadh",
+          "addressCountry": "SA"
+        },
+        "areaServed": "Taiba Markets, Riyadh",
+        "description": "Gold Jewellery · Taiba Markets"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 7,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Olaya District Gold Boutiques",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Riyadh",
+          "addressCountry": "SA"
+        },
+        "areaServed": "Olaya Street Area, Riyadh",
+        "description": "Jewellery Boutiques · Olaya Street Area"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 8,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Al-Balad Jewelry Shops",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Jeddah",
+          "addressCountry": "SA"
+        },
+        "areaServed": "Historic Al-Balad, Jeddah",
+        "description": "Jewellery Shops · Historic Al-Balad"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 9,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Dammam Gold Market",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Dammam",
+          "addressCountry": "SA"
+        },
+        "areaServed": "Al-Balad Commercial Area, Dammam",
+        "description": "Jewellery & Bullion · Al-Balad Commercial Area"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 10,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Kuwait Gold Souk Dealers",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Kuwait City",
+          "addressCountry": "KW"
+        },
+        "areaServed": "Mubarakiya / Gold Souk, Kuwait City",
+        "description": "Bullion & Jewellery · Mubarakiya / Gold Souk"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 11,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "The Avenues Gold Retailers",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Kuwait City",
+          "addressCountry": "KW"
+        },
+        "areaServed": "The Avenues Mall, Kuwait City",
+        "description": "Jewellery Retail · The Avenues Mall"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 12,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Doha Gold Souq Shops",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Doha",
+          "addressCountry": "QA"
+        },
+        "areaServed": "Doha Gold Souq, Doha",
+        "description": "Gold Jewellery · Doha Gold Souq"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 13,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Villaggio & Mall Jewellery",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Doha",
+          "addressCountry": "QA"
+        },
+        "areaServed": "Villaggio Mall / City Center, Doha",
+        "description": "Jewellery Retail · Villaggio Mall / City Center"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 14,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Manama Gold City Stores",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Manama",
+          "addressCountry": "BH"
+        },
+        "areaServed": "Manama Gold City, Manama",
+        "description": "Jewellery Retail · Manama Gold City"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 15,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Manama Souk Gold Traders",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Manama",
+          "addressCountry": "BH"
+        },
+        "areaServed": "Manama Souk, Manama",
+        "description": "Gold Jewellery & Bullion · Manama Souk"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 16,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Muttrah Gold Market Shops",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Muscat",
+          "addressCountry": "OM"
+        },
+        "areaServed": "Muttrah Souq, Muscat",
+        "description": "Gold Jewellery · Muttrah Souq"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 17,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Seeb Gold Market Dealers",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Muscat",
+          "addressCountry": "OM"
+        },
+        "areaServed": "Seeb Commercial Area, Muscat",
+        "description": "Jewellery & Bullion · Seeb Commercial Area"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 18,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Khan El Khalili Gold Shops",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Cairo",
+          "addressCountry": "EG"
+        },
+        "areaServed": "Khan El Khalili, Cairo",
+        "description": "Gold Jewellery · Khan El Khalili"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 19,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Wekalet El-Balah Gold Street",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Cairo",
+          "addressCountry": "EG"
+        },
+        "areaServed": "Wekalet El-Balah / Downtown, Cairo",
+        "description": "Wholesale & Retail Gold · Wekalet El-Balah / Downtown"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 20,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Attarine Gold Market",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Alexandria",
+          "addressCountry": "EG"
+        },
+        "areaServed": "Attarine District, Alexandria",
+        "description": "Jewellery Shops · Attarine District"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 21,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Downtown Amman Gold Stores",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Amman",
+          "addressCountry": "JO"
+        },
+        "areaServed": "Downtown Gold Street, Amman",
+        "description": "Jewellery Shops · Downtown Gold Street"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 22,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Mecca Mall Jewellery Row",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Amman",
+          "addressCountry": "JO"
+        },
+        "areaServed": "Mecca Mall, Amman",
+        "description": "Jewellery Retail · Mecca Mall"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 23,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Casablanca Gold Boutiques",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Casablanca",
+          "addressCountry": "MA"
+        },
+        "areaServed": "Maarif / Ziraoui Area, Casablanca",
+        "description": "Jewellery Boutiques · Maarif / Ziraoui Area"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 24,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Marrakech Souk El Jeld Gold",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Marrakech",
+          "addressCountry": "MA"
+        },
+        "areaServed": "Medina Souks, Marrakech",
+        "description": "Traditional Jewellery · Medina Souks"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 25,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Zaveri Bazaar Gold Dealers",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Mumbai",
+          "addressCountry": "IN"
+        },
+        "areaServed": "Zaveri Bazaar, Mumbai",
+        "description": "Bullion & Jewellery · Zaveri Bazaar"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 26,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "Karol Bagh Jewellery Market",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Delhi",
+          "addressCountry": "IN"
+        },
+        "areaServed": "Karol Bagh, Delhi",
+        "description": "Jewellery & Bullion · Karol Bagh"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 27,
+      "item": {
+        "@type": "JewelryStore",
+        "name": "T. Nagar Gold & Jewellery Shops",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Chennai",
+          "addressCountry": "IN"
+        },
+        "areaServed": "T. Nagar Shopping District, Chennai",
+        "description": "Jewellery Retail · T. Nagar Shopping District"
+      }
+    }
+  ]
+}
+  </script>
   </head>
   <body>
     <a class="skip-link" href="#main-content">Skip to main content</a>

--- a/tests/seo-structured-data.test.js
+++ b/tests/seo-structured-data.test.js
@@ -1,0 +1,170 @@
+/**
+ * Structured-data + metadata-quality guards for the content pages whose
+ * non-visual SEO layer is owned by the JSON-LD injector and the head metadata:
+ *   - shops.html        → ItemList of JewelryStore listings (no fabricated data)
+ *   - calculator.html   → WebApplication with a featureList
+ *   - countries/<slug>/ → Dataset + BreadcrumbList (FAQPage is runtime-injected)
+ *
+ * Enforced invariants:
+ *   1. <title> <= 60 chars, <meta name="description"> <= 155 chars.
+ *   2. Exactly one canonical, and og:url === canonical.
+ *   3. Every <script type="application/ld+json"> block is valid JSON.
+ *   4. shops.html ItemList exists, every item is a JewelryStore with
+ *      name + addressLocality + addressCountry, and NO fabricated fields
+ *      (telephone, openingHours, aggregateRating, review, geo, priceRange).
+ *   5. calculator.html WebApplication exists with a non-empty featureList.
+ *   6. Each country hub emits a Dataset.
+ */
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+
+const TITLE_MAX = 60;
+const DESCRIPTION_MAX = 155;
+
+// Country hubs are discovered from disk (countries/<slug>/index.html), excluding
+// the directory landing page, so new countries are covered automatically.
+function countryHubFiles() {
+  const dir = path.join(ROOT, 'countries');
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => `countries/${e.name}/index.html`)
+    .filter((rel) => fs.existsSync(path.join(ROOT, rel)));
+}
+
+const PAGES = ['shops.html', 'calculator.html', ...countryHubFiles()];
+
+function read(file) {
+  return fs.readFileSync(path.join(ROOT, file), 'utf8');
+}
+function head(html) {
+  const m = html.match(/<head[\s\S]*?<\/head>/i);
+  return m ? m[0] : html;
+}
+function getTitle(h) {
+  const m = h.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  return m ? m[1].trim() : null;
+}
+function getMeta(h, attr, name) {
+  const m = h.match(
+    new RegExp(`<meta[^>]+${attr}=["']${name}["'][^>]*content=["']([^"']*)["']`, 'i')
+  );
+  return m ? m[1] : null;
+}
+function jsonLdBlocks(html) {
+  const re = /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  const out = [];
+  let m;
+  while ((m = re.exec(html)) !== null) out.push(m[1].trim());
+  return out;
+}
+function jsonLdObjects(html) {
+  return jsonLdBlocks(html).map((b) => JSON.parse(b));
+}
+
+for (const file of PAGES) {
+  test(`${file}: title <= ${TITLE_MAX} chars`, () => {
+    const title = getTitle(head(read(file)));
+    assert.ok(title, `${file}: missing <title>`);
+    assert.ok(
+      title.length <= TITLE_MAX,
+      `${file}: title is ${title.length} chars (> ${TITLE_MAX}): "${title}"`
+    );
+  });
+
+  test(`${file}: meta description <= ${DESCRIPTION_MAX} chars`, () => {
+    const desc = getMeta(head(read(file)), 'name', 'description');
+    assert.ok(desc, `${file}: missing meta description`);
+    assert.ok(
+      desc.length <= DESCRIPTION_MAX,
+      `${file}: description is ${desc.length} chars (> ${DESCRIPTION_MAX})`
+    );
+  });
+
+  test(`${file}: exactly one canonical and og:url === canonical`, () => {
+    const h = head(read(file));
+    const canonicals = h.match(/rel=["']canonical["']/gi) || [];
+    assert.equal(canonicals.length, 1, `${file}: expected 1 canonical, found ${canonicals.length}`);
+    const canonical = (h.match(/rel=["']canonical["'][^>]*href=["']([^"']+)["']/i) || [])[1];
+    const ogUrl = getMeta(h, 'property', 'og:url');
+    assert.ok(canonical, `${file}: missing canonical href`);
+    assert.equal(ogUrl, canonical, `${file}: og:url (${ogUrl}) !== canonical (${canonical})`);
+  });
+
+  test(`${file}: every JSON-LD block is valid JSON`, () => {
+    const blocks = jsonLdBlocks(read(file));
+    assert.ok(blocks.length >= 1, `${file}: expected at least one JSON-LD block`);
+    for (const block of blocks) {
+      assert.doesNotThrow(() => JSON.parse(block), `${file}: invalid JSON-LD block`);
+    }
+  });
+}
+
+test('shops.html: emits an ItemList of JewelryStore listings with no fabricated fields', () => {
+  const objs = jsonLdObjects(read('shops.html'));
+  const itemList = objs.find((o) => o['@type'] === 'ItemList');
+  assert.ok(itemList, 'shops.html: missing ItemList JSON-LD');
+  assert.ok(Array.isArray(itemList.itemListElement), 'ItemList: itemListElement must be an array');
+  assert.ok(itemList.itemListElement.length >= 1, 'ItemList: expected at least one listing');
+  assert.equal(
+    itemList.numberOfItems,
+    itemList.itemListElement.length,
+    'ItemList: numberOfItems must match itemListElement length'
+  );
+
+  // Fabrication guard — these fields are NOT in data/shops.js and must never
+  // be invented (Google policy + AGENTS.md trust rules).
+  const forbidden = [
+    'telephone',
+    'openingHours',
+    'aggregateRating',
+    'review',
+    'geo',
+    'priceRange',
+    'latitude',
+    'longitude',
+  ];
+  const blob = JSON.stringify(itemList);
+  for (const field of forbidden) {
+    assert.ok(!blob.includes(field), `ItemList must not contain fabricated field "${field}"`);
+  }
+
+  for (const entry of itemList.itemListElement) {
+    const store = entry.item;
+    assert.equal(store['@type'], 'JewelryStore', 'each listing must be a JewelryStore');
+    assert.ok(store.name, 'each store must have a name');
+    assert.ok(store.address && store.address.addressLocality, 'each store needs addressLocality');
+    assert.ok(store.address && store.address.addressCountry, 'each store needs addressCountry');
+  }
+});
+
+test('calculator.html: emits a WebApplication with a featureList', () => {
+  const objs = jsonLdObjects(read('calculator.html'));
+  const app = objs.find((o) => o['@type'] === 'WebApplication');
+  assert.ok(app, 'calculator.html: missing WebApplication JSON-LD');
+  assert.ok(app.name, 'WebApplication: missing name');
+  assert.ok(
+    Array.isArray(app.featureList) && app.featureList.length >= 1,
+    'WebApplication: featureList must be a non-empty array'
+  );
+  assert.ok(
+    app.offers && app.offers.price === '0',
+    'WebApplication: free calculator should advertise a zero-price offer'
+  );
+});
+
+for (const file of countryHubFiles()) {
+  test(`${file}: emits a Dataset`, () => {
+    const objs = jsonLdObjects(read(file));
+    const dataset = objs.find((o) => o['@type'] === 'Dataset');
+    assert.ok(dataset, `${file}: missing Dataset JSON-LD`);
+    assert.ok(dataset.variableMeasured, `${file}: Dataset missing variableMeasured`);
+  });
+}


### PR DESCRIPTION
## What

Non-visual SEO / structured-data / metadata QA across the content pages — **shops.html, calculator.html, and all 21 country hubs**. Every edit is confined to `<head>` and injected JSON-LD: **zero body, visual, layout, or pricing changes** (verified by comparing each file's post-`</head>` body against base — 0 differences across 23 files).

## Why

Schema, canonicals, metadata, hreflang, and internal links are product quality on this site (AGENTS.md §"Technical SEO policy"). The content pages had oversized titles/descriptions, incomplete OG/Twitter tags, and no rich structured data beyond BreadcrumbList. This makes that layer excellent and **build-safe**.

## Approach note (read first)

The original task framing assumed hand-authored JSON-LD in HTML and a hand-edited `sitemap.xml`. This repo's build makes that **non-durable**: `scripts/node/inject-schema.js` strips & re-injects *all* `<script type="application/ld+json">` on every build, and `sitemap.xml` is **gitignored / generated**. Per AGENTS.md ("schema injection runs via inject-schema.js — don't hand-author"; "sitemap is generated — must not hand-edit") I extended the **generator** instead. Only generator file touched outside the literal allowlist: `scripts/node/inject-schema.js` (not owned by the parallel visual task). Re-running the injector is idempotent (0 changes).

## How — by scope item

### 1. Structured data (per page)
| Page | JSON-LD @types emitted |
| --- | --- |
| `shops.html` | BreadcrumbList **+ ItemList** (27 `JewelryStore` nodes) |
| `calculator.html` | BreadcrumbList **+ WebApplication** |
| `countries/<slug>/index.html` ×21 | BreadcrumbList **+ Dataset** (+ runtime FAQPage) |

- **shops** — `ItemList` of 27 `JewelryStore` nodes built **only** from real fields in `data/shops.js`: `name`, `city`→`addressLocality`, `countryCode`→`addressCountry`, `market`/`city`→`areaServed`, `category`/`market`→`description`. **No fabricated** `telephone`/`geo`/`openingHours`/`aggregateRating`/`review`/`priceRange` — the page itself frames listings as *"market areas or dealer clusters, not a single shop"* and the data has empty phone/website. A test asserts none of those fields ever appear.
- **calculator** — `WebApplication` (`applicationCategory: FinanceApplication`, free `Offer`, `featureList` = the 5 visible tools: gold value, scrap/melt, Zakat 2.5%, buying power, unit converter). Matches the visible tabs.
- **country hubs** — added `Dataset` (`variableMeasured: "Gold price per gram in <CUR>"`, currency from `src/config/countries.js`). **FAQPage stays runtime-injected** by `country-page.js` (`injectFaqSchema`, id `faq-schema-ld`) *alongside the visible FAQ* — parity-correct and not duplicated. The deeper `/<slug>/gold-price/` variant is `noindex` (canonical→hub) and left as-is.
- 46 JSON-LD blocks across the 23 pages — **0 parse failures**.

### 2. Metadata length & quality (all country pages, not just UAE)
- **Titles ≤ 60:** normalized all 21 hub titles + the calculator title (19 were >60, worst 84). New hub pattern `Gold Price in {Country} Today — {CUR} | Gold Ticker Live` (max 57). Calculator → `Gold Calculator — Value, Scrap, Zakat | Gold Ticker Live` (56).
- **Descriptions ≤ 155:** shortened the 6 oversized hub descriptions (Pakistan/Turkey/Iraq/Syria/Palestine/Yemen, 207–220 chars) while **keeping the spot-linked "reference" framing**. The other 15 were already ≤155 and left untouched (minimal diff).
- **Canonical:** exactly one self-referential canonical per page; `og:url == canonical` preserved (enforced by `check-seo-meta.js` + new tests).

### 3. Social / Open Graph + Twitter
- Added the missing `twitter:title`, `twitter:description`, `og:locale` (+`og:locale:alternate`), `og:image:alt` to the **15 hubs** that lacked them; refreshed oversized og/twitter descriptions on the 6 "reference rates" hubs. `shops.html` / `calculator.html` were already complete.

### 4. Bilingual SEO — hreflang decision (verified, not assumed)
**Finding:** AR is a **client-side `?lang=ar` toggle**, *not* distinct URLs, for shops/calculator/countries (only a few core pages like `ar/index.html`, `ar/methodology/` have real AR docs). `?lang=ar` URLs return **200** (same static file; JS switches language) — **not 404**.
**Decision: KEEP the existing `?lang=ar` hreflang alternates** (did not add new ones, did not remove, did not invent AR URLs). Reason: `scripts/node/check-seo-meta.js` (in `npm run validate`) **hard-requires** `hreflang` en/ar/x-default on every indexable page — removing them fails CI — and `?lang=ar` is the established site-wide convention returning 200. ⚠️ The `?lang=ar` pattern is imperfect (Google may canonicalize the query away); a future round could build real `ar/` country pages or relax the check. Flagging for the owner.

### 5. Sitemap
**No change required.** The production generator `scripts/node/generate-sitemap.js` (run in CI **and** deploy *after* `npm run build`, overwriting the legacy hardcoded `build/generateSitemap.js`) is **filesystem-driven**: it already includes shops, calculator, and all 21 hubs, skips `countries/*/gold-price` duplicates + noindex pages, and `check-sitemap-coverage.js` enforces 1:1 coverage (**239 URLs ↔ 344 files, all aligned**, lastmod from mtime). `sitemap.xml` is gitignored. The legacy `build/generateSitemap.js` is **superseded** (its output is overwritten in deploy) and slightly behind — recommend retiring it in a follow-up.

### 6. Internal linking + link integrity
- `scripts/node/check-links.js`: all internal links across **390 HTML files resolve — no broken internal links**.
- Owned-page linking is already sound: hubs → calculator / tracker / methodology / learn / GCC comparison; shops → calculator / tracker / country markets / methodology / guides.
- **Gap flagged for a later (visual-allowed) round:** country hubs do **not** link to `shops.html` (shops → countries exists, but not the reverse). Adding a contextual shops link to the hub tools row is a *visible* body edit, out of scope for this non-visual PR.

## Proof (commands run)
- `npm test` → **1205 pass / 0 fail** (added 115 in `tests/seo-structured-data.test.js`: title ≤60, description ≤155, every JSON-LD block valid JSON, honest ItemList with no fabricated fields, WebApplication featureList, Dataset per hub).
- `npm run lint` → clean. `npm run validate` → **exit 0**. `npm run build` → succeeds; injector idempotent.
- Regenerated `reports/seo/{inventory,governance}.json`.
- **Zero body changes** confirmed (every HTML diff inside `<head>`); **no forbidden files touched** (index.html, tracker.html, any CSS, nav/footer/ticker/chart, home.js, pricing/constants/translations all untouched).

## Risks / notes
- Extended `scripts/node/inject-schema.js` (outside the literal allowlist, but mandated by AGENTS.md; not owned by the parallel visual task).
- `JewelryStore` typing for editorial market-cluster listings is a deliberate, conservative choice (zero single-business signals emitted). Easy to switch to `Place`/`LocalBusiness` if preferred.
- Pre-existing repo prettier debt (~88 unrelated files flagged by `format:check`) left untouched/out of scope; all of *my* changed files are prettier-clean.
- **Branch:** committed to `claude/youthful-gates-360xch` (the session-designated branch). The task text requested `feat/seo-structured-data-metadata-qa` — flagging the discrepancy; happy to rename/retarget if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017FJ5aR93nKNDY6GvhKWTBH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are head metadata and build-time schema injection with automated guards; no pricing, auth, or visible UI logic. Main caveat is SEO policy choices (e.g. `JewelryStore` for market clusters, retained `?lang=ar` hreflang) rather than runtime breakage.
> 
> **Overview**
> Extends **`scripts/node/inject-schema.js`** so the build injects durable JSON-LD: **`WebApplication`** on `calculator.html`, **`ItemList`** of honest **`JewelryStore`** entries on `shops.html` (from `data/shops.js` only—no phone/hours/ratings), and **`Dataset`** on each **`countries/<slug>/index.html`** hub (currency from `src/config/countries.js`). Matching blocks are written into those HTML heads; FAQ on hubs stays runtime-only per existing `country-page.js` behavior.
> 
> **Head-only SEO pass** across calculator, shops, and 21 country hubs: shorter **titles** (≤60) and **descriptions** (≤155), especially on the six “reference rates” hubs; added **OG locale / image alt** and **Twitter title/description** where missing; breadcrumb JSON-LD split fixed so new schema scripts sit in separate blocks.
> 
> Adds **`tests/seo-structured-data.test.js`** to guard metadata limits, canonical/`og:url` parity, valid JSON-LD, ItemList honesty, calculator `featureList`, and per-hub `Dataset`. Regenerates **`reports/seo/governance.json`** and **`inventory.json`** timestamps and inventory fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ee8c20155ebd41bf7e433be84888a24d9379839. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->