### PR TITLE
fix(theme): flip remaining hardcoded ivory gradient stops in dark mode

### DIFF
--- a/styles/city-page.css
+++ b/styles/city-page.css
@@ -384,7 +384,7 @@
     135deg,
     var(--color-gold-tint) 0%,
     var(--color-gold-bg) 60%,
-    rgb(253 250 240 / 80%) 100%
+    color-mix(in srgb, var(--surface-primary) 85%, transparent) 100%
   );
   border: 1.5px solid rgb(196 144 46 / 40%);
   border-radius: var(--radius-lg);

--- a/styles/guide-page.css
+++ b/styles/guide-page.css
@@ -554,7 +554,7 @@
     135deg,
     var(--color-gold-tint) 0%,
     var(--color-gold-bg) 60%,
-    rgb(253 250 240 / 80%) 100%
+    color-mix(in srgb, var(--surface-primary) 85%, transparent) 100%
   );
   border: 1.5px solid rgb(196 144 46 / 40%);
   border-radius: var(--radius-xl);

--- a/styles/pages/calculator.css
+++ b/styles/pages/calculator.css
@@ -1199,7 +1199,7 @@
   background: linear-gradient(
     135deg,
     var(--color-gold-tint) 0%,
-    rgb(253 250 240 / 80%) 60%,
+    color-mix(in srgb, var(--surface-primary) 85%, transparent) 60%,
     transparent 100%
   );
   border: 1.5px solid rgb(196 144 46 / 40%);


### PR DESCRIPTION
## What
Replaces hardcoded near-white gradient stops (`rgb(253 250 240 / 80%)`) that had **no `[data-theme='dark']` override** — so they stayed bright in dark mode — with a theme-aware token (`color-mix(in srgb, var(--surface-primary) 85%, transparent)`):
- `styles/city-page.css` — `.city-cta-banner`
- `styles/guide-page.css` — `.guide-cta`
- `styles/pages/calculator.css` — `.calc-result`

## Why
Follow-up to #451 (merged). The Gold Integrity reviews on #451 and #452 flagged these as the same defect class: the earlier gradient stops use `--color-gold-tint`/`--color-gold-bg` (which flip per theme), but a final/middle stop was a fixed near-white, leaving a bright ivory patch on the otherwise-dark surface in dark mode.

## How
`--surface-primary` is `#fff` in light and `#0c0e14` in dark, so the mixed stop darkens with the theme while preserving the lighter-highlight intent in light mode.

Note: `home.css .tool-card--primary` also has an ivory stop but already carries a `[data-theme='dark']` background override (the ivory only applies in light mode), so it is intentionally left unchanged.

## Proof
- `npm run style` (stylelint), prettier `--check`, and `check-basic-a11y.js` all pass.
- No remaining `rgb(253 250 240 / 80%)` stops lacking a dark override anywhere in `styles/`.
- Scope: 3 files, presentation-only — no pricing, freshness, translation, or SEO metadata changes.

## Risks
None — cosmetic dark-mode gradient corrections routed through an existing token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkPRegf54XG1jQECPiH1up