### PR TITLE
ph2/01: Precision Instrument readout + spot-vs-retail invariant fix

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -50,6 +50,7 @@
       }
     ],
     "selector-class-pattern": null,
+    "custom-property-pattern": "^[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*$",
     "property-no-vendor-prefix": null,
     "keyframes-name-pattern": null,
     "no-descending-specificity": null,

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
         aria-atomic="true"
         hidden
       >
-        <span class="hfb-icon" aria-hidden="true">⚡</span>
+        <span class="hfb-icon" aria-hidden="true"></span>
         <span id="hfb-text"></span>
         <button id="hfb-dismiss" class="hfb-dismiss" aria-label="Dismiss freshness banner" type="button">×</button>
       </div>
@@ -240,6 +240,18 @@
                 ><span class="skeleton-inline shell-skeleton-freshness-strip" role="presentation" aria-hidden="true"></span></span
               >
             </div>
+            <hr class="hlc-rule" aria-hidden="true" />
+            <p class="hlc-retail" id="hlc-retail">
+              <span class="hlc-retail-label" data-i18n="heroRetailNote"
+                >Retail prices add making charges, VAT &amp; margin</span
+              >
+              <a
+                class="hlc-retail-link"
+                href="content/spot-vs-retail-gold-price/"
+                data-i18n="heroRetailLink"
+                >How retail differs →</a
+              >
+            </p>
             <div class="hlc-sparkline" id="hlc-sparkline" aria-hidden="true"></div>
             <div class="hlc-stats-row" id="hlc-stats-row" hidden>
               <div class="hlc-stat">

--- a/redesign/AUDIT.md
+++ b/redesign/AUDIT.md
@@ -1,0 +1,311 @@
+# GoldTickerLive — Phase 0 Discovery & Audit
+
+**Scope:** All 390 HTML pages of the live, trust-critical site goldtickerlive.com (EN + AR), plus its design tokens, build/data pipeline, SEO governance, accessibility gate, performance baseline, content corpus, imagery, trust invariants, and the substantial prior redesign work already on disk. This is a **discovery-and-audit-only** deliverable — no source files were modified. Findings carry a strict **VERIFIED** (a command was run / an exact file:line was read) vs **UNVERIFIED** (reasoned/estimated) flag, and where an adversarial verifier refuted or corrected a dimension agent, the corrected value is used and noted. **Date: 2026-06-29.**
+
+---
+
+## Executive summary
+
+- **390 HTML pages, fully accounted for.** A page-family map of 24 families sums to exactly 390, and an independent mutually-exclusive re-partition of all 390 paths assigned 390/390 with zero unassigned and zero double-assigned. `allAccountedFor: true` is **CONFIRMED** by the verifier. (VERIFIED — `find` returned 390; family-sum = 390; countries subtree = 263.)
+- **The country corpus is the dominant content gap.** 263 of 390 pages are country/city pages, and they are overwhelmingly thin, near-duplicate template scaffolding: 69 gold-shops pages collapse to **2 distinct skeletons** with **zero real shop listings**, 47 of 69 gold-rate pages share one ~48-word skeleton, and only ~8 flagship capitals are enriched. SEO governance already flags **152 thin-risk indexable pages**. (VERIFIED.)
+- **EN/AR parity is met at the string level, NOT at the indexable-document level.** The central dictionary `src/config/translations.js` has perfect key parity (**1144 = 1144, 0 gaps**, CI-enforced), but only **20/390 pages (5.1%)** ship static `<html lang="ar">`; the other 370 (incl. all 263 country pages) are EN shells translated at runtime via `?lang=ar`. The verifier found a **stronger** problem than reported: even with JS on, the 69 city gold-rate pages keep their **H1, intro, and entire FAQ in English** under `?lang=ar` (Dubai gold-rate page = 40 static Arabic chars vs 13,389 in a real AR guide).
+- **The hreflang/sitemap layer is broken and self-contradicting.** Committed `public/sitemap.xml` lists only **18 URLs** (0 country pages) against ~372 indexable; page HTML declares AR via non-indexable `?lang=ar` (128 refs) while the sitemap uses `/ar/` paths; `/ar/calculator/` and `/ar/shops/` are sitemapped but **404** (no backing files); and the noindex `/ar/` redirect stub is listed at priority 1.0. (VERIFIED.)
+- **Imagery is a total greenfield gap.** Across all 390 pages there are **zero `<img>` tags, zero srcset/picture, zero lazy-loading, zero content alt text**. The repo holds 11 raster files (1 OG image, 5 favicons, 4 orphaned ~1MB screenshots referenced nowhere, 1 zero-byte stray). A single shared OG image serves all 264 pages that declare one. (VERIFIED.)
+- **All five trust invariants are currently UPHELD.** AED peg 3.6725 is the only peg value in source (the only near-miss grep hits are latitudes and USD/oz log prices); AED is provably deleted from the FX feed and re-applied from the peg on every path; troy-oz 31.1035 is canonical in core math; spot-vs-retail is rigorously separated; freshness/provenance is enforced product-wide and the static gate passes; spot price **throws rather than fabricates**. (VERIFIED, with two narrow caveats below.)
+- **Two invariant caveats (both already disclosed, low/medium severity).** (1) A second troy-oz value `31.1034768` appears in two calculators' fallback path **and in public methodology/FAQ copy**, while the footer/learn-hub show `31.1035` — a user-visible transparency inconsistency. (2) The freshness gate is **allowlist-based** and excludes `admin/` and `server/`, so "every price surface is labeled" is true for known surfaces but not provably exhaustive.
+- **Substantial prior redesign work is already on the branch and must be EXTENDED, not rebuilt.** A mature warm-parchment token system (`styles/partials/tokens.css`, 541 lines, 1.25 type scale, `--price-*` semantic aliases, EN/AR font stacks) plus design-feel Areas A–H artifacts (self-hosted fonts, unified price-display primitive, city-gold-rate template) are present, committed, and wired into `styles/global.css`. **A fresh design system is NOT warranted.**
+- **Documentation drift hazard.** CHANGELOG/PLAN/PROGRESS claim a "premium neutral re-theme," but the on-disk tokens are still warm parchment (`#fefcf7`). Trust the files, not the narrative.
+- **PR #443 security work splits into APPLIED vs STAGED-ONLY.** GREEN defect fixes (redirects, offline paths, footer headings) appear applied; RED-zone items (Supabase RLS migrations 002/003, billing fail-closed, AR hreflang unification "Phase 43") are **staged-only and gated on two blocking owner questions** — do NOT apply them in a design redesign.
+- **The build is static-first vanilla ES modules + Vite; the Express server / Supabase / Stripe are NOT in the production serving path** (`API_BACKEND_ENABLED: false`). Production is GitHub Pages serving committed `data/gold_price.json` + client-side compute. The redesign must not assume a backend.
+- **Governance gates are green on the pure-Node subset.** `npm run validate` is a 17-check required merge gate; the runnable subset (freshness, seo-meta on 390 files, basic-a11y on 341, inject-schema, inventory-seo 343/341/338, sw-precache, sw-coverage) all PASS today. The full suite (vite, eslint, stylelint, Playwright, pa11y-ci, Lighthouse, 146 test files) is **UNVERIFIED** — devDeps are not installed.
+
+---
+
+## Page-family map
+
+Every one of the 390 HTML files is assigned to exactly one of 24 families. Counts and structure notes are VERIFIED via `find`, targeted regex counts, and per-file `wc -l` / `grep title|lang|dir` reads of 1–3 representatives per family.
+
+| Family | Count | URL pattern | EN/AR status | Representative pages | Notes |
+|---|---|---|---|---|---|
+| home | 2 | `/` and `/ar/` | EN full 1295-line home; AR a 46-line stub | `index.html`, `ar/index.html` | Asymmetric: AR home is a thin runtime-hydrated shell vs rich EN home |
+| live-price-karat | 8 | `/gold-price/{18,21,22,24}k/` + `/ar/…` | EN (4) + **dedicated AR (4)** | `gold-price/24k/index.html`, `ar/gold-price/24k/index.html` | **Best parity family** — AR page (174 lines) slightly longer than EN (147) |
+| countries-hub | 1 | `/countries/` | EN only; AR runtime | `countries/index.html` | 309-line directory hub linking all 21 country landings |
+| country-landing | 21 | `/countries/{country}/` | EN only; AR runtime | `countries/uae/index.html` | Country overview, `cp-*` block classes; one per country dir |
+| country-gold-price | 21 | `/countries/{country}/gold-price/` | EN only; AR runtime | `countries/uae/gold-price/index.html` | noindex,follow; self-canonicals to hub (duplicate-by-design) |
+| city-landing | 69 | `/countries/{country}/{city}/` | EN only; AR runtime | `countries/uae/dubai/index.html` | Thin ~96-line city hub funneling to gold-rate/gold-shops |
+| city-gold-rate | 69 | `/countries/{country}/{city}/gold-rate/` | EN only; AR runtime | `countries/uae/dubai/gold-rate/index.html` | SEO workhorse (~300 lines); H1/FAQ English-locked even under `?lang=ar` |
+| city-gold-shops | 69 | `/countries/{country}/{city}/gold-shops/` | EN only; AR runtime | `countries/uae/dubai/gold-shops/index.html` | Per-city dealer directory; **0 real listings** anywhere |
+| country-cities-legacy | 9 | `/countries/{c}/cities/` + `cities/{city}.html` (uae, saudi-arabia, egypt, qatar) | EN only; AR runtime | `countries/uae/cities/dubai.html` (454 lines) | **Older duplicate city template** — canonical/consolidation risk |
+| country-markets | 4 | `/countries/{c}/markets/…` (uae, egypt only) | EN only; AR runtime | `countries/uae/markets/dubai-gold-souk.html` (435 lines) | Rich editorial souk guides; expansion candidate |
+| calculator | 1 | `/calculator.html` | EN only; AR runtime | `calculator.html` (830 lines) | Flagship value/scrap/zakat tool |
+| tracker | 1 | `/tracker.html` | EN only; AR runtime | `tracker.html` (1789 lines) | **Largest single page**; `tracker-pro-v4.css` elevation layer live |
+| historical-chart | 2 | `/chart/` and `/ar/chart/` | EN + dedicated AR | `chart/index.html` | Empty on static hosting (loads only `/api/v1/prices/history`) |
+| methodology | 3 | `/methodology.html`, `/methodology/`, `/ar/methodology/` | EN ×2 + dedicated AR | `methodology.html` (656), `methodology/index.html` (121) | **TWO distinct EN pages at near-identical URLs** — duplicate/canonical risk |
+| pricing-subscribe | 1 | `/pricing.html` | EN only; AR runtime | `pricing.html` (483 lines) | Stripe-backed subscription entry |
+| editorial-root | 5 | `/insights.html`, `/invest.html`, `/learn.html`, `/compare.html`, `/shops.html` | EN only; AR runtime | `learn.html`, `shops.html` | Root editorial/hub singletons |
+| guide-article | 29 | `content/guides/*.html` (8 flat) + `{slug}/` (10 dir EN) + `ar/` (11) | EN (18) + **dedicated AR (11)** | `content/guides/24k-vs-22k-vs-18k-gold/index.html` | **Flat-legacy vs dir-style duplication** of overlapping topics |
+| content-tool | 7 | `content/tools/*.html` (5 EN) + `ar/` (2) | EN (5) + dedicated AR (2) | `content/tools/zakat-calculator.html` | AR parity gap (2 of 5) |
+| content-misc | 14 | `content/{various}/` editorial + utility | EN only; AR runtime | `content/embed/gold-ticker.html`, `content/faq/index.html` | Heterogeneous; splittable editorial vs utility/app |
+| app-utility | 3 | `/account.html`, `/dashboard.html`, `/developer.html` | EN only; AR runtime | `account.html` | Auth/app surfaces (Supabase/JWT) |
+| legal | 2 | `/privacy.html`, `/terms.html` | EN only; AR runtime | `privacy.html` | Standard legal long-form |
+| site-utility | 3 | `/404.html`, `/offline.html`, `/design-lab.html` | EN only | `design-lab.html` | Should be noindex; design-lab is dev playground |
+| admin | 16 | `/admin/` + `/admin/{section}/` | EN only (internal) | `admin/index.html` (979) | Must be auth-gated + noindex; not public |
+| stub-noindex | 30 | stray `index.html` in code/config dirs | EN noindex placeholders | `src/index.html`, `server/index.html` | Identical 63-line "Not a public page" stubs; excluded from sitemap |
+
+**Reconciliation to 390:** 2+8+1+21+21+69+69+69+9+4+1+1+2+3+1+5+29+7+14+3+2+3+16+30 = **390**. Countries subtree check: 69×3 + 21 + 21 + 1 + 9 + 4 = **263**. **`allAccountedFor: true` — CONFIRMED by the adversarial verifier** (390/390 partitioned, 0 unassigned, 0 double-assigned; stub-noindex=30 and admin=16 confirmed excluded from `public/sitemap.xml`).
+
+> **Verifier correction (narrative only, no count change):** the city-landing structure note says the naive regex `countries/{c}/{x}/index.html` "matched 75"; that regex literally matches 96 (it also captures the 21 country-level `gold-price/index.html`). The 75 figure is the depth-2 `index.html` count *excluding* `gold-price/`; subtracting the 6 cities/markets index pages yields the correct **69** true city landings. Final count is right; the intermediate "75" was described imprecisely.
+
+---
+
+## Architecture
+
+### Navigation, internal linking & SEO routing (URLs / canonical / hreflang / sitemap)
+
+The global nav, footer, breadcrumbs, ticker, and spot-bar are **100% client-side-injected** via `mountSharedShell()` / `injectNav` / `injectFooter` (`src/components/site-shell.js:10-19`). Raw delivered HTML contains **zero** `site-nav`/`footer-col` markup (`grep -c` ⇒ 0 on both `index.html` and the deepest country leaf), so the ~30 uniform nav/footer links exist only after JS runs. Mitigations: the homepage ships 22 static `/countries/` body links, and country leaves embed static `BreadcrumbList` JSON-LD (`countries/uae/dubai/gold-rate/index.html:78`).
+
+Canonical coverage is solid: **373/390** files carry `rel=canonical` (the 17 without are 16 admin + offline + 404, all intentional noindex). Country gold-price duplicates correctly self-canonicalise to the country hub with `robots noindex,follow`. `_redirects` is coherent (clean-URL 301s, ISO-2 aliases, city price-consolidation, final `/* → /404.html`).
+
+The serious problems are in the **AR/hreflang + sitemap** layer (VERIFIED throughout):
+
+| Issue | Measurement | Evidence |
+|---|---|---|
+| Committed sitemap stale & ~95% incomplete | 18 `<loc>`, **0 country pages**, vs ~372 indexable | `grep -c '<loc>' public/sitemap.xml` ⇒ 18; `grep -c countries` ⇒ 0 |
+| Build generates a different sitemap, never committed | `build/generateSitemap.js` emits 212 URLs (53 static + 21 hubs + 69 gold-rate + 69 gold-shops) to **ROOT**, not `public/` | scratchpad run ⇒ 212; `package.json:11` build chain; no ROOT/sitemap.xml on disk |
+| Two divergent generators | `build/generateSitemap.js` + `scripts/node/generate-sitemap.js`, both `?lang=ar`, disagree with committed `/ar/` | `:59`, `:125` vs `public/sitemap.xml:11` |
+| AR hreflang is non-indexable `?lang=ar` | 128 file refs point to `?lang=ar` (same doc, runtime-translated) | `src/seo/hreflang.js:9`; `grep -c lang=ar` ⇒ 128 |
+| Homepage ignores its real `/ar/` twin | `index.html:63` declares `hreflang ar=/?lang=ar`; `home.js:1416` runtime-clobbers any correct alternate | `src/seo/hreflang.js:15` removes & re-adds `?lang=ar` |
+| Sitemap lists non-existent AR URLs | `/ar/calculator/`, `/ar/shops/` ⇒ **404** (no backing files) | `find ar` = 7 files only |
+| noindex `/ar/` stub sitemapped at priority 1.0 | `ar/index.html` is a `location.replace('/?lang=ar')` bouncer | `ar/index.html:26,28,35` |
+
+Internal-link density is healthy on hubs (index 55, learn 37, tracker 27, methodology 27) but thin on deep country leaves (~6–7 static anchors), and several guides are near-orphaned (`gold-making-charges-guide` 3 inbound, `zakat-gold-guide` 5). Because nav/footer are JS-injected, those leaves have effectively no crawlable global navigation.
+
+### Internationalization (EN/AR) & RTL
+
+Arabic is delivered **three ways**, and is **NOT a 390-page mirror**:
+
+1. **Runtime client-side translation** — `src/config/translations.js` (2621 lines; EN 1144 keys === AR 1144 keys, **0 gaps**, 1131/1144 AR values carry Arabic script; the 12 EN-identical values are language-neutral codes/templates). Applied via fail-open `tx()` helpers (`TRANSLATIONS[lang]?.[k] ?? TRANSLATIONS.en?.[k] ?? key`) plus ~294 `data-i18n` HTML attributes. Covers ~370 pages.
+2. **Dedicated `/ar/` HTML pages** — 7 (index stub, chart, methodology, gold-price/{18,21,22,24}k). The karat pages are the correct reciprocal-hreflang model.
+3. **Dedicated AR content** — `content/guides/ar/` (11) + `content/tools/ar/` (2) = 13 real translated documents.
+
+**Measured static-bilingual coverage: 20/390 = 5.1%** (one of the 7 `/ar/` files, `ar/index.html`, is a noindex redirect stub, so genuine content ≈ 19). RTL CSS is mature: ~432 logical-property usages (margin/padding/inset/border-inline, text-align start/end) and **263 explicit `[dir=rtl]` override rules** across 26 files; ~135 physical residues remain (mostly non-public `admin.css`). A few public physical residues lack RTL overrides (`invest.css:382` `.invest-goal-card`; `shops.css:2258,2273` nearme status/results).
+
+**Parity verdict (adversarial verifier): the site does NOT meet a strict "EN/AR parity + correct RTL" bar today.** String/meaning parity in the central dict = **MET**; indexable-AR-document parity = **NOT MET**. The verifier found a stronger gap than the i18n agent reported: under `?lang=ar`, the 69 city gold-rate pages keep their **H1, intro, and entire FAQ in static English** — the hydrator only translates `country-page-kicker`/`country-faq-title`-style IDs that the `cgr-`/`city-faq-` template never uses, and only fills the live-price widgets. The Dubai gold-rate page = **40 static Arabic chars vs 13,389 in a real AR guide**. With JS disabled, all 370 runtime-AR pages expose EN-only content. (VERIFIED.)
+
+### Build pipeline, data/price flow & server
+
+**Production is static-first GitHub Pages, vanilla ES6 + Vite — no live backend.** `deploy.yml` builds `dist/` and publishes to Pages; it never starts `server.js`. `src/config/constants.js:25` sets `API_BACKEND_ENABLED: false` (the `/api/v1/*` endpoints "always 404" on Pages). The Express server + Supabase + Stripe run only on self-hosted/Replit.
+
+**Price flow:** a scheduled GitHub Action (`gold-price-fetch.yml`) runs a Python provider chain (`gold_api_com → twelvedata_xauusd → fmp_gcusd`), writes `data/gold_price.json` with full provenance/freshness metadata, and commits it; `deploy.yml` republishes every ~30 min during market hours. The browser fetches that JSON network-first (`src/lib/api.js`) and computes all karat × currency prices client-side via `price-calculator.js`.
+
+**Build chain (8 steps):** `extract-baseline → normalize-shops → render-learn-static-fallback → inject-theme-preinit → inject-schema → generateSitemap → vite build`. Vite bundles ~127 non-leaf HTML entries but **excludes `countries/`, `admin/`, `embed/`**, which are copied verbatim and load raw `src/` ES modules; `flatten-css.js` collapses the `global.css` `@import` waterfall on the dist copy at deploy time.
+
+**Governance gate `npm run validate` (17 checks)** is a required CI merge gate and runs on every deploy. The pure-Node subset was **run and PASSES** today: freshness-metadata, seo-meta (390 files), basic-a11y (341), inject-schema (365), inventory-seo (343/341/338), sw-precache (10), sw-coverage (15), theme-preinit (371), audit-content-pages (47). **Note:** `seo-governance.js --check` reports **STALE** but exits 0 (non-strict — warns, does not gate), so duplicate/thin-content regressions can ship undetected. The PWA service worker (`sw.js v17`) precaches 10 shells and treats `/data/gold_price.json` as **network-only** (honors the freshness invariant). One stale label: `server/services/goldPriceService.js:51` hardcodes `source:'goldpricez'` while the data file provider is `gold_api_com` (non-prod path, but a provenance violation to fix).
+
+**Constraint for the redesign:** stay vanilla ES modules + static MPA; do not introduce a framework; any new top-level/renamed page must be added to `sw.js PRECACHE_URLS` + the sw-coverage allow-list, or the gates break; any shared CSS/JS refactor must still work **unbundled** on the ~263 verbatim-copied leaf pages.
+
+---
+
+## Baselines
+
+### SEO (mostly VERIFIED via pure-Node scripts)
+
+The site has a mature, well-governed SEO baseline. All four audit scripts pass; titles/descriptions are 100% unique across the indexable country set; a deliberate noindex/canonical scheme protects against the city/gold-price proliferation. Notable gaps: essentially no Product/Offer structured data, the runtime `?lang=ar` AR strategy, 152 thin-risk pages, and no `llms.txt`.
+
+| Metric | Value | Verified |
+|---|---|---|
+| `seo-audit.js` pages scanned / with issues | 381 / **0** | VERIFIED |
+| `inventory-seo.js --check` | 343 files, 341 canonical, 338 JSON-LD | VERIFIED |
+| `check-seo-meta.js` | PASS, 390 files | VERIFIED |
+| `seo-governance.js` totals | 376 pages, 239 indexable, **152 thin-risk**, 0 duplicate clusters, 0 missing canonical/hreflang/schema | VERIFIED |
+| noindex pages | 151 (96 city index + 21 country gold-price + 16 admin + utilities) | VERIFIED |
+| Deployed sitemap (build-generated) | **212 URLs** | VERIFIED (scratchpad run) |
+| Committed `public/sitemap.xml` | **18 URLs** (stale placeholder) | VERIFIED |
+| Country title uniqueness | gold-rate 69/69, gold-shops 69/69, hubs 21/21 | VERIFIED |
+| Product / Offer schema | **0 Product**, 1 Offer | VERIFIED |
+| OG / Twitter coverage | og:title 369, twitter:card 369, og:image 264 | VERIFIED |
+| `hreflang ar=?lang=ar` on country pages | 263 | VERIFIED |
+| `llms.txt` | **absent** | VERIFIED |
+
+### Accessibility — WCAG 2.2 AA (static VERIFIED; runtime UNVERIFIED)
+
+The CI a11y gate (`check-basic-a11y.js`) **PASSES** (exit 0): 341 public files, 0 images, 0 iframes, enumerated light/dark contrast pairs all ≥4.5:1, plus img/iframe/input hygiene. Static foundation is strong and has materially advanced past the stale `reports/a11y-audit.md` (the prior 27 missing-h1 and 13 missing-skip-link findings are **resolved**). Residual static risks: a sub-24px tap target and a light-mode freshness-label contrast failure. **All runtime ARIA/keyboard/focus-trap behavior is UNVERIFIED** (no devDeps for pa11y/Playwright/axe/Lighthouse).
+
+| Metric | Value | Verified |
+|---|---|---|
+| `check-basic-a11y.js` | PASS (exit 0) | VERIFIED |
+| `<img>` / `<iframe>` in public HTML | 0 / 0 | VERIFIED |
+| Gate contrast pairs (light/dark) | 13/13 + 10/10 pass | VERIFIED |
+| `lang` attribute coverage | 390/390 | VERIFIED |
+| `dir` missing | 15 (all admin, internal) | VERIFIED |
+| Multiple `<h1>` (public) | 0 | VERIFIED |
+| `countries/**/index.html` with h1 | 256/256 | VERIFIED |
+| Global `:focus-visible`, reduced-motion, 44px touch min | present | VERIFIED (`base.css:777,860`; `utilities.css:771`) |
+| **karat-strip copy button** | **22×22px — fails WCAG 2.5.8 (24px min)** | VERIFIED (`home.css:2601-2606`) |
+| **Freshness "stale/amber" label** | `--color-amber #f59e0b` ⇒ **2.09:1, fails AA** (light mode; not in gate's pair list) | VERIFIED (`home.css:768,789`) |
+| Runtime ARIA tab/keyboard/focus-trap | **UNVERIFIED** | — |
+
+### Performance / asset weight (source bytes VERIFIED; Core Web Vitals UNVERIFIED)
+
+Production posture is reasonable (terser + cssMinify, subsetted woff2 with font-display:swap, inlined critical CSS, flattened `@import` chain, zero `<img>` on top pages). Source weights are heavy unminified; the biggest concrete risks are `tracker.html` (92KB inline), `translations.js` (184KB shipped to every hydrating page), and the **non-blocking Lighthouse config with no Core Web Vitals budgets**.
+
+| Metric | Value | Verified |
+|---|---|---|
+| Source CSS total (43 files) | 960,140 B (~937 KB) | VERIFIED |
+| Source JS total (src+root+assets) | 1,568,234 B (~1.53 MB) | VERIFIED |
+| Total HTML payload (390) | 4,165,271 B (~3.97 MB), avg 10.7 KB | VERIFIED |
+| `tracker.html` | 92,681 B | VERIFIED |
+| `index.html` | 62,505 B | VERIFIED |
+| Largest HTML | `admin/social/index.html` 93,042 B (auth-gated) | VERIFIED |
+| Largest CSS | `tracker-pro.css` 124,415 B; `components.css` 105,281 B | VERIFIED |
+| Largest JS | `translations.js` 183,506 B; `shops.js` 105,319 B | VERIFIED |
+| Fonts (5 woff2, subsetted) | ~170 KB | VERIFIED |
+| **Orphaned screenshots** | 4 PNGs ~4.4 MB, **0 references** | VERIFIED |
+| Lighthouse config | desktop-only, all assertions **`warn`**, **no LCP/CLS/INP budgets**, numberOfRuns 1 | VERIFIED |
+| Core Web Vitals (LCP/CLS/INP) | **UNVERIFIED estimates** (CLS low, LCP/INP moderate on tracker) | UNVERIFIED |
+
+### Content quality (VERIFIED via scratchpad measurement)
+
+Hand-written hubs are excellent (`methodology.html` is a model of provenance honesty; `learn.html` = 1486 words / 15 guides; guides median ~1356 words). The problem is the 263-page country corpus. The two project content scripts **pass but are misleading**: `audit-content-pages.js` scans only `content/` (47 files) and never touches country pages; `enrich-placeholder-pages.js --check` keys off a literal placeholder marker, not thinness.
+
+| Metric | Value | Verified |
+|---|---|---|
+| `audit-content-pages.js` | PASS (47 files, **country pages not scanned**) | VERIFIED |
+| Country gold-shops | 69 pages, median **39 words**, **2 skeletons**, **0 listings** | VERIFIED |
+| Country gold-rate | 69 pages, median 51 words; **47/69 at ~48-word floor**; ~8 capitals enriched | VERIFIED |
+| Country gold-price hubs | 21 pages, 2 skeletons | VERIFIED |
+| `data-i18n` hooks across 263 country pages | **0** (yet all declare `hreflang ar`) | VERIFIED |
+| Placeholder-marker grep | 247 hits, mostly false positives; substantive = 18 honest "coming soon" + 1 affiliate comment | VERIFIED |
+| Lorem-ipsum / fabricated text | **0** | VERIFIED |
+
+### Imagery (VERIFIED — total greenfield gap)
+
+| Metric | Value | Verified |
+|---|---|---|
+| `<img>` across 390 pages | **0** | VERIFIED |
+| srcset / `<picture>` / lazy-loading | **0** | VERIFIED |
+| Content-image alt text | **0** | VERIFIED |
+| Raster files in repo | 11 PNG (1 OG, 5 favicons, 4 orphaned screenshots, 1 zero-byte stray) + 2 SVG | VERIFIED |
+| WebP / AVIF / JPEG / GIF | **0** | VERIFIED |
+| Distinct OG images | **1** shared across all 264 pages declaring it | VERIFIED |
+| OG image | 1200×630, 26 KB PNG; `og:image:alt` localized to AR on `/ar/` karat pages | VERIFIED |
+| `media-governance.js` | 17-line runtime lazy-load shim, effectively a no-op (no images exist) | VERIFIED |
+
+---
+
+## Invariants & trust audit
+
+| Invariant | Status | Evidence |
+|---|---|---|
+| **AED peg = 3.6725** (never from FX API) | **UPHELD — VERIFIED & CONFIRMED by verifier** | Defined once (`constants.js:9`); only near-miss grep hits are latitudes + USD/oz log prices. AED deleted from FX response and re-applied on every path: `api.js:261-263`, `fxService.js:24,55,68,78`, `pricingEngine.js:42`, `price-calculator.js:59,75` |
+| **Troy oz = 31.1035 g** (canonical in math) | **UPHELD in math; AT-RISK in copy — PARTIAL (verifier)** | Canonical `constants.js:10` used by core engines; no 28.35/31.1 in any calc. **But** `31.1034768` is hardcoded in `investment-calculator.js:8` + `scrap-calculator.js:8` (fallback) **and shown in public copy** `methodology-live.js:89,95`, `faq-schema.js:11,22`, `translations.js` — vs `31.1035` in footer/learn-hub. User-visible divisor inconsistency (~7e-7, never affects live results) |
+| **Spot/reference vs retail/jewellery separation** | **UPHELD — VERIFIED & CONFIRMED** | Making charges always "illustrative" with disclaimer, never live quotes (`ShopVsReferencePanel.js:1-4,43-47`); `market-intel.js:1-7` documented "NOT live… reference only"; shops per-karat uses peg (`shops.js:2283-2285`); calculator copy frames outputs as "spot-linked reference estimates, not final retail quotes" |
+| **Freshness / provenance labels mandatory** | **UPHELD for known surfaces; AT-RISK on exhaustiveness — PARTIAL (verifier)** | Truth-first state machine `freshness-policy.js:17-58` (live≤5s/cached≤60s/delayed≤300s/estimated/closed/fallback); gate `check-freshness-metadata.js` PASSES (exit 0). **But** gate is allowlist-based (9 selectors, `:19-29`) and **excludes `admin/` and `server/`** (`:8-17`) — coverage not provably exhaustive. `/chart/` renders empty on static hosting |
+| **No fabricated data + honest fallback states** | **UPHELD — VERIFIED & CONFIRMED** | Spot has no synthetic fallback — fetches pipeline JSON → localStorage → **throws** `NetworkError` (`api.js:192-239`); calculator inits `spotUsdPerOz:0`, every render guarded (`calculator.js:63,471,595,714`); the only hardcoded literal `DEFAULT_SPOT_USD_OZ=2400` is a **labeled editable fallback** (stale vs ~4065 — UX note, not fabrication); history layered + source-tagged (`historical-data.js:5-55`) |
+
+**Verifier overall:** could not refute any trust invariant as violated. The only material nuances — the `31.1035` vs `31.1034768` public-copy split and the non-exhaustive allowlist freshness gate — were already disclosed by the dimension agent and align with the verifier. **EN/AR pricing-token parity (`parity-diff-scan`) remains UNVERIFIED** (Playwright not installed), so AR runtime-translation parity for peg/divisor copy could not be independently checked.
+
+---
+
+## Prior-work reconciliation
+
+Deep, multi-agent prior redesign effort is **largely already materialized on the current redesign branch** (`claude/goldtickerlive-redesign-jlne1s`), not pending. Three overlapping programs:
+
+1. **Design-feel Areas A–H** (from `cursor/design-feel-revamp-4d4a`): tokens/type system, self-hosted fonts, unified price-display primitive, chart theming, city-gold-rate template, motion, perf. **VERIFIED present, committed, and wired** — `styles/partials/{fonts,price-display}.css` and `styles/pages/city-gold-rate.css` are `@import`-ed by `styles/global.css:1,2,12`; `tokens.css` has the Source Sans 3 + Cairo stacks, 1.25 ratio, and `--price-up/--price-down/--text-muted/--surface-raised` aliases; self-hosted woff2 under `assets/fonts/`; migration scripts present. These are **ADDED relative to `origin/main`** — treat as foundation to extend/verify, not re-implement.
+2. **PR #443 `claude/elegant-cori-lyo379`** (security/schema/RLS/Stripe/SEO): GREEN defect fixes (D1 redirects, D2 offline paths, D5 dead X-Frame meta, D6 footer headings) appear applied; D7/D9 filed as plans. **RED-zone items are STAGED-ONLY**: `supabase/migrations/002_admin_rls_lockdown.sql`, `003_public_insert_hardening.sql`, `verify.sql`, billing fail-closed, Leaflet SRI, Lighthouse gate, **Phase 43 `/ar` hreflang unification**, GDPR export — gated on two blocking owner questions (are Supabase signups enabled? what writes `public.orders`?). **Do NOT apply these in a design redesign.**
+3. **Tracker revamp programs** (20/30/50-phase): the 30-phase visual revamp is marked complete; `styles/pages/tracker-pro-v4.css` (491 lines, "Design System v4 elevation layer") is live (`@import`-ed by `tracker-pro.css:5`). Preserve the honesty logic (classifyDelta + flat band, **no default up=green**, AA-legible movement colours on the always-dark hero).
+
+**Preserve / extend:** the warm-parchment token system (`tokens.css`, 541 lines), the price-display primitive, self-hosted fonts, the city-gold-rate template, all 7 trust components (note: `FreshnessStrip.js` is imported in **0 files** — revive or formally retire it), `design-lab.html` as the prototyping surface, and the AGENTS.md six non-negotiables. **Rebuild candidates still open:** Homepage (#13) and Tracker (#14) per `docs/plans/README.md` — slot into existing REVAMP_PLAN.md Track C/D, do not fork.
+
+**Conflicts to watch:** (a) **documentation drift** — CHANGELOG/PLAN claim a "premium neutral" palette, but on-disk tokens (and `origin/main`) are still warm parchment `#fefcf7` — trust the file; (b) ~430 design-relevant files diverge from `origin/main` with an empty merge-base, so future merge is non-trivial; (c) generated surfaces (69 gold-rate + 264 country files) must be changed **through the generator** (`consolidate-country-pages.js`), never hand-edited; (d) §14 non-goals forbid SPA/framework/chart-lib swap.
+
+---
+
+## Risk register
+
+| # | Risk | Severity | Affected area | Mitigation |
+|---|---|---|---|---|
+| 1 | Committed `public/sitemap.xml` advertises only 18 of ~372 indexable URLs (0 country pages); the build-generated 212-URL sitemap is never committed | **Critical** | SEO discovery / crawl budget | Consolidate to one generator that writes `public/sitemap.xml`; gate `check-sitemap-coverage` in CI; commit a complete sitemap covering all country/city pages |
+| 2 | Three-way hreflang contradiction (HTML `?lang=ar` vs sitemap `/ar/` vs runtime override) + 404 AR sitemap URLs (`/ar/calculator/`, `/ar/shops/`) + noindex `/ar/` stub at priority 1.0 | **High** | AR SEO / hreflang clustering | Pick ONE AR strategy; fix homepage hreflang + remove `home.js` runtime clobber; drop 404 AR URLs and the stub from the sitemap |
+| 3 | Indexable-AR-document parity NOT met: 370/390 pages runtime-only; city gold-rate H1/intro/FAQ stay **English even with JS on** | **High** | EN/AR parity invariant | Either build real `/ar/` mirrors for high-value pages or extend the hydrator to translate `cgr-`/`city-faq-` markup; add `data-i18n` to country templates or drop misleading `hreflang ar` |
+| 4 | 263 thin, near-duplicate, indexable country pages (gold-shops 0 listings; 47/69 gold-rate at ~48-word floor); 152 thin-risk flagged | **High** | Content quality / thin-content/doorway SEO | Tier the corpus; enrich major cities; noindex/consolidate empty long-tail; give the 51 silent shop stubs an honest empty-state; extend content audit to scan `countries/` |
+| 5 | Applying PR #443 RED-zone RLS migrations / hreflang changes without owner answers could leave an exploitable RLS hole or break Stripe billing | **High** | Security / billing / data integrity | Keep strictly read/UI-side; do not apply `migrations/002,003`, `verify.sql`, billing fail-closed, or Phase 43 until owner answers the two blocking questions |
+| 6 | Total imagery greenfield: 0 content images, 1 shared OG, no AVIF/WebP pipeline, no zero-CLS dimension governance | Medium | Imagery / social sharing / LCP | Build per-template OG pipeline + AVIF/WebP + bilingual alt + mandatory width/height before introducing any editorial imagery; delete 4.4 MB orphaned screenshots |
+| 7 | Public-facing divisor inconsistency: methodology/FAQ show `31.1034768`, footer/learn-hub show `31.1035` | Medium | Trust / transparency | Reconcile copy to one divisor; replace literal with `CONSTANTS.TROY_OZ_GRAMS`; add anti-drift lint |
+| 8 | Freshness gate is allowlist-based and excludes `admin/`/`server/` — "every price surface labeled" not provably exhaustive | Medium | Freshness invariant | Periodically reconcile `PRICE_MARKERS` against new templates; stop blanket-excluding admin |
+| 9 | `/chart/` renders empty on static hosting (loads only `/api/v1/prices/history`, `API_BACKEND_ENABLED:false`) | Medium | Trust perception | Point chart at static history layers or hide the surface when backend disabled |
+| 10 | `seo-governance.js --check` is non-strict (warns, exits 0) — duplicate/thin regressions can ship undetected during a 390-page redesign | Medium | SEO governance / CI | Regenerate the snapshot and promote to `--strict` |
+| 11 | All runtime a11y (ARIA keyboard, focus trap, computed dynamic contrast, tap-target geometry) + Core Web Vitals are UNVERIFIED (no devDeps) | Medium | A11y / performance | Run pa11y/axe/Lighthouse (mobile) on the served build in a devDeps-enabled phase before any AA/CWV claim |
+| 12 | Sub-24px karat-strip copy button; light-mode amber freshness label at 2.09:1 | Low–Med | WCAG 2.2 AA | Bump hit area to ≥24px; replace amber text token with an AA-passing one and add it to the gate's contrast list |
+| 13 | Documentation drift ("premium neutral" claim) + generated-page fragility + orphaned `FreshnessStrip.js` | Low–Med | Prior-work reconciliation | Trust files over docs; route page changes through generators; revive or retire `FreshnessStrip.js` |
+
+---
+
+## Recommendations & sequencing into Phase 1+
+
+> Phase 0 is discovery only — this section orders the *work*, it does not design the new system.
+
+**Design-system decision:** **EXTEND the existing warm-parchment token system, do NOT start fresh.** A mature `tokens.css` (541 lines, semantic `--price-*` aliases, dual EN/AR font stacks) is already adopted and wired; design-feel Areas A–H are delivered foundation. Add a component-token layer between primitives and `components.css`, and prototype in `design-lab.html` against live tokens.
+
+1. **Phase 1 — Foundation verification & SEO plumbing (highest leverage, lowest risk).** Consolidate to one sitemap generator that writes `public/sitemap.xml` and gate it in CI (fixes Risk 1, the single highest-impact SEO fix). Resolve the hreflang strategy and fix the homepage + remove the `home.js` clobber (Risk 2). Regenerate `reports/seo/governance.json` and promote `--check` toward `--strict`. Verify the A–H artifacts render before changing them.
+2. **Phase 2 — i18n/AR decision & RTL hardening.** Per the owner gate, either build real `/ar/` mirrors for high-value pages or fix the hydrator to translate the `cgr-`/`city-faq-` templates and drop misleading `hreflang ar` where no AR body exists (Risk 3). Convert the few public physical CSS residues to logical properties; extend `i18n-local-dict-parity.test.js` to all 21 page-local dicts.
+3. **Phase 3 — Content depth on the 263 country pages.** Tier the corpus, enrich major cities using `methodology.html`/`aed-peg-explained.html` as the voice/accuracy template, give silent shop stubs honest empty-states, and route all changes through `consolidate-country-pages.js`. Extend the content audit to scan `countries/`. Fact-check any AI-assisted enrichment (no fabricated local detail).
+4. **Phase 4 — A11y & performance fixes.** Bump the karat copy button to ≥24px; fix the amber freshness contrast and add the token to the gate; add font preload to `tracker.html`; investigate splitting `translations.js` so the full key table isn't parsed on every EN page.
+5. **Phase 5 — Imagery system.** Build the per-template OG + AVIF/WebP pipeline with mandatory dimensions and bilingual alt; delete the 4.4 MB orphaned screenshots.
+6. **Phase 6 — Homepage (#13) & Tracker (#14) rebuilds.** Slot into REVAMP_PLAN Track C/D; honor §14 non-goals and the no-banners/no-urgency/labeled-reference-price trust guardrails; preserve `tracker-pro-v4.css` and the classifyDelta honesty logic.
+7. **Phase 7 — Full verification (requires devDeps).** Install devDeps; run `npm test` (146 files), `npm run build`, Lighthouse mobile, pa11y/axe over the top templates, and linkinator on `dist/`. Confirm all UNVERIFIED items below.
+
+**Throughout:** keep `npm run validate` green; bump `sw.js CACHE_NAME` + `PRECACHE_URLS` for any new/renamed page; hold every trust invariant; never apply PR #443 RED-zone migrations.
+
+---
+
+## VERIFIED vs UNVERIFIED ledger
+
+**VERIFIED — actually run / exact file:line read this audit:**
+- `find` ⇒ 390 HTML files; family-sum = 390; countries subtree = 263; full 390/390 mutually-exclusive partition (0 unassigned, 0 double-assigned).
+- Pure-Node gates run & passing: `check-freshness-metadata`, `check-seo-meta` (390), `check-basic-a11y` (341), `audit-content-pages` (47), `inject-schema --check` (365), `inventory-seo --check` (343/341/338), `check-sw-precache`, `check-sw-coverage`, `inject-theme-preinit --check` (371), `seo-audit.js` (381/0).
+- `seo-governance.js` totals (376/239/152/0…); `build/generateSitemap.js` ⇒ 212 URLs (scratchpad); committed sitemap = 18 `<loc>`.
+- `translations.js` parse: 1144 EN === 1144 AR keys; i18n pure-node test suites pass (sitewide-guard 3/3, sitemap-parity 3/3).
+- Asset weights (du / wc): CSS 937 KB, JS 1.53 MB, HTML 3.97 MB; per-file sizes (tracker 92,681 B etc.); fonts ~170 KB; 4.4 MB orphaned screenshots with 0 references.
+- Imagery: 0 `<img>`/srcset/picture/lazy/alt; 11 raster + 2 SVG inventory; 1 shared OG.
+- Invariant code reads: AED peg single value + delete-from-FX paths; troy-oz 31.1035 in core math + the 31.1034768 copy split; spot-vs-retail separation; spot-throws-not-fabricates; `DEFAULT_SPOT_USD_OZ=2400` labeled fallback.
+- Prior-work artifacts on disk + `git diff origin/main..HEAD`; staged RED-zone migrations present; `tracker-pro-v4.css` live; warm-parchment tokens (vs stale "premium neutral" doc).
+
+**UNVERIFIED — reasoned / estimated, must be confirmed in a devDeps-enabled phase:**
+- Core Web Vitals (LCP/CLS/INP) — Lighthouse/Playwright cannot run (no devDeps); production minified+gzipped wire weights unmeasured.
+- Runtime a11y: ARIA tab keyboard pattern, mobile-drawer focus trap/restore, live-region announcements, rendered focus order, actual tap-target geometry at 320/375; full token-on-surface contrast sweep (gate is an allowlist).
+- EN/AR runtime parity (`parity-diff-scan`, `leaked-key-scan`) — need `@playwright/test`; AR peg/divisor copy parity unverified.
+- `i18n-local-dict-parity.test.js` (needs `acorn`); the 146-file `node --test` suite (needs node_modules); eslint/stylelint/vite build.
+- That the build emits `/ar/calculator/` & `/ar/shops/` — reasoned absent (build not run), but no render step found.
+- City-specific FAQ facts (VAT rates, market names, hallmarking bodies) were read but **not fact-checked** against primary sources.
+
+---
+
+## Open questions for the owner (Phase 0 GATE)
+
+1. **AR strategy (blocks Phase 2):** Commit to ONE of — (a) real `/ar/` document URLs for high-value pages (the model the 7 `/ar/` karat pages already follow), or (b) `?lang=ar` runtime translation with honest hreflang (and dropping misleading `hreflang ar` where no AR body exists). Today the site advertises Arabic it does not deliver as indexable documents.
+2. **Scope of the 263 country pages (blocks Phase 3):** Enrich-and-keep (which tiers?), noindex/consolidate the empty long-tail, or a hybrid? And: is real, verified gold-shop data coming, or should all 69 gold-shops pages be noindexed until it exists? (No fabricated local detail.)
+3. **Imagery budget & licensing (blocks Phase 5):** Per-template/per-country OG cards (bounded template set vs hundreds of committed PNGs)? Any editorial photography — and is it original/licensed? Self-host Leaflet/map tiles?
+4. **Design system (blocks Phase 1 framing):** Confirm **extend** the existing warm-parchment tokens (recommended) vs any appetite for a re-theme — and confirm the "premium neutral" CHANGELOG claim is abandoned in favor of the on-disk palette.
+5. **PR #443 RED-zone (blocks any security/billing/hreflang change):** (a) Are Supabase email signups enabled? (b) What writes `public.orders` in static production? Until answered, the RLS lockdown, fail-closed billing, and Phase 43 hreflang unification stay staged.
+6. **Branch/merge sequencing:** With ~430 files diverged from `origin/main` (empty merge-base), which lands first and how is prior work preserved across the merge?
+7. **`/chart/` on static hosting:** Acceptable to point it at static history layers, or hide it when `API_BACKEND_ENABLED:false`? It currently renders empty in production.
+
+---
+
+## Phase 0 gate — owner decisions (2026-06-29)
+
+The owner reviewed this audit and approved it. Resolved decisions (these govern Phases 1+):
+
+| # | Decision | Owner's choice |
+|---|---|---|
+| 1 | **Gate** | **Approved**; commit `redesign/AUDIT.md` as the Phase 0 checkpoint, then hold for a separate "go" before Phase 1. |
+| 2 | **Design system** | **EXTEND the existing warm-parchment token system.** All Phase 1 design directions build on `tokens.css` / price-display primitive / EN+AR font stacks — no fresh re-theme. The "premium neutral" doc claim is abandoned in favor of the on-disk palette. |
+| 3 | **Arabic strategy** | **Hybrid:** build real `/ar/` document mirrors for high-value pages (home, karat, calculator, methodology, flagship cities); keep `?lang=ar` runtime translation elsewhere; **remove misleading `hreflang ar` wherever no Arabic body exists.** |
+| 4 | **263 country/city pages** | **Tiered hybrid:** enrich major cities/capitals with real content; noindex/consolidate the thin long-tail; give gold-shops pages an honest empty-state until real listings exist. **No fabricated local detail.** |
+
+**Still open — deferred to their phase gates (do not act on these yet):**
+- **Imagery budget & licensing** (blocks Phase 5): per-template OG scope, original vs licensed editorial photography, self-host Leaflet/tiles?
+- **PR #443 RED-zone** (blocks any security/billing/hreflang change): (a) Are Supabase email signups enabled? (b) What writes `public.orders` in static production? RLS lockdown, fail-closed billing, and Phase 43 hreflang unification stay staged until answered.
+- **Branch/merge sequencing** (~430 files diverged from `origin/main`, empty merge-base): land order and prior-work preservation.
+- **`/chart/` on static hosting:** point at static history layers vs hide when `API_BACKEND_ENABLED:false`.

--- a/redesign/DESIGN-SYSTEM.md
+++ b/redesign/DESIGN-SYSTEM.md
@@ -1,0 +1,685 @@
+# GoldTickerLive — Design System (Phase 1)
+
+**Date:** 2026-06-29 **Status:** Phase 1 synthesis — exploration complete, one direction chosen. No
+source files modified (this is the only document written).
+
+This design system **EXTENDS the existing warm-parchment token foundation** per the locked Phase 0
+gate decision. It does **not** start fresh, re-theme to "premium neutral", or replace the identity.
+Every move below is a _refinement within_ the warm-parchment system already shipping at
+goldtickerlive.com: the canvas stays warm parchment, the typeface stays the self-hosted grotesque,
+and the existing freshness/state machine, spot-vs-retail primitives, dark theme, OS-fallback, and
+RTL font swap are preserved verbatim. The deltas are surgical: cool the canvas a hair, demote gold
+from ubiquitous ornament to a single value signal, concentrate all boldness on the live-price
+readout, calm the chrome, and fix two documented bugs (the broken type-scale ratio and the retail
+chip that is currently _heavier_ than the reference chip).
+
+The page's single job is unchanged and governs every decision: **answer "what is gold worth right
+now, and can I trust this number?" instantly.** Data is the hero. Gold reads as value and craft, not
+bling.
+
+---
+
+## Current system (baseline)
+
+The new system builds directly on these real, shipping values (verified against
+`styles/partials/tokens.css`).
+
+### Palette (current — light theme; dark in parentheses)
+
+| Token                                     | Hex                   | Role                                                                        |
+| ----------------------------------------- | --------------------- | --------------------------------------------------------------------------- |
+| `--color-bg`                              | `#fefcf7`             | Page canvas — warm parchment (the signature cream base). Dark `#060708`.    |
+| `--color-surface`                         | `#ffffff`             | Primary card surface. Dark `#0c0e14`.                                       |
+| `--color-surface-2`                       | `#faf7ee`             | Secondary surface — tinted parchment (chips, stat rows). Dark `#141720`.    |
+| `--color-surface-3`                       | `#f3eedd`             | Tertiary — deepest warm tint, skeleton/zebra. Dark `#1b1e2c`.               |
+| `--color-border`                          | `#e4d9c0`             | Default border — warm tan. Dark `#242840`.                                  |
+| `--color-border-subtle`                   | `#ece5d2`             | Subtle hairline. Dark `#1a1e30`.                                            |
+| `--border-strong`                         | `#d6ccb4`             | Stronger border (outline buttons, separators).                              |
+| `--color-text`                            | `#15110a`             | Primary ink — warm near-black. Dark `#f2eedd`.                              |
+| `--color-text-muted`                      | `#6a5c48`             | Secondary text — warm taupe. Dark `#a09890`.                                |
+| `--color-text-faint`                      | `#6f6350`             | Tertiary — AA-tuned ≥4.5:1 on tints. Dark `#8f857a`.                        |
+| `--color-gold`                            | `#c4902e`             | Core metallic gold — accents, dots, focus ring, foil rules. Dark `#ddb040`. |
+| `--color-gold-light`                      | `#ddb040`             | Lighter gold — gradient midtone, hover. Dark `#f0ca5c`.                     |
+| `--color-gold-bright`                     | `#f0ca5c`             | Brightest gold — foil highlight, gradient peak. Dark `#fad97a`.             |
+| `--color-gold-dark`                       | `#7e5912`             | Text/accent gold — AA on tinted surfaces (`--text-accent`). Dark `#c4902e`. |
+| `--color-gold-deep`                       | `#6b4a0e`             | Deepest gold — GCC values, active tab text, hover.                          |
+| `--color-gold-bg`                         | `#fdf8e8`             | Gold-wash background. Dark `#100e08`.                                       |
+| `--color-gold-tint`                       | `#f8f2dc`             | Pale gold tint — reference chip bg, hover wash. Dark `#0c0a06`.             |
+| `--color-live`                            | `#1a7a32`             | LIVE green — freshness pulse, market-open. Dark `#5dd98b`.                  |
+| `--color-daily`                           | `#a85800`             | Daily-fixed amber-brown. Dark `#f0a350`.                                    |
+| `--color-fixed`                           | `#1050a0`             | Fixed/official blue. Dark `#6ba3f0`.                                        |
+| `--color-stale`                           | `#a84000`             | Stale/unavailable burnt-orange. Dark `#f0a350`.                             |
+| `--color-move-up`                         | `#176832`             | Price up green (light). Dark `#5dd98b`.                                     |
+| `--color-move-down`                       | `#b81428`             | Price down red (light). Dark `#f87171`.                                     |
+| `--color-move-up-strong` / `-down-strong` | `#5dd98b` / `#f87171` | AA-safe movement for always-dark surfaces (tracker hero/chart).             |
+| `--color-error`                           | `#b81428`             | Error/stale text + danger. Dark `#f87171`.                                  |
+| `--tp-hero-glass`                         | `rgb(12 14 22 / 72%)` | Tracker hero glass — **always-dark** midnight, regardless of theme.         |
+
+### Typography (current)
+
+- **Faces:** Self-hosted woff2 — Source Sans 3 (EN, `--font-latin`) + Cairo (AR, swapped under
+  `[dir=rtl]`). Weight axis 400–700 only; `--weight-light:300`/`--weight-extrabold:800` synthesize
+  (faux). `--font-mono` is system-only.
+- **CRITICAL GAP:** `--font-display === --font-main === --font-numeric === --font-sans` → all
+  resolve to Source Sans 3. There is **no distinct data/display typeface**; terminal numerics and
+  marketing headlines share one voice.
+- **Scale:** Major Third `--type-ratio: 1.25` from 16px. Steps 2xs `.625` / xs `.75` / sm `.875` /
+  base `1` / md `1.0625` / lg `1.25` / xl `1.5625` / 2xl `≈1.953` (all computed) **then 3xl `2.4375`
+  / 4xl `3.0625` / 5xl `3.8125` / 6xl `4.75` are hand-set — BREAKING the ratio** (correct 3xl ≈
+  `2.441`).
+- **Fluid data:** `--text-data-lg` clamp(1.95→2.75rem), `--text-data-xl` clamp(2.5→3.85rem).
+- **Hero override (problematic):** `.hlc-price` clamp(3.4rem, 8.5vw, **5.25rem**) / weight **800** /
+  tabular / tracking −0.025em. Hero H1 clamp(2.8→4.1rem)/800 with an **italic gold subtitle**.
+- **Numeric primitive:** `--font-feature-tabular: 'tnum' 1, 'lnum' 1` applied on price selectors.
+
+### Spacing / radii / elevation / motion (current)
+
+- **Spacing:** 4px base. Non-linear past space-4: `0,1px,2,4,8,12,16` then
+  `5=24, 6=32, 7=48, 8=64, 9=80, 10=96`. **Trap:** the named index stops tracking the multiplier at
+  space-5 (×6, not ×5). `--rhythm-section: space-7 (48)`, `--card-padding: space-4 (16)`.
+- **Radii:** xs4 / sm8 / md12 / lg16 / xl22 / 2xl28 + pill999. Hero uses 2xl (28). No
+  sharp/architectural option.
+- **Elevation:** dual ramp — neutral `--shadow-xs…2xl` (warm-ink rgba) **and a parallel
+  `--shadow-gold/-lg/-xl`**. Hero stacks `shadow-xl + shadow-gold`.
+- **Motion:** `--transition .18s`; full easing library (`--ease-premium` cubic-bezier(.16,1,.3,1)
+  etc.); durations instant80→xslow550. Keyframes `pulse-live-hero`, `badge-glow`, `spark-dot-pulse`,
+  `skeleton-shimmer`, `fade-up`. All gated behind `prefers-reduced-motion`.
+
+### Known issues this redesign must fix
+
+1. **Boldness is sprayed, not spent** — four stacked radial "orb" glows + parallax on the hero
+   section, a gold-foil top rule **and** bottom rule **and** corner radial glow on one card,
+   `backdrop-filter: blur(2px)`, and universal `translateY(-2…-5px)` hover-lift + gold-glow on
+   virtually every card. This is the banned "flashy dashboard" look.
+2. **Gold is ornament, not value** — 5-stop foil/metallic gradients, gold-tint hovers, gold shadows,
+   a `◈` glyph, emoji icons (`⚡ ◈ ⬇`, flags at 1.45rem). Reads consumer-app, not Bloomberg/bank.
+3. **No data typeface** — the highest-leverage upgrade the audit flagged.
+4. **Retail chip is currently HEAVIER than the reference chip** (`price-display.css:26-30, 282-286`:
+   `price-kind--retail` uses a gold _gradient_ fill + 1.5px 50% gold border vs the reference chip's
+   flat tint + 35% border). This is an **active spot-vs-retail invariant violation** — retail must
+   never carry equal-or-greater visual weight.
+5. **Broken type-scale ratio** (`--text-3xl: 2.4375rem` hand-set).
+
+---
+
+## Directions explored
+
+Three refinements of the warm-parchment system were drafted and scored by a three-lens judge panel.
+All three converge on the same correct diagnosis (the AI tell is the _spray of effects_, not the
+palette) and the same playbook (cool the canvas ~1.5%, desaturate gold, kill
+orbs/foil/glow/blur/hover-lift, retire faux-800, one structural rule, freshness adjacent to the
+price). They differ in the _signature device_ and how hard they manufacture the "precision
+instrument" feel.
+
+### Direction A — Precision Instrument
+
+**Concept:** A private-bank reading room rendered in warm parchment. Data is the hero through
+weight, scale and disciplined space — gold demoted to a single value signal — with one bold live
+readout that states the price, its freshness, and its spot-vs-retail standing as plainly as a
+terminal ticker.
+
+**Palette (deltas):**
+
+| Token              | Value                             | Role                                                                                                                               |
+| ------------------ | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `--color-bg`       | `#fefcf7 → #fdfbf5`               | Cool the parchment ~1.5% toward "paper", off "cream marketing".                                                                    |
+| `--color-text`     | `#15110a` (kept)                  | Hierarchy comes from ink, not gold.                                                                                                |
+| `--color-ink-data` | **NEW** `#0f0c06`                 | The single darkest ink, reserved for the live spot price + tracker readout — the literal darkest mark on the page. Dark `#f7f3e6`. |
+| `--color-gold`     | `#c4902e → #b07d1f`               | Desaturated/deepened struck-metal gold. Value signal only — never a body-card fill. Dark `#ddb040` kept.                           |
+| `--color-rule`     | **NEW** = calmed `--color-border` | The single structural seam (spot/retail divider, table baseline).                                                                  |
+
+**Signature hero — THE LIVE READOUT:** Near-flat parchment-white panel, radius **16px** (down from
+28), **no** foil rule, **no** corner glow, **no** backdrop-blur, **no** hover-lift; a single
+`--shadow-md` is the entire chrome budget. Top to bottom: (1) the spot **price** in
+`--color-ink-data` (darkest mark on the page), tabular + slashed-zero, dominating at
+clamp(2.6→3.9rem); currency unit `USD/oz` trailing, muted. (2) **Freshness rendered as the price's
+second line** — a 7px status dot + `LIVE · 14:32:07 GST · XAU/USD`, with explicit state words (LIVE
+/ DELAYED / CACHED / STALE / UNAVAILABLE). The dot is the only animated thing on the page. (3)
+Change row (glyph + tinted square + delta, never colour alone). (4) **One** 1px `--color-rule`
+divider, then the **spot-vs-retail row**: `Retail (est., +making + 5% VAT)` one full type-step
+smaller, muted ink, on plain canvas — subordination by scale + ink weight + label + position below
+the rule, never a gold box.
+
+```
+EN (dir=ltr) — two-column, copy left / readout right
+┌────────────────────────────┬──────────────────────────────────────┐
+│  ● Auto-refresh · labeled   │  GOLD SPOT PRICE        [market: OPEN] │
+│  Gold Prices Today          │   ██████████████                       │ ← darkest ink, 800, tabular
+│  UAE, GCC & Arab World      │   2,417.30  USD/oz                     │
+│  Spot-linked reference …    │   ● LIVE · 14:32:07 GST · XAU/USD       │ ← freshness IS line 2
+│  [ Open Live Tracker ]      │   ▲ +12.40 (+0.52%)  per troy ounce     │
+│  [ Use Gold Calculator ]    │   ┄ Open ┄ High ┄ Low ┄                 │
+│  Browse · Alerts · Shops    │   ──────────────────────────────────   │ ← the ONE rule
+│                             │   Retail (est. +making +5% VAT)  ~2,5—  │ ← subordinate
+│                             │   How retail differs →                  │
+└────────────────────────────┴──────────────────────────────────────┘
+```
+
+**Anti-AI rationale:** Cliché #1 (cream+serif+terracotta): stays parchment by mandate but cools the
+canvas, keeps a grotesque (no serif), and desaturates gold off every fill — no terracotta, warmth is
+substrate not theme. Cliché #2 (near-black+acid): the accent is a sparingly-used struck-metal value
+signal on a _light_ page. Cliché #3 (broadsheet hairlines): the inverse — structure from
+weight/scale/space, exactly one rule line. Reads designed-not-generated because boldness is spent on
+a single element while everything else is near-zero chrome.
+
+**Self-critique:** The differentiation from cliché #1 is subtle and "not screenshot-obvious in a
+thumbnail." Reusing Source Sans 3 + slashed-zero for the data voice is the _cheapest_ terminal tell
+— the audit flagged the missing data typeface as highest-leverage, so this is the most contestable
+call. Stripping nearly all motion risks "looks unfinished" feedback.
+
+### Direction B — Vault / Bullion Craft
+
+**Concept:** The current price rendered as a struck assay readout on a deepened parchment vault —
+one matte-gilt rule of authority, freshness as a dateline, retail demoted to a sub-ledger; gold
+becomes weight, not shine.
+
+**Palette (deltas):**
+
+| Token                 | Value                                                  | Role                                                                                                                            |
+| --------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `--color-bg`          | `#fefcf7 → #fbf7ee`                                    | Deepen parchment toward "aged vault". Dark `#07080b`.                                                                           |
+| `--color-vault-ink`   | `#171109`                                              | Primary ink with a hair more depth — the assay-readout colour. Dark `#f3efe0`.                                                  |
+| `--color-gilt`        | `#9c6f1f`                                              | The single value-accent — one authority rule, reference mark, focus ring, live tick. **Never** a gradient/fill. Dark `#d8b25a`. |
+| `--color-gilt-edge`   | `#c9a55a`                                              | Milled-rim highlight only. Dark `#e4c478`. _(Drafted with a leaked placeholder `#c9a costing`; corrected here.)_                |
+| `--color-retail-wash` | `#f4ecd9`                                              | Flat retail sub-ledger bg (NOT a gradient). Dark `#14110a`.                                                                     |
+| `--rim-inset`         | inset light-top + dark-bottom                          | The struck/milled bevel (replaces gold shadow on the plate).                                                                    |
+| `--font-numeric-data` | subset woff2 (e.g. IBM Plex Mono, digits only ~8–12KB) | The highest-leverage add — a true tabular/mono data face.                                                                       |
+
+**Signature hero — THE ASSAY PLATE:** A single weighty parchment plate, square-shouldered (radius
+**10px**), bordered by a _milled rim_ (1px border + 1px inset light-top + 1px inset shadow-bottom →
+reads pressed/struck, not floating). The price is the only large element — weight **700** (not 800),
+`--color-vault-ink`, engraved not glowing. **Above** it: one **2px flat matte-gilt bar (~40px)** —
+the only metallic element, the "certified" mark (NOT the 5-stop foil). Freshness is a typeset
+**dateline** — gilt tick (live) / amber square (cached) / hollow red square (stale) +
+`XAU/USD · 12:04:31 GST · live`, the existing state machine restyled flat + square (thin state-keyed
+underline, no pill). Retail appears only as a recessed sub-ledger strip at the plate's foot, inset
+into `--color-retail-wash`, ~one-third the price size, flat, prefixed `Est. retail —`.
+
+```
+EN (dir=ltr) — copy left / assay plate right
++----------------------------+   +-------------------------------------+
+| [• auto-refresh · labeled] |   |====  (40px matte-gilt rule)         |
+|  Gold Prices Today         |   |  GOLD SPOT PRICE        market:OPEN |
+|  UAE, GCC & Arab World     |   |   2,387.40   USD / troy ounce       | ← 700, engraved
+|  Spot-linked reference …   |   |  ▲ +12.30 (+0.52%)   24h            |
+|  [ Open Live Tracker ]     |   |  ──────────────                     |
+|  [ Use Gold Calculator ]   |   |  ▪ XAU/USD · 12:04:31 GST · live    | ← dateline
+|  Browse · Alerts · Shops   |   |  Open 2,375  High 2,391  Low 2,369  |
+|                            |   | :Est. retail — making + VAT [how]: | ← recessed sub-ledger
++----------------------------+   +-------------------------------------+
+```
+
+**Anti-AI rationale:** Replaces decoration with a genuine **material metaphor** (a struck assay
+plate) that has internal logic. The milled-rim bevel is the sharpest answer to cliché #3 — it
+doesn't just use fewer hairlines, it makes the edge read physical. Demoting gold to a single flat
+solid gilt bar is the most decisive anti-bling move; retiring 800-weight entirely ("NO 800
+anywhere") is the private-bank-not-app discipline. It is the only direction that _actually_ proposes
+the distinct data typeface the audit flagged.
+
+**Self-critique:** Dropping the price to 700/data-xl shrinks the brand moment. The
+matte-gilt-on-deepened-parchment distinction is fidelity-dependent and may collapse to "beige and
+brown" on cheap screens — and `--color-gilt #9c6f1f` is used as _text_ (chip ink + dateline), where
+it **fails AA** (computes 4.17:1 on parchment, 3.79:1 on retail-wash). Squaring only the hero to
+10px while the rest stays 16–28px may read as a mistake. The new woff2 is the only change touching
+the asset/font path. Did not verify `tracker-pro-v4.css`, so the dark-tracker unification is
+unproven. _(And the draft shipped a literal broken token value — a spec-hygiene defect.)_
+
+### Direction C — Editorial Trust Desk
+
+**Concept:** The gold price rendered as a financial-desk headline: one dominant number, a provenance
+"dateline" (source · timestamp · state), and a one-line plain-language read — authority earned
+through hierarchy and a single hairline rule, not serifs or gold.
+
+**Palette (deltas):**
+
+| Token               | Value               | Role                                                                         |
+| ------------------- | ------------------- | ---------------------------------------------------------------------------- |
+| `--color-bg`        | `#fefcf7 → #fcfaf4` | Calmer "paper of record". Dark `#07080b`.                                    |
+| `--color-dateline`  | `#8a7a5e`           | NEW — provenance/byline ink + small-caps eyebrows. Dark `#b3a888`.           |
+| `--color-rule`      | `#d8cdb2`           | NEW — the single structural hairline (dateline rule).                        |
+| `--color-gold-mark` | `#9c6f16`           | Demoted gold — reference mark/dot + reference chip ink only. Dark `#d9b24a`. |
+| `--color-ink`       | `#13100a`           | Headline number + H1 ink. Dark `#f3efe0`.                                    |
+| `--color-live`      | `#1a7a32 → #176a2c` | Deepened ~1 step for AA as small dateline text.                              |
+
+**Signature hero — THE DATELINE HERO:** Four stacked, inline-start-aligned registers separated by
+**one** full-width hairline: (1) small-caps eyebrow `GOLD SPOT · XAU/USD` + a single gold-mark dot.
+(2) The dominant **number** in **AED** (peg-converted), clamp 3.0–4.6rem/700, with a subordinate
+`USD/oz` line and an inline change pill. (3) The **dateline rule**, on which the provenance renders
+as a _sentence_: `Updated 14:32:07 GST · source: Spot feed · LIVE`, state words explicit. (4) The
+**read** — one plain-language lede. Retail never appears as a number in the hero — only named in the
+read-line and pushed to the below-fold ShopVsReference panel.
+
+```
+EN (dir=ltr) — left-aligned dateline column
+┌──────────────────────────────────────────────┐
+│ • GOLD SPOT · XAU/USD            [market: ●OPEN]│ ← small-caps eyebrow + gold dot
+│   AED 9,012.40                    ▲ +0.84%      │ ← THE NUMBER (700, tabular)
+│   USD 2,453.10 / troy oz                        │ ← subordinate
+│ ───────────────────────────────────────────────│ ← THE DATELINE RULE
+│ Updated 14:32:07 GST · Spot feed · ● LIVE       │ ← provenance as a sentence
+│ About 1g of 24K ≈ AED 245 at spot. Jewellers    │ ← THE READ
+│ add making charges, VAT & margin.               │
+│ Open 8,998 · High 9,031 · Low 8,977             │
+└──────────────────────────────────────────────┘
+```
+
+**Anti-AI rationale:** Provenance as authored sentences (`delayed ~90s`, `fallback estimate`)
+instead of "templated badge soup" is a real anti-generated tell; pulling retail entirely out of the
+hero is the strongest spot-vs-retail _honesty_.
+
+**Self-critique:** The premise is a "confident DISPLAY voice" but it forbids any display face and
+manufactures the editorial signal from **small-caps-via-letter-spacing on Source Sans 3** — the
+single most generic premium-SaaS move, and a fragile a11y pattern. Worse, **Cairo can't render
+caps-spacing**, so the supposed signature signal does not survive the bilingual mandate — half the
+audience never sees it. Freshness as a sentence is harder to scan and truncate (long Arabic
+strings). `--color-dateline #8a7a5e` **fails AA** (4.00:1) and `--color-gold-mark #9c6f16` fails
+(4.28:1) on the most trust-critical text. Switching the hero number to AED shifts emphasis away from
+the XAU/USD spot traders anchor on.
+
+---
+
+## Judge panel & decision
+
+Three lenses, each scored 0–10 per direction.
+
+| Lens                                                                               | Precision Instrument | Vault / Bullion Craft | Editorial Trust Desk |
+| ---------------------------------------------------------------------------------- | :------------------: | :-------------------: | :------------------: |
+| **1. Trust & invariant fit** (freshness unmistakable, spot-vs-retail obvious)      |        **9**         |         **9**         |          6           |
+| **2. Premium restraint & anti-AI-look** (designed-not-generated, dodges 3 clichés) |        **7**         |         **8**         |          6           |
+| **3. Feasibility** (token delta, RTL, WCAG 2.2 AA verified, static-first perf)     |        **9**         |           6           |          4           |
+| **TOTAL**                                                                          |        **25**        |        **23**         |        **16**        |
+
+**Per-lens favourites:** Trust → Precision (by a hair over Vault). Premium → Vault. Feasibility →
+Precision.
+
+### CHOSEN DIRECTION: **Precision Instrument** (with grafts from Vault / Bullion Craft)
+
+**Why.** Precision Instrument wins the aggregate (25 vs 23 vs 16) and, decisively, owns the
+tiebreaker the brief names — the best **trust + premium balance that actually ships**. It scores
+top-of-set on Trust (its freshness-as-the-price's-second-line is the most immediate "is this
+current?" answer of the three) and top-of-set on Feasibility (a true _evolution_ of the tokens — 4
+adds, 6 retunes, ~0 removals — with verified AA on every key pair, RTL that _eliminates_ the
+existing physical-prop hazards, and a net _reduction_ in paint cost). Vault scored one point higher
+on the pure-aesthetics lens, but its signature value-accent (`--color-gilt #9c6f1f`) is used as
+small _text_ where it **fails WCAG AA (4.17:1)**, it gambles the whole "precision" signal on a new
+font file in the asset path, and it leaves the dark tracker hero unverified — all of which the
+feasibility judge penalised hard (6/10). Editorial Trust Desk is disqualified for a top slot: its
+signature device fails AA twice over (`#8a7a5e` = 4.00:1, `#9c6f16` = 4.28:1), the device itself
+**does not survive RTL** (Cairo can't render small-caps), and freshness-as-prose blunts the single
+thing the trust lens prizes most.
+
+Choosing Precision Instrument honours the locked Phase 0 gate most faithfully too: it is the
+smallest, cleanest delta from the shipping token system, so it reads unambiguously as _refinement_,
+not rewrite.
+
+### Runner-up ideas grafted in (from Vault / Bullion Craft)
+
+Vault's premium lead is real, and its strongest _non-failing_ ideas are grafted onto the Precision
+base:
+
+1. **The milled-rim bevel as the structural edge** (`--rim-inset`: inset light-top + shadow-bottom,
+   **block-axis only** so it needs no RTL mirroring). This is strictly better than a flat hairline
+   border _and_ better than the physical-prop foil rule it replaces — it reads "struck/pressed",
+   giving the readout material authority without a single gradient. Adopted as the hero readout's
+   edge treatment, layered with Precision's single `--shadow-md`.
+2. **The "certified mark" idea, de-metallised.** Instead of Vault's gilt bar, the reference
+   price-kind chip's _border_ re-points from the current 5-stop foil to a **flat** desaturated gold
+   at low alpha — one quiet mark that says "this is the reference", zero gradient.
+3. **The data-typeface upgrade documented as a Phase-2 stretch.** Precision ships the perf-safe
+   slashed-zero-on-Source-Sans-3 baseline now (zero new bytes). Vault's distinct
+   `--font-numeric-data` (subset mono, digits + symbols only, `font-display: swap`, `unicode-range`
+   scoped, preloaded) is recorded as the **single highest-leverage future upgrade** with concrete
+   loading constraints — so the audit's core complaint is answered, just deferred behind the
+   static-first budget rather than declined.
+
+What is **rejected** from the runners-up: Vault's `#9c6f1f` gilt-as-text (fails AA) and its broken
+`#c9a costing` token; Editorial's small-caps eyebrow (RTL-fragile, generic), its AED-as-hero-number
+(shifts emphasis off XAU/USD), and its freshness-as-prose (poor scannability/truncation).
+
+---
+
+## Chosen design system (source of truth)
+
+This is the definitive spec. Everything is expressed as CSS custom properties, RTL-aware via logical
+properties, and preserves the existing dark theme + `prefers-color-scheme` fallback + `[dir=rtl]`
+font swap.
+
+### Palette
+
+Light values shown first; **Dark** in the final column. Tokens marked **NEW** are added; **RETUNE**
+changes an existing value; everything else is **KEPT** verbatim.
+
+| Token                                     | Light                 | Dark                  | Role                                                                                                                           | Status              |
+| ----------------------------------------- | --------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------- |
+| `--color-bg`                              | `#fdfbf5`             | `#060708`             | Page canvas — parchment cooled ~1.5% off "cream".                                                                              | RETUNE (`#fefcf7`→) |
+| `--color-surface`                         | `#ffffff`             | `#0c0e14`             | Primary card surface.                                                                                                          | KEPT                |
+| `--color-surface-2`                       | `#faf7ee`             | `#141720`             | Secondary tinted surface.                                                                                                      | KEPT                |
+| `--color-surface-3`                       | `#f3eedd`             | `#1b1e2c`             | Tertiary tint, skeleton/zebra.                                                                                                 | KEPT                |
+| `--color-border`                          | `#d9cfb6`             | `#242840`             | Default border — calmed.                                                                                                       | RETUNE (`#e4d9c0`→) |
+| `--color-border-subtle`                   | `#ece5d2`             | `#1a1e30`             | Subtle hairline.                                                                                                               | KEPT                |
+| `--border-strong`                         | `#d6ccb4`             | —                     | Stronger border.                                                                                                               | KEPT                |
+| `--color-rule`                            | `var(--color-border)` | (inherits)            | **The single structural seam** (readout spot/retail divider, table baseline). One per region, never decorative.                | **NEW (alias)**     |
+| `--color-text`                            | `#15110a`             | `#f2eedd`             | Primary ink.                                                                                                                   | KEPT                |
+| `--color-ink-data`                        | `#0f0c06`             | `#f7f3e6`             | **Darkest mark on the page** — reserved exclusively for the live spot price value + tracker readout. Hierarchy by ink density. | **NEW**             |
+| `--color-text-muted`                      | `#6a5c48`             | `#a09890`             | Secondary text (freshness/retail body).                                                                                        | KEPT                |
+| `--color-text-faint`                      | `#6f6350`             | `#8f857a`             | Tertiary, AA-tuned.                                                                                                            | KEPT                |
+| `--color-gold`                            | `#b07d1f`             | `#ddb040`             | **Struck-metal value signal only** — focus ring, the live-OK accent dot, reference-chip border. Never a body-card fill.        | RETUNE (`#c4902e`→) |
+| `--color-gold-light`                      | `#ddb040`             | `#f0ca5c`             | Gradient midtone (legacy use only).                                                                                            | KEPT                |
+| `--color-gold-bright`                     | `#f0ca5c`             | `#fad97a`             | Gradient peak (legacy use only).                                                                                               | KEPT                |
+| `--color-gold-dark`                       | `#7e5912`             | `#c4902e`             | Text/accent gold (`--text-accent`), AA on tints.                                                                               | KEPT                |
+| `--color-gold-deep`                       | `#6b4a0e`             | —                     | Reference kind-chip label, single hero seal. AA on gold-tint.                                                                  | KEPT                |
+| `--color-gold-tint`                       | `#f8f2dc`             | `#0c0a06`             | Reference chip bg.                                                                                                             | KEPT                |
+| `--color-live`                            | `#1a7a32`             | `#5dd98b`             | LIVE green — freshness pulse, market-open.                                                                                     | KEPT                |
+| `--color-daily`                           | `#a85800`             | `#f0a350`             | Daily-fixed amber-brown.                                                                                                       | KEPT                |
+| `--color-fixed`                           | `#1050a0`             | `#6ba3f0`             | Fixed/official blue.                                                                                                           | KEPT                |
+| `--color-stale`                           | `#a84000`             | `#f0a350`             | Stale/unavailable.                                                                                                             | KEPT                |
+| `--color-move-up` / `-down`               | `#176832` / `#b81428` | `#5dd98b` / `#f87171` | Price movement (light).                                                                                                        | KEPT                |
+| `--color-move-up-strong` / `-down-strong` | `#5dd98b` / `#f87171` | —                     | AA-safe movement on always-dark surfaces.                                                                                      | KEPT                |
+| `--color-error`                           | `#b81428`             | `#f87171`             | Error/stale text + danger.                                                                                                     | KEPT                |
+
+**WCAG contrast notes (recomputed; light theme unless noted).** All "AA" = WCAG 2.2 AA for normal
+text (≥4.5:1) unless flagged as a graphical object (≥3:1).
+
+- `--color-ink-data #0f0c06` on `--color-surface #ffffff` ≈ **18.9:1** (AAA); on
+  `--color-bg #fdfbf5` ≈ **18.7:1**. The price is the most legible mark on the page — by design.
+- `--color-text #15110a` on `#fdfbf5` ≈ 17.0:1 (AAA).
+- `--color-text-muted #6a5c48` on `#fdfbf5` ≈ **6.2:1** (AA) — freshness/retail body text.
+- `--color-text-faint #6f6350` on `--color-surface-3 #f3eedd` ≈ ~5:1 (AA), unchanged.
+- `--color-gold-deep #6b4a0e` on `--color-gold-tint #f8f2dc` ≈ **5.4:1** (AA) — reference kind-chip
+  label.
+- `--color-gold #b07d1f` as a **7px status dot** is a graphical object (needs ≥3:1): on `#fdfbf5` ≈
+  **3.5:1** (passes 3:1). **It is NEVER used as small text** — that is the rule that keeps the
+  desaturated gold safe (and is exactly the rule Vault's gilt-as-text broke).
+- Status palette untouched: `--color-live #1a7a32` ≈ 4.8:1; `--color-error #b81428` ≈ 6.1:1;
+  `-strong` dark-safe variants ≥4.5:1 on dark. Movement is **colour + glyph + tinted shape**, never
+  colour alone.
+- Dark theme: `--color-ink-data #f7f3e6` on `#060708` ≈ ~18:1; `--color-gold #ddb040` on `#060708` ≈
+  ~9:1.
+
+### Typography
+
+**Faces (KEPT — no new file ships in Phase 1):** Source Sans 3 (`--font-latin`) + Cairo
+(`--font-arabic`, swapped under `[dir=rtl]`). Weights 400/500/600/700; **faux-800 retired** from the
+hero (the size carries authority, not synthetic weight).
+
+**The precision-instrument voice, manufactured from what we already pay for:**
+
+- `--font-numeric: var(--font-latin)` with
+  **`font-variant-numeric: tabular-nums lining-nums slashed-zero`** and
+  `--font-feature-tabular: 'tnum' 1, 'lnum' 1, 'zero' 1`. Slashed-zero is the single most "terminal"
+  signal and it rides the already-loaded SS3 woff2 — **zero new bytes**. Cairo numerals stay tabular
+  via the existing RTL swap.
+- _(Phase-2 stretch, documented not shipped:_ `--font-numeric-data` = a subset monospaced face (e.g.
+  IBM Plex Mono / Spline Sans Mono), digits + `. , % $` + ~12 currency/karat glyphs only (~8–12KB),
+  `font-display: swap`, `unicode-range` scoped, `<link rel=preload>`. This is the highest-leverage
+  upgrade if the perf budget allows one more woff2.)\*
+
+**Scale (Major Third, `--type-ratio: 1.25` from 16px base) — fixed:**
+
+| Token                       | Value                                                                        | Note                                                                                                                                                   |
+| --------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--text-2xs` … `--text-2xl` | `.625` / `.75` / `.875` / `1` / `1.0625` (md) / `1.25` / `1.5625` / `≈1.953` | KEPT (computed).                                                                                                                                       |
+| `--text-3xl`                | `calc(var(--type-base) * 1.25 * 1.25 * 1.25 * 1.25 * 1.25)` ≈ **2.441rem**   | **FIX** — restores the ratio (was hand-set `2.4375`). Use chained `calc(... * ratio)`, **not** `pow()` (uneven engine support, can break first paint). |
+| `--text-4xl`…`6xl`          | retained for legacy                                                          | Remove from default hero flow.                                                                                                                         |
+| `--text-data-lg`            | clamp(1.95→2.75rem)                                                          | KEPT.                                                                                                                                                  |
+| `--text-data-xl`            | clamp(2.6rem, 5vw, 3.9rem)                                                   | RETUNE (marginal, from `clamp(2.5, 4.8vw, 3.85)`).                                                                                                     |
+
+**Hierarchy (the whole design):**
+
+- Hero spot **price** → `--text-data-xl` clamp(2.6→3.9rem), weight **700**, `--color-ink-data`,
+  tabular + slashed-zero, `--tracking-tight`. Caps the runaway `.hlc-price` 5.25rem/800 override.
+- Change row → `--text-data-md` / 700.
+- Open/High/Low strip → `--text-data-sm` / 600.
+- Freshness line → `--text-ui-sm` / 600, tabular.
+- Retail row → `--text-base` / 600 — **one full step DOWN** from the change/reference cluster.
+- Marketing H1 → drops **800 → 700**, loses the italic gold subtitle (headlines must not out-shout
+  the number).
+
+**Line heights / tracking (KEPT):** none 1 / tight 1.2 / snug 1.35 / normal 1.5 / relaxed 1.65;
+tighter −.04 / tight −.025 / wide .025 / caps .1em.
+
+### Spacing
+
+KEEP the 4px base and the existing scale. The space-5 = ×6 quirk is left as-is (changing it risks
+regressions) but documented as canonical in the token-audit. The readout uses generous vertical
+rhythm (`space-5`/`space-6` between price → freshness → change → rule → retail) so hierarchy reads
+through whitespace, not borders.
+
+```
+--space-unit: 0.25rem;  /* 4px base — KEPT */
+--rhythm-section: var(--space-7);   /* 48px — KEPT */
+--card-padding:   var(--space-4);   /* 16px — KEPT */
+```
+
+### Radii
+
+```
+--radius-xs:4  --radius-sm:8  --radius-md:12  --radius-lg:16  --radius-xl:22  --radius-2xl:28  --radius-pill:999   /* ramp KEPT */
+--radius-card:   var(--radius-lg);   /* 16 */
+--readout-radius: var(--radius-lg);  /* 16 — the hero readout drops from 2xl(28) to lg(16): sharper = instrument */
+```
+
+The hero readout retunes **down** from `--radius-2xl` (28) to `--radius-card` (16). No new sharp/0px
+token is introduced (Vault's 10px is rejected as inconsistent with the rest of the page).
+
+### Elevation / shadows
+
+The readout collapses the current `--shadow-xl + --shadow-gold + inset ring + hover-to-2xl` stack
+into a **single soft `--shadow-md`**, layered with the grafted **milled-rim bevel** (block-axis
+insets, no mirroring needed):
+
+```
+--readout-chrome: var(--shadow-md);                       /* NEW — the entire hero elevation budget */
+--rim-inset: inset 0 1px 0 rgb(255 255 255 / 70%),        /* NEW — grafted from Vault; struck/pressed edge */
+             inset 0 -1px 0 rgb(21 17 10 / 8%);
+/* Dark: inset 0 1px 0 rgb(255 255 255 / 6%), inset 0 -1px 0 rgb(0 0 0 / 40%) */
+```
+
+- The parallel **`--shadow-gold` ramp is retired from usage** (tokens stay defined for legacy;
+  nothing new applies them).
+- Static content cards: `--shadow-xs` at rest, **no hover-lift**.
+- Value is signalled by ink density + the live dot, never by glow.
+
+### Motion
+
+KEEP the full easing/duration library and **every** `prefers-reduced-motion` guard.
+
+```
+--ease-premium: cubic-bezier(.16, 1, .3, 1);   /* KEPT */
+--transition: .18s ease;                       /* KEPT */
+/* durations instant80 → xslow550 — KEPT */
+```
+
+- **The only animation on the home hero is the freshness LIVE dot** (existing `pulse-live-hero`,
+  ~2s, reduced-motion-gated).
+- Retire from usage: hero-section parallax, the four orb glows, `card-reveal`/`fade-up`/hover-lift
+  staggers on static cards, `badge-glow` on the hero.
+- Keep state-transition crossfades on the freshness chip (legitimately informative when state
+  changes).
+
+### Signature live-price hero (the one bold element)
+
+A near-flat parchment-white readout panel. **Chrome budget, total:** `--readout-radius` (16px) +
+`--rim-inset` (struck edge) + `--readout-chrome` (one `--shadow-md`). **No** foil top rule, **no**
+bottom rule, **no** corner radial glow, **no** `backdrop-filter`, **no** hover translateY. The
+reference price-kind chip border re-points from the 5-stop foil to a **flat** `--color-gold` at low
+alpha (the de-metallised "certified mark" grafted from Vault).
+
+Render order, top → bottom:
+
+1. **Kind chip** `GOLD SPOT PRICE` (gold-tint bg, `--color-gold-deep` label) + **market-status**
+   pill.
+2. **PRICE** — `--color-ink-data` (darkest mark on the page), `--text-data-xl` (2.6→3.9rem), weight
+   700, tabular + slashed-zero. Trailing, muted: `USD/oz`.
+3. **FRESHNESS = the price's second line** (not a footnote): a 7px status dot (`--color-gold` OK /
+   `--color-live` confirmed-live / amber cached / red stale) + explicit state word +
+   `· 14:32:07 GST · XAU/USD`, `--text-ui-sm`/600 tabular. **State words are always present** — LIVE
+   / DELAYED / CACHED / STALE / UNAVAILABLE — never colour alone. The dot is the only animated
+   element.
+4. **Change row** — existing glyph + tinted-square direction indicator + delta + `per troy ounce`.
+5. **The ONE rule** — a single 1px `--color-rule` horizontal divider.
+6. **Spot-vs-retail row** (below the rule) — `Retail (est., +making + 5% VAT)` at `--text-base`/600,
+   `--color-text-muted`, on plain canvas (**no gold box**). Subordinate by scale + ink weight + the
+   explicit `est.` label + position below the rule. Trailing micro-link `How retail differs →`.
+   Quiet provenance caption: `Spot-linked reference · shops add making charges, VAT, margin`.
+
+**ASCII wireframe — EN (`dir=ltr`), two-column home hero (copy left, readout right):**
+
+```
+┌────────────────────────────┬──────────────────────────────────────────┐
+│  ● Auto-refresh · labeled   │  GOLD SPOT PRICE              [market: OPEN]│  kind-chip + status
+│                             │                                            │
+│  Gold Prices Today          │   ███████████████                          │  PRICE — darkest ink,
+│  UAE, GCC & Arab World      │   2,417.30  USD/oz                         │  700, tabular slashed-0
+│                             │                                            │
+│  Spot-linked reference      │   ● LIVE · 14:32:07 GST · XAU/USD            │  freshness = line 2
+│  prices before retail …     │   ▲ +12.40  (+0.52%)   per troy ounce       │  glyph+tint indicator
+│                             │   ┄┄ Open ┄ High ┄ Low ┄┄                    │  O/H/L strip, data-sm
+│  [ Open Live Tracker ]      │   ─────────────────────────────────────    │  the ONE rule
+│  [ Use Gold Calculator ]    │   Retail (est. +making +5% VAT)     ~2,5—    │  subordinate, plain bg
+│                             │   How retail differs →                      │
+│  Browse · Alerts · Shops    │   Spot-linked reference · shops add …        │  quiet provenance
+└────────────────────────────┴──────────────────────────────────────────┘
+```
+
+**RTL mirroring (`dir=rtl`).** The whole two-column grid mirrors at the grid level — the readout
+column moves to the **left**, copy to the **right** — via logical properties only. Inside the
+readout: kind-chip → right edge, market-status → left (flex `order`, no physical positioning); the
+freshness row uses `text-align: start` so `LIVE · timestamp` begins on the reading edge in both
+directions; `USD/oz` → `دولار/أونصة` trailing the number on its start side; the O/H/L strip and the
+single `--color-rule` divider are full-width / direction-agnostic. The change glyph (▲/▼) keeps
+semantic up = gain in both locales (colour + glyph, never rotation). Crucially, **this hero removes
+the foil rule and corner glow entirely — deleting the only non-mirroring physical-prop code paths**
+that exist in the current hero (`home.css:407-419` `top/left/right`). The grafted `--rim-inset` is
+block-axis only, so it needs no mirroring. Localised pseudo-content is preserved: `· Retail est.` →
+`· تقدير تجزئة`, state words → AR equivalents.
+
+---
+
+## Token-change plan for `styles/partials/tokens.css`
+
+A minimal, ordered diff. Apply in this order. Anything touching dark-mode is flagged **[DARK]**.
+
+### 1. ADD — new custom properties (4 + 2 component tokens)
+
+| Token                     | Value                                                                     | Where used                                                                   | Dark override                                                                     |
+| ------------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `--color-ink-data`        | `#0f0c06`                                                                 | `.hlc-price`, `.price-hero__value--xl`, tracker readout value                | **[DARK]** `#f7f3e6`                                                              |
+| `--color-rule`            | `var(--color-border)`                                                     | the single structural seam (readout divider, table baseline)                 | inherits (no separate value needed)                                               |
+| `--readout-chrome`        | `var(--shadow-md)`                                                        | the hero readout's only elevation                                            | inherits (`--shadow-md` already has dark form)                                    |
+| `--rim-inset`             | `inset 0 1px 0 rgb(255 255 255 / 70%), inset 0 -1px 0 rgb(21 17 10 / 8%)` | hero readout struck edge (grafted from Vault)                                | **[DARK]** `inset 0 1px 0 rgb(255 255 255 / 6%), inset 0 -1px 0 rgb(0 0 0 / 40%)` |
+| `--readout-radius`        | `var(--radius-lg)`                                                        | hero readout corner (component alias)                                        | inherits                                                                          |
+| `--font-numeric-features` | `'tnum' 1, 'lnum' 1, 'zero' 1`                                            | extend `--font-feature-tabular` usage on price selectors (adds slashed-zero) | inherits                                                                          |
+
+### 2. RETUNE — change value, keep token name (no consumer churn)
+
+| Token            | Old                             | New                                                                                                                                     | Note                                                                                                                                                                                                                                                           |
+| ---------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--color-bg`     | `#fefcf7`                       | `#fdfbf5`                                                                                                                               | Cool the parchment ~1.5%. **[DARK]** unchanged (`#060708`).                                                                                                                                                                                                    |
+| `--color-border` | `#e4d9c0`                       | `#d9cfb6`                                                                                                                               | Calmer rule colour. **[DARK]** unchanged (`#242840`).                                                                                                                                                                                                          |
+| `--color-gold`   | `#c4902e`                       | `#b07d1f`                                                                                                                               | Desaturate/deepen to struck-metal value signal. **[DARK] KEEP `#ddb040`** (the dark gold is already correct — do **not** retune it; only the light value changes). The AA-tuned `--color-gold-dark`/`-deep`/`--text-accent` are **unaffected** and still pass. |
+| `--text-3xl`     | `2.4375rem` (hand-set)          | `calc(var(--type-base) * var(--type-ratio) * var(--type-ratio) * var(--type-ratio) * var(--type-ratio) * var(--type-ratio))` ≈ 2.441rem | Restores the 1.25 ratio. **Use chained `calc()`, not `pow()`** (engine support).                                                                                                                                                                               |
+| `--text-data-xl` | `clamp(2.5rem, 4.8vw, 3.85rem)` | `clamp(2.6rem, 5vw, 3.9rem)`                                                                                                            | Marginal; the hero price uses this instead of a 5.25rem override.                                                                                                                                                                                              |
+
+### 3. KEEP — do not touch (explicitly preserved)
+
+- Entire **status palette** + AA notes: `--color-live`/`-daily`/`-fixed`/`-stale`/`-move-up`/`-down`
+  and the `-strong` dark-safe variants.
+- The full **freshness state machine** (`data-freshness-key` / `data-freshness-age` + colours +
+  `⚠`/`✕` glyphs + pulse).
+- All AA-tuned **gold text tokens** (`--color-gold-dark`, `--color-gold-deep`, `--text-accent`),
+  `--color-gold-tint`.
+- **Radius ramp**, **spacing scale**, **motion/easing/duration** library.
+- **`[data-theme=dark]` block**, **`prefers-color-scheme` fallback**, **`[dir=rtl]` font swap**
+  (`--font-main`/`-display`/`-numeric` → Cairo).
+- **`--font-feature-tabular`** primitive (extended in §1, not replaced).
+
+### 4. RETIRE FROM USAGE — leave defined, stop applying (mark DEAD in token-audit)
+
+These stay in the token file for legacy/lint safety, but **must be explicitly documented as dead**
+so they are not silently re-applied. Verified live today at `home.css:394` (blur) and
+`home.css:403-422` (`::before`/`::after` physical-prop foil + corner glow).
+
+- `--rule-foil` (5-stop) and `--foil-underline` — on `.hero-live-card::before`.
+- `--gradient-gold` (5-stop) — as a fill on the reference/retail chips and content cards.
+- `--shadow-gold` / `-lg` / `-xl` — the parallel gold-glow ramp (no new applications).
+- `backdrop-filter: blur(2px)` on the hero card; the four `.hero::before` orb radials + parallax;
+  the `::after` corner radial glow.
+- `--color-champagne` / `-soft` — retire (already flagged in token-audit; do not expand).
+- The italic gold `.hero-title-sub`; the `◈` tool-card glyph; the `⚡` freshness-banner emoji; flag
+  emoji at 1.45rem.
+
+### 5. New semantic component tokens to introduce
+
+- `--readout-chrome`, `--rim-inset`, `--readout-radius`, `--font-numeric-features` (all in §1).
+- `--color-rule` as the canonical name for the single structural seam.
+
+**Net delta:** ~6 added, 6 retuned, 0 hard-removed from the token file. A true evolution within the
+warm-parchment identity, not a rewrite.
+
+---
+
+## Invariant & a11y guardrails
+
+How this system upholds the hard invariants and the brief's a11y/perf demands.
+
+### Spot-vs-retail subordination (STRICT)
+
+- The reference (spot) price is `--color-ink-data` — the **literal darkest, largest mark** on the
+  page. Retail sits **below the single `--color-rule` divider**, one full type-step smaller, in
+  `--color-text-muted`, on **plain canvas with no gold box**.
+- **Fixes the current invariant violation:** today `price-kind--retail` carries a gold _gradient_
+  fill + 1.5px 50% gold border, making retail _heavier_ than the reference chip. The new system
+  removes that gradient (it joins the retired-from-usage list) so retail can never out-weigh the
+  reference. Reference and retail are distinguished by mass, label, and position — never by giving
+  retail the stronger visual.
+- Retail always carries the explicit `est.` label + `+making + VAT` qualifier; the hero provenance
+  caption names making charges, VAT, and margin. Making-charge figures remain computed estimates,
+  never live shop data.
+
+### Freshness always visible (PRODUCT, not decoration)
+
+- Freshness is the **price's second line**, impossible to miss in the same downward glance that
+  reads the price.
+- The verified `data-freshness-key` / `data-freshness-age` state machine is preserved verbatim, only
+  restyled. **Every state shows an explicit word** (LIVE / DELAYED / CACHED / STALE / UNAVAILABLE /
+  estimated / derived / fallback) plus its glyph (`●`/`⚠`/`✕`) — **never colour alone**. The status
+  dot is `aria-hidden` decoration; the word carries meaning.
+- The freshness chip text is legible (`--text-ui-sm`/600 tabular) — never the "10px grey timestamp"
+  failure.
+
+### WCAG 2.2 AA contrast (recomputed, not self-reported)
+
+- Every key text pair passes AA: `--color-ink-data` 18.7–18.9:1, `--color-text` 17:1,
+  `--color-text-muted` 6.2:1, `--color-text-faint` ~5:1, `--color-gold-deep` on tint 5.4:1,
+  `--color-live` 4.8:1, `--color-error` 6.1:1.
+- The desaturated `--color-gold #b07d1f` is **only ever a graphical object** (7px dot, focus ring,
+  chip border) at ≥3:1 (3.5:1 on parchment) — **never small text**. This is the explicit rule that
+  avoids the AA failures that sank Vault's gilt-as-text (4.17:1) and Editorial's dateline (4.00:1) /
+  gold-mark (4.28:1).
+- Movement is colour + glyph + tinted shape; dark surfaces use the `-strong` AA-safe variants.
+
+### RTL correctness (logical-property-first)
+
+- The hero mirrors at the grid level; inside the readout, everything uses `inset-inline`,
+  `margin-inline`, `padding-inline`, `text-align: start/end`, `border-inline` — no hardcoded
+  left/right.
+- This direction **eliminates** the only physical-prop hazards in the current hero (the foil rule's
+  `top/left/right` and the corner glow's `right:-60px`) by removing those effects entirely. The
+  grafted `--rim-inset` is block-axis only → no mirroring.
+- The `[dir=rtl]` Cairo font swap and tabular numeral features carry over; localised pseudo-content
+  (`· تقدير تجزئة`, AR state words) is preserved.
+
+### Static-first performance (faster than current)
+
+- **Net reduction in paint cost.** Removing `backdrop-filter: blur(2px)`, four stacked
+  radial-gradient orbs, the scroll-linked parallax transform, and multi-layer gold shadows cuts
+  compositor work and improves LCP/INP — the LCP element becomes a plain text node + one
+  `--shadow-md` + a cheap inset bevel, not a blurred glow-stacked card.
+- **Zero new font bytes in Phase 1** — slashed-zero is a feature flag on the already-loaded SS3
+  woff2. `font-display: swap`, subset `unicode-range`, and the `min-block-size: 1em` CLS guard on
+  `.hlc-price` are unchanged.
+- The Phase-2 `--font-numeric-data` upgrade, if adopted, is constrained to a digit/symbol subset
+  (~8–12KB), `font-display: swap`, `unicode-range` scoped, preloaded — so it stays within the
+  static-first budget.
+- No framework; vanilla ES6 + Vite preserved. All animation behind `prefers-reduced-motion`.

--- a/redesign/PHASE2-PLAN.md
+++ b/redesign/PHASE2-PLAN.md
@@ -1,0 +1,1005 @@
+# Phase 2 — Component Library Implementation Plan
+
+**Date:** 2026-06-29 **Status:** Phase 2 planning — READ-ONLY plan. This document is the only file
+written; no source files are modified, no git, no `npm install`. It applies the chosen **Precision
+Instrument** design system (`redesign/DESIGN-SYSTEM.md`) to the core components — the signature
+live-price readout, the spot-vs-retail price primitive, and the shared shell — and fixes the two
+documented audit defects (`redesign/AUDIT.md`).
+
+All Phase-1 tokens are already present and unconsumed in `styles/partials/tokens.css`
+(`--color-ink-data`, `--color-rule`, `--readout-radius`, `--readout-chrome`, `--rim-inset`,
+`--font-numeric-features`; retuned `--color-gold #b07d1f`, `--color-bg #fdfbf5`,
+`--color-border #d9cfb6`). Phase 2 is greenfield **application** of those tokens. No raw hex is
+introduced anywhere.
+
+**Verification convention.** Every edit is tagged **VERIFIED** (the exact lines were read in this
+planning pass) or **UNVERIFIED** (reasoned, must be confirmed at implementation). Almost every CSS
+line below is VERIFIED; the load-bearing UNVERIFIED items are the JS retail-render wiring, the
+runtime contrast re-measurement, and the per-site replacement values in the large decorative batch.
+
+**Hard invariants this plan must never violate** (re-confirmed in the checklist, §7): AED peg
+3.6725; troy oz 31.1035; STRICT spot-vs-retail subordination (retail smaller / muted / `est.` /
+below the rule, never equal-or-greater weight); freshness always visible with an explicit state
+**WORD** (LIVE/DELAYED/CACHED/STALE/UNAVAILABLE), never colour alone; no fabricated data; EN/AR
+parity + RTL via logical properties only; static-first vanilla ES6 + Vite.
+
+**Generated-page constraint.** `styles/partials/price-display.css` is **shared, unbundled** CSS
+loaded by the 263 verbatim-copied country/city pages (via `global.css`) and by `/chart/`. Its
+`.cp-mi-stat--retail`, `.cp-hero .cp-price-value`, and `.price-kind--reference` rules render on
+those pages. `styles/country-page.css` is likewise loaded unbundled on every country page. **None of
+these classes are baked into HTML by the generator** — the retail card is JS-injected at runtime by
+`countries/country-page.js`, so no generated HTML is hand-edited and `consolidate-country-pages.js`
+needs no change. `styles/pages/home.css` is loaded **only** by `index.html` (the 263 country pages
+do not import it), so all home-hero/decorative edits are scoped to the homepage. `index.html` is
+already `/` in `sw.js PRECACHE_URLS`; no top-level page is added or renamed, so PRECACHE_URLS and
+the sw-coverage allow-list need no new entries — but bump `sw.js CACHE_NAME` on deploy so the edited
+shell re-caches.
+
+---
+
+## Priority 0 — Spot-vs-retail invariant fix
+
+**One line:** Remove the gold gradient + thick gold border from every retail surface so retail can
+never carry equal-or-greater visual weight than the reference (spot) mark — fixing the active
+invariant violation at `price-display.css:26-30` and `:282-286` and the live country-page retail
+card cascade in `country-page.css:741-744,1087-1090`.
+
+**Why this makes retail subordinate.** After these edits, subordination is enforced by four
+independent structural signals, none of which is colour-alone:
+
+1. **Ink weight** — retail text drops to `--color-text-muted` (#6a5c48, 6.2:1 AA) while the
+   reference/spot value uses `--color-ink-data` (#0f0c06, the darkest mark on the page).
+2. **Fill** — retail loses its gold gradient entirely and sits on a flat neutral surface; the
+   reference chip keeps the single quiet gold-tint mark.
+3. **Border mass** — retail border drops `1.5px → 1px` and from gold to neutral; the reference chip
+   keeps its (now flat, low-alpha) gold edge, which is strictly heavier than retail's hairline.
+4. **Label + position** — the explicit `est.` / `· Retail est.` label is untouched; on the readout
+   retail also sits below the single `--color-rule` divider (§Priority 1).
+
+The reference (spot) chip is the only surface that retains any gold, and only as a flat low-alpha
+edge — the de-metallised "certified mark" grafted from Vault.
+
+### Edits (apply in this order)
+
+**P0-1 — `styles/partials/price-display.css:20-24` — reference chip → flat de-metallised gold edge.
+VERIFIED.**
+
+```css
+/* before */
+.price-kind--reference {
+  color: var(--text-accent);
+  background: var(--color-gold-tint);
+  border: 1px solid color-mix(in srgb, var(--color-gold) 35%, transparent);
+}
+/* after */
+.price-kind--reference {
+  color: var(--color-gold-deep);
+  background: var(--color-gold-tint);
+  /* De-metallised "certified mark": one flat low-alpha gold edge, no foil/gradient */
+  border: 1px solid color-mix(in srgb, var(--color-gold) 30%, transparent);
+}
+```
+
+Rationale: DESIGN-SYSTEM §Signature hero + §Spot-vs-retail. `--color-gold-deep` (#6b4a0e, 5.4:1 on
+gold-tint) is the spec's named "reference kind-chip label" role (tokens table line 370). Consumers:
+`index.html:216` (home hero title) and `src/pages/chart/chart-page.js:211` (chart hero) — the
+load-bearing visible change. **Open question for the writer is resolved below (§8): the colour swap
+`--text-accent → --color-gold-deep` is OPTIONAL spec-alignment; leaving `--text-accent` also passes
+AA and the invariant fix does not depend on it. This plan mandates `--color-gold-deep` for spec
+fidelity but flags it as the one cosmetic, non-invariant choice.**
+
+**P0-2 — `styles/partials/price-display.css:26-30` — retail chip → flat muted, subordinate.
+VERIFIED.**
+
+```css
+/* before */
+.price-kind--retail {
+  color: var(--color-gold-deep);
+  background: linear-gradient(135deg, var(--color-gold-bg) 0%, var(--surface-secondary) 100%);
+  border: 1.5px solid color-mix(in srgb, var(--color-gold) 50%, transparent);
+}
+/* after */
+.price-kind--retail {
+  /* Subordinate to reference: flat muted, no gold gradient, no thick gold border */
+  color: var(--color-text-muted);
+  background: var(--surface-secondary);
+  border: 1px solid var(--border-subtle);
+}
+```
+
+Rationale: directly removes the gold gradient (joins RETIRE-FROM-USAGE) + the 1.5px 50%-gold border.
+**Latent rule — VERIFIED zero markup consumers** (grep: `.price-kind--retail` appears only in this
+CSS definition and DESIGN-SYSTEM.md prose), so this cannot break a rendered page; it forward-proofs
+the primitive against any future retail-chip usage. **Reconciliation note:** the Priority-1 (hero)
+area map proposed `background: transparent; border: 1px solid var(--color-rule)` for the same rule.
+This plan uses the Priority-0 owner's version (`--surface-secondary` + `--border-subtle`) because it
+matches the shipping `.cp-mi-stat--retail` treatment (P0-3) for cross-surface consistency;
+`--color-rule` is an alias of `--color-border` (≈ `--border-subtle`), so the two proposals are
+visually near-identical hairlines and there is no invariant difference.
+
+**P0-3 — `styles/partials/price-display.css:282-286` — shipping retail card (`.cp-mi-stat--retail`)
+de-metallise. VERIFIED.**
+
+```css
+/* before */
+.cp-mi-stat--retail {
+  border: 1.5px solid color-mix(in srgb, var(--color-gold) 55%, transparent);
+  background: linear-gradient(160deg, var(--color-gold-bg) 0%, var(--surface-secondary) 100%);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-gold) 12%, transparent);
+}
+/* after */
+.cp-mi-stat--retail {
+  /* Retail estimate: subordinate to the reference cards — flat, muted, no gold, no ring */
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-secondary);
+  box-shadow: none;
+}
+```
+
+Rationale: this is the retail surface that **actually renders** on ~263 country pages
+(`countries/country-page.js:493`). Removing the gold gradient (RETIRE), dropping the border to 1px
+off-gold, and killing the gold inset ring makes it lighter-or-equal to the neutral `.cp-mi-stat`
+sibling (`country-page.css:1073-1080`, 1.5px `--border-subtle`). The `· Retail est.` /
+`· تقدير تجزئة` label pseudo (`:288-298`) is untouched — the `est.` meaning survives.
+
+**P0-4 — `styles/country-page.css:741-744` — flatten the earlier retail block. VERIFIED.**
+
+```css
+/* before */
+.cp-mi-stat--retail {
+  border-color: var(--color-gold);
+  background: var(--color-gold-tint);
+}
+/* after */
+.cp-mi-stat--retail {
+  border-color: var(--border-subtle);
+  background: var(--surface-secondary);
+}
+```
+
+Rationale: defense-in-depth — removes gold from the first definition so no cascade ordering can
+resurrect a gold retail card.
+
+**P0-5 — `styles/country-page.css:1087-1090` — flatten the WINNING retail block + clear the raw-hex
+gold. VERIFIED.**
+
+```css
+/* before */
+.cp-mi-stat--retail {
+  border-color: rgb(196 144 46 / 35%);
+  background: linear-gradient(135deg, var(--color-gold-tint) 0%, var(--gradient-card) 100%);
+}
+/* after */
+.cp-mi-stat--retail {
+  border-color: var(--border-subtle);
+  background: var(--surface-secondary);
+}
+```
+
+Rationale: this is the rule that actually wins on country pages (later top-level rule, equal
+specificity to `:741`). It carries the **raw-hex old-gold `rgb(196 144 46)` (#c4902e)** — a Phase-1
+token violation — plus the gold gradient. Replacing with `--border-subtle` + `--surface-secondary`
+matches P0-3, clears the raw hex, and makes retail provably subordinate to the neutral `.cp-mi-stat`
+sibling on every country page in light and dark (both tokens have dark overrides in tokens.css).
+
+**Dark mode:** none of P0-1…P0-5 sit inside `[data-theme=dark]`; all use tokens that already have
+dark overrides, so dark theme inherits the flat treatment automatically.
+
+---
+
+## Priority 1 — Signature live-price readout
+
+Rebuild `.hero-live-card` as the Precision-Instrument readout per DESIGN-SYSTEM §Signature hero:
+flat parchment panel, one `--shadow-md` + struck rim, no foil/orb/glow/blur/hover-lift; the price is
+the darkest, largest mark; freshness carries an explicit state **WORD**; one rule divider; a
+subordinate retail row below it. Files touched in apply order: `price-display.css` (price primitive)
+→ `home.css` (hero chrome + price + title + new rule/retail) → `home.js` (freshness word + retail
+render) → `index.html` (retail row markup).
+
+### P1-1 — `styles/partials/price-display.css:59-70` — re-point the shared price primitive to the data voice. VERIFIED.
+
+```css
+/* before */
+.price-hero__value,
+.hlc-price,
+.cp-hero .cp-price-value,
+.order-price-badge {
+  font-family: var(--font-numeric);
+  font-variant-numeric: tabular-nums lining-nums;
+  font-feature-settings: var(--font-feature-tabular);
+  font-weight: var(--weight-extrabold);
+  color: var(--text-primary);
+  line-height: var(--leading-none);
+  letter-spacing: var(--tracking-tight);
+}
+/* after */
+.price-hero__value,
+.hlc-price,
+.cp-hero .cp-price-value,
+.order-price-badge {
+  font-family: var(--font-numeric);
+  font-variant-numeric: tabular-nums lining-nums slashed-zero;
+  font-feature-settings: var(--font-numeric-features);
+  font-weight: var(--weight-bold);
+  color: var(--color-ink-data);
+  line-height: var(--leading-none);
+  letter-spacing: var(--tracking-tight);
+}
+```
+
+Rationale: DESIGN-SYSTEM §Typography retires faux-800 ("size carries authority, not synthetic
+weight") and adds slashed-zero (zero new bytes). This is the PRIMITIVE, so the ink-data/700 voice
+propagates to the chart-page reference value and the country `cp-hero .cp-price-value` too —
+intended and consistent with the system. Shared/unbundled CSS, VERIFIED these selectors style only
+price values.
+
+### P1-2 — `styles/pages/home.css:519-528` — cap the runaway `.hlc-price` override. VERIFIED.
+
+```css
+/* before */
+.hlc-price {
+  font-family: var(--font-numeric);
+  font-size: clamp(3.4rem, 8.5vw, 5.25rem);
+  font-weight: var(--weight-extrabold);
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  letter-spacing: var(--tracking-tight);
+  min-block-size: 1em;
+}
+/* after */
+.hlc-price {
+  font-family: var(--font-numeric);
+  font-size: var(--text-data-xl);
+  font-weight: var(--weight-bold);
+  color: var(--color-ink-data);
+  font-variant-numeric: tabular-nums lining-nums slashed-zero;
+  font-feature-settings: var(--font-numeric-features);
+  line-height: 1;
+  letter-spacing: var(--tracking-tight);
+  min-block-size: 1em;
+}
+```
+
+### P1-3 — `styles/pages/home.css:3375-3380` — align the duplicate `.hlc-price` so the voice is deterministic. VERIFIED.
+
+```css
+/* before */
+.hlc-price {
+  font-family: var(--font-numeric);
+  font-size: var(--text-data-xl);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+/* after */
+.hlc-price {
+  font-family: var(--font-numeric);
+  font-size: var(--text-data-xl);
+  font-weight: var(--weight-bold);
+  color: var(--color-ink-data);
+  font-variant-numeric: tabular-nums lining-nums slashed-zero;
+  font-feature-settings: var(--font-numeric-features);
+  letter-spacing: var(--tracking-tight);
+}
+```
+
+**Cascade note (P1-1/2/3 must all land):** `.hlc-price` is defined in **three** places, all
+specificity (0,1,0) — `price-display.css:59-70`, `home.css:519-528`, `home.css:3375-3380`. The
+winner depends on `@import`/source order, which `flatten-css.js` collapses at deploy. Setting
+ink-data/700/slashed-zero in all three makes the result deterministic regardless of order. Do NOT
+update only one.
+
+### P1-4 — `styles/pages/home.css:383-395` — collapse readout chrome to the design-system budget. VERIFIED.
+
+```css
+/* before */
+.hero-live-card {
+  background: var(--surface-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2xl, 28px);
+  padding: var(--space-6) var(--space-6);
+  box-shadow: var(--shadow-xl), var(--shadow-gold);
+  position: relative;
+  overflow: hidden;
+  transition:
+    box-shadow var(--transition-premium),
+    transform var(--transition-premium);
+  backdrop-filter: blur(2px);
+}
+/* after */
+.hero-live-card {
+  background: var(--surface-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--readout-radius);
+  padding: var(--space-6) var(--space-6);
+  box-shadow: var(--rim-inset), var(--readout-chrome);
+  position: relative;
+  overflow: hidden;
+}
+```
+
+Rationale: DESIGN-SYSTEM §Signature hero chrome budget = `--readout-radius` (16px) + `--rim-inset`
+(struck edge) + `--readout-chrome` (one `--shadow-md`). Removes backdrop-blur, the shadow-gold
+stack, and the box-shadow/transform transition. `--rim-inset` is block-axis only → no RTL impact;
+net paint reduction (removes a blur compositor layer).
+
+### P1-5 — `styles/pages/home.css:397-400` — delete the hover-lift. VERIFIED.
+
+```css
+/* before */
+.hero-live-card:hover {
+  box-shadow: var(--shadow-2xl), var(--shadow-gold-xl);
+  transform: translateY(-2px);
+}
+/* after */
+/* hover-lift retired (DESIGN-SYSTEM §Motion/Elevation: no hover translateY on the readout) */
+```
+
+### P1-6 — `styles/pages/home.css:402-424` — delete the foil top rule + corner radial glow. VERIFIED.
+
+```css
+/* before (402-412 + 414-424) */
+.hero-live-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--rule-foil);
+  opacity: 1;
+}
+.hero-live-card::after {
+  content: '';
+  position: absolute;
+  top: -60px;
+  right: -60px;
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle, rgb(221 176 64 / 10%) 0%, transparent 65%);
+  pointer-events: none;
+}
+/* after */
+/* foil top rule + corner radial glow retired
+   (DESIGN-SYSTEM §RTL: deletes the only physical-prop top/left/right paths in the hero) */
+```
+
+Rationale: removes the **only non-mirroring physical-prop code paths** in the hero
+(`top/left/right`) — a POSITIVE for the RTL invariant — plus retires `--rule-foil` and the corner
+glow.
+
+### P1-7 — `styles/pages/home.css:426-460` — rework dark + LIVE variants: drop all gold glow. VERIFIED.
+
+```css
+/* before (the dark .hero-live-card, dark ::after, dark :hover, spot-terminal--live x2 blocks) */
+[data-theme='dark'] .hero-live-card {
+  box-shadow:
+    var(--shadow-xl),
+    var(--shadow-gold),
+    inset 0 0 0 1px rgb(221 176 64 / 10%);
+}
+[data-theme='dark'] .hero-live-card::after {
+  background: radial-gradient(circle, rgb(221 176 64 / 18%) 0%, transparent 65%);
+}
+[data-theme='dark'] .hero-live-card:hover {
+  box-shadow:
+    var(--shadow-2xl),
+    var(--shadow-gold-xl),
+    inset 0 0 0 1px rgb(221 176 64 / 14%);
+}
+.hero-live-card.spot-terminal--live {
+  box-shadow:
+    var(--shadow-xl),
+    var(--shadow-gold),
+    0 0 0 1px rgb(221 176 64 / 20%);
+}
+[data-theme='dark'] .hero-live-card.spot-terminal--live {
+  box-shadow:
+    var(--shadow-xl),
+    var(--shadow-gold-xl),
+    0 0 28px rgb(221 176 64 / 14%),
+    inset 0 0 0 1px rgb(221 176 64 / 18%);
+}
+/* after */
+[data-theme='dark'] .hero-live-card {
+  background: var(--color-surface);
+  border-color: var(--color-border);
+  box-shadow: var(--rim-inset), var(--readout-chrome);
+}
+/* LIVE state signalled by the freshness dot + state word only — no card glow
+   (DESIGN-SYSTEM §Elevation: value signalled by ink density + the live dot, never by glow) */
+```
+
+Rationale: tokens.css:476-477 already provides the dark `--rim-inset`. POSITIVE for the freshness
+invariant — LIVE is no longer signalled by glow/colour; the dot + WORD (P1-11/12) carry it.
+
+### P1-8 — `index.html:166-169` + `styles/pages/home.css:206-234` — demote the marketing H1. VERIFIED.
+
+Markup is **unchanged** (keeps `#hero-title-sub`, on which `home.js:981` and translations key
+`home.heroSub` depend). The italic-gold treatment is removed in CSS:
+
+```css
+/* home.css:210 before → after */
+.hero-title-main { ... font-weight: var(--weight-extrabold); ... }   /* → var(--weight-bold) */
+/* home.css:224-234 before → after */
+.hero-title-sub {
+  ...
+  color: var(--text-accent);   /* → var(--color-text-muted) */
+  ...
+  font-style: italic;          /* → normal (remove the declaration) */
+  opacity: 0.9;                /* → 1 (or remove) */
+}
+```
+
+Rationale: DESIGN-SYSTEM §Typography — H1 drops 800→700 and loses the italic gold subtitle so the
+headline does not out-shout the number. **a11y flag:** `.hero-title-main mark` (home.css:218-222)
+uses raw `--color-gold` as text, which FAILS AA — out of this priority's scope, routed to §8.
+
+### P1-9 — `styles/pages/home.css:650-659` — demote the provenance trust-line from a gold box. VERIFIED.
+
+```css
+/* before */
+.hlc-trust-line {
+  margin: 0 0 var(--space-4);
+  padding: var(--space-3);
+  color: var(--text-secondary);
+  background: var(--color-gold-tint);
+  border: 1px solid var(--color-gold-glow);
+  border-radius: var(--radius-md);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+/* after */
+.hlc-trust-line {
+  margin: 0 0 var(--space-3);
+  padding: 0;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+```
+
+Rationale: DESIGN-SYSTEM §Signature hero item 6 — quiet provenance caption on plain canvas, no gold
+box. The provenance text (`index.html:262-264`, "Spot-linked reference · shops may add making
+charges, VAT, and margin") stays fully visible; only the box chrome is removed.
+
+### P1-10 — `index.html` (insert after the `price-hero` block, before `.hlc-sparkline` at :243) — add the single rule + subordinate retail row. VERIFIED (insertion point) / UNVERIFIED (final markup + JS wiring).
+
+```html
+<!-- after the closing </div> of .price-hero (line 242), before .hlc-sparkline -->
+<hr class="hlc-rule" aria-hidden="true" />
+<p class="hlc-retail" id="hlc-retail">
+  <span class="hlc-retail-label" id="hlc-retail-label">Retail (est. +making +5% VAT)</span>
+  <span class="hlc-retail-value" id="hlc-retail-value" data-testid="retail-estimate">—</span>
+  <a class="hlc-retail-link" href="content/spot-vs-retail-gold-price/" id="hlc-retail-link"
+    >How retail differs →</a
+  >
+</p>
+```
+
+Rationale: DESIGN-SYSTEM §Signature hero render order 5 (the ONE rule) + 6 (spot-vs-retail row below
+the rule). The hero has **no retail number today** (VERIFIED `index.html:243` jumps from the
+freshness chip to the sparkline). **DECISION (resolving the area-map open question):** per the
+no-fabricated-data invariant, `#hlc-retail-value` must show an **illustrative est. RANGE** derived
+from the SAME making-charge constants as `ShopVsReferencePanel.js` (`MAKING_LOW 0.08` /
+`MAKING_HIGH 0.22`) plus the 5% VAT qualifier — never a single fabricated retail price. **If the
+implementer cannot wire honest JS + EN/AR translation keys in this phase, ship the row as label-only
+("Retail varies — see calculator →") rather than a placeholder dash that implies missing data.**
+This requires new translation keys (`home.retailEstLabel`, `home.retailLink`) with AR parity before
+shipping. `data-testid="retail-estimate"` is provided for test hooks. Confirm the
+`content/spot-vs-retail-gold-price/` href resolves (UNVERIFIED — implementer to verify the target
+exists or repoint).
+
+### P1-10b — `styles/pages/home.css` (add near the `.hlc-trust-line`/`.hlc-indicators` region, ~648-660) — CSS for the rule + retail row. VERIFIED (no such rules exist today).
+
+```css
+.hlc-rule {
+  block-size: 1px;
+  border: 0;
+  background: var(--color-rule);
+  margin: var(--space-5) 0 var(--space-4);
+}
+.hlc-retail {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
+  margin: 0;
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+}
+.hlc-retail-value {
+  font-family: var(--font-numeric);
+  font-variant-numeric: tabular-nums lining-nums slashed-zero;
+  font-feature-settings: var(--font-numeric-features);
+}
+.hlc-retail-link {
+  font-size: var(--text-ui-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--color-gold-dark);
+  text-decoration: none;
+  margin-inline-start: auto;
+}
+.hlc-retail-link:hover {
+  text-decoration: underline;
+}
+.hlc-retail-link:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  border-radius: var(--radius-xs);
+}
+```
+
+Rationale: retail is `--text-base`/600 in `--color-text-muted` on plain canvas (no gold box) — one
+full type-step below the price (`--text-data-xl`/700/ink-data). The micro-link uses
+`--color-gold-dark` (#7e5912, AA-safe text gold) — **never `--color-gold`** (graphical-object only).
+`margin-inline-start: auto` keeps RTL correct. Confirm `--focus-ring-*` tokens exist before using
+them (UNVERIFIED — if absent, fall back to
+`outline: 2px solid var(--color-gold); outline-offset: 2px` as used elsewhere in home.css).
+
+### P1-11 — `src/pages/home.js:432, 436` — surface the explicit freshness state WORD in the hero readout. VERIFIED.
+
+```js
+// before (:432 render path; :436 fallback)
+hlcUpdatedEl.textContent = `${sourceText} · ${ageText}`;
+...
+setTextById('hlc-updated', `${sourceText} · ${ageText}`);
+// after
+hlcUpdatedEl.textContent = `${statusText} · ${sourceText} · ${ageText}`;
+...
+setTextById('hlc-updated', `${statusText} · ${sourceText} · ${ageText}`);
+```
+
+Rationale: INVARIANT FIX. `statusText` (= Live/Delayed/Cached/Stale/Fallback/Unavailable via
+`SOURCE_TX_KEY`, EN translations.js:856-861 / AR :2167-2172) is **already destructured at
+home.js:422** and used for the karat strip (:440) but **omitted from the hero readout line** — so
+the hero shows source+age but never the state WORD, signalling state by dot colour alone. Prepending
+`statusText` upholds "never colour alone." EN/AR parity preserved (tx-driven).
+
+### P1-12 — `src/pages/home.js:331, 335` — mirror the state-word fix in the per-second timer. VERIFIED.
+
+```js
+// before (:331 builds the live-updating string)
+const hlcText = `${sourceText} · ${ageText}`;
+// after
+const hlcText = `${statusText} · ${sourceText} · ${ageText}`;
+```
+
+Rationale: `startFreshnessTimer` (home.js:323-348) **already destructures `statusText` at :329** but
+builds `hlcText` without it. Without this, the state word is overwritten one second after the first
+render. The `hlcEl.textContent = hlcText` write at :335 then carries the word continuously.
+
+---
+
+## Priority 2 — Retire decorative effects (hero-first)
+
+DESIGN-SYSTEM §4 RETIRE-FROM-USAGE. All enumerated items live in `styles/pages/home.css` +
+`index.html` + `src/pages/home.js` — **home-only**, so zero generator/sw involvement and the 263
+country pages are unaffected (they don't import home.css). Tokens stay defined in tokens.css; this
+priority only stops APPLYING them on home. **Apply the hero edits (P2-1…P2-8) first, then the
+below-fold batch (P2-9…P2-12) in one pass with before/after screenshots.**
+
+**Overlap reconciliation with Priority 1.** P1-4…P1-7 already rewrite `.hero-live-card` (383-460) —
+those edits ARE the chrome/foil/glow/blur/hover-lift retirement for the readout, so **P2 does not
+re-touch 383-460**; the per-file list in §6 merges them into one sequence. P2 owns the hero-SECTION
+decorations (`.hero::before/::after`, `.hero-badge` animation, the parallax JS) and the below-fold
+cards.
+
+### P2-1 — `src/pages/home.js:1580-1603` — remove the hero-backdrop scroll parallax block. VERIFIED.
+
+```js
+// before: the `if (heroEl) { ... window.addEventListener('scroll', ...) }` parallax block
+// after:
+// (hero parallax removed — Precision Instrument: the freshness dot is the only hero animation)
+```
+
+Remove the JS first (safest, no visual regression on the now-flat hero) so there is no dangling
+`--hero-parallax-y` write after the CSS target is deleted.
+
+### P2-2 — `styles/pages/home.css:106-118` — delete `.hero::before` (4 orb radials + parallax transform + will-change). Also delete the dead reduced-motion guard at `:120-124`. VERIFIED.
+
+### P2-3 — `styles/pages/home.css:143-148` — delete the dark `[data-theme='dark'] .hero::before` orb override (now targets a removed pseudo). VERIFIED.
+
+### P2-4 — `styles/pages/home.css:127-136` — delete `.hero::after` (3px `--rule-foil` bottom rule). The existing 1px `--color-border-subtle` `border-block-end` (`:101`) is the seam. VERIFIED.
+
+### P2-5 — covered by P1-6 (`.hero-live-card::before` foil top rule + `::after` corner glow, 402-424). No separate edit.
+
+### P2-6 — covered by P1-4/P1-5/P1-7 (`.hero-live-card` chrome, hover, dark/LIVE shadow stacks). No separate edit.
+
+### P2-7 — `styles/pages/home.css:180` — remove `animation: badge-glow 3s ...` from `.hero-badge` (keep the static box-shadow at :179). VERIFIED.
+
+```css
+/* before */
+box-shadow: 0 0 0 4px rgb(26 122 50 / 6%);
+animation: badge-glow 3s ease-in-out infinite;
+/* after */
+box-shadow: 0 0 0 4px rgb(26 122 50 / 6%);
+/* badge-glow animation retired — hero badge is static */
+```
+
+`.hero-badge-dot` `pulse-live-hero` (`:189`) is **preserved** as the single allowed hero animation.
+The `@keyframes badge-glow` (`:69-77`) becomes orphaned — leave defined (lint-safe) or delete; do
+NOT delete `pulse-live-hero`.
+
+### P2-8 — `index.html:155` — remove the ⚡ emoji from the freshness banner icon span. VERIFIED.
+
+```html
+<!-- before -->
+<span class="hfb-icon" aria-hidden="true">⚡</span>
+<!-- after -->
+<span class="hfb-icon" aria-hidden="true"></span>
+<!-- emoji retired; freshness carried by the #hfb-text state word -->
+```
+
+The ⚡ was `aria-hidden` decoration; `#hfb-text` (:156) carries the explicit state word — freshness
+invariant intact.
+
+### P2-9 — `styles/pages/home.css:224-234` — covered by P1-8 (de-italic/de-gold the subtitle). No separate edit; if P2 runs before P1, apply the §P1-8 CSS here.
+
+### P2-10 — `styles/pages/home.css:1431-1438` — remove the universal `.gcc-card`/`.tool-card` hover translateY(-5px) + shadow-gold-lg. VERIFIED.
+
+```css
+/* before */
+.gcc-card:hover,
+.tool-card:hover {
+  box-shadow: var(--shadow-gold-lg), var(--shadow-lg);
+  border-color: var(--color-gold);
+  transform: translateY(-5px);
+  text-decoration: none;
+  color: inherit;
+}
+/* after */
+.gcc-card:hover,
+.tool-card:hover {
+  border-color: var(--color-gold);
+  text-decoration: none;
+  color: inherit;
+}
+```
+
+The matching reduced-motion guard (~1445-1455) becomes redundant but harmless.
+
+### P2-11 — `styles/pages/home.css:1660-1669` (◈ glyph) + `:1480` (gcc-flag size). VERIFIED.
+
+```css
+/* delete .tool-card--primary::after entirely (the ◈ glyph) */
+/* .gcc-flag — downsize from the decorative-graphic size */
+.gcc-flag {
+  font-size: var(--text-base);
+  flex-shrink: 0;
+} /* was 1.45rem */
+```
+
+`.gcc-flag` downsizing is the literal spec fix ("flag emoji at 1.45rem"); the emoji itself ships in
+JS-injected gcc-card markup, so full de-emojification would be a separate JS change (out of scope).
+
+### P2-12 — `styles/pages/home.css:1321,1323` + `:3062` — remove `--gradient-gold` fills. VERIFIED.
+
+```css
+/* .home-section-title::after (1321 + 1323) before → after */
+background: var(--gradient-gold); /* → var(--color-gold-dark) */
+box-shadow: var(--shadow-gold); /* → remove */
+/* .home-stat-value (3062-3065) before → after: drop the gradient text-clip, render solid */
+background: var(--gradient-gold);
+-webkit-background-clip: text;
+-webkit-text-fill-color: transparent;
+background-clip: text;
+/* → remove all four; the existing color: var(--color-gold-deep) at :3056 becomes the solid fill */
+```
+
+a11y: `.home-stat-value` solid `--color-gold-deep` must pass AA on its surface (gradient-clip text
+contrast is currently unmeasurable; solid is strictly more legible) — confirm at implementation.
+
+### P2-13 — `styles/pages/home.css` — the remaining `--shadow-gold/-lg/-xl` + `translateY(-2..-5px)` batch. VERIFIED present (per-site value UNVERIFIED).
+
+Across home.css there are ~24 `shadow-gold*` applications and ~11 `translateY(-[2-5]px)` hover sites
+(e.g. `:331,349-350,984,991,997-998,1657,1682,1803,1811,1818,1843,2475,2549,3040,3130,3371`).
+DESIGN-SYSTEM §4 + §Elevation: no new shadow-gold applications, no hover-lift on static cards.
+Replace with `--shadow-xs` at rest, no transform, **site by site** after the hero edits land. This
+is the largest batch and the highest visual-regression risk — do it last, in one pass, with
+before/after screenshots. (Each site VERIFIED present via grep; the chosen replacement per site is a
+judgement call.)
+
+---
+
+## Priority 3 — Shared shell + a11y fixes
+
+### P3-1 — `styles/pages/home.css:2605-2606` — karat copy button → WCAG 2.5.8 ≥24px. VERIFIED.
+
+```css
+/* before */
+width: 22px;
+height: 22px;
+/* after */
+/* WCAG 2.5.8: target size >= 24px (was 22px). Logical sizing keeps RTL parity. */
+inline-size: 24px;
+block-size: 24px;
+min-inline-size: 24px;
+min-block-size: 24px;
+```
+
+Icon-only button (no text label), so width/height ARE the target size; 24px is the WCAG 2.2 AA floor
+(AUDIT.md:144 + Risk 12). Logical sizing keeps RTL parity (the `margin-inline-start:2px` at :2619 is
+untouched). The `@media (pointer:coarse)` rule at :2628-2632 only changes opacity — geometry is
+inherited, so touch devices also get 24px. Confirm the glyph stays centred (display:inline-flex +
+center already at :2602-2604).
+
+### P3-2 — `styles/pages/home.css:768` — stale freshness label amber → AA warning ink. VERIFIED.
+
+```css
+/* before */
+.karat-strip-updated[data-freshness-key='stale'] {
+  color: var(--color-amber);
+}
+/* after */
+.karat-strip-updated[data-freshness-key='stale'] {
+  color: var(
+    --color-warning-text
+  ); /* #7a4f15 = 6.86:1 on --color-bg (was --color-amber #f59e0b = 2.08:1, AA fail) */
+}
+```
+
+### P3-3 — `styles/pages/home.css:789` — age-based 'amber' label amber → AA warning ink. VERIFIED.
+
+```css
+/* before */
+.karat-strip-updated[data-freshness-age='amber'] {
+  color: var(--color-amber);
+}
+/* after */
+.karat-strip-updated[data-freshness-age='amber'] {
+  color: var(
+    --color-warning-text
+  ); /* AA-passing; matches freshness-chip[data-freshness-age='amber'] at price-display.css:253 */
+}
+```
+
+Rationale (P3-2/3): `--color-amber #f59e0b` computes 2.08:1 on `--color-bg` (AA fail) and was never
+in the gate's pair list. `--color-warning-text` (#7a4f15 light, 6.86:1; #e0b060 dark, VERIFIED in
+tokens.css:74/442) is the canonical warning ink the freshness-chip already uses
+(price-display.css:216,253), semantically correct (stale is a warning, not an error), and has a dark
+override. The ⚠ glyph (:776) + the explicit `statusText` word (home.js:440) remain — colour is never
+the sole signal. `--color-amber` stays DEFINED in tokens.css:277 (still a legitimate
+graphical-object background fill elsewhere); only its use as small freshness TEXT is removed.
+
+### P3-4 — `scripts/node/check-basic-a11y.js:61` — lock the warning ink in the gate. VERIFIED.
+
+```js
+// before (end of CONTRAST_PAIRS)
+  ['--color-success', '--color-bg'],
+  ['--color-success', '--color-surface'],
+];
+// after
+  ['--color-success', '--color-bg'],
+  ['--color-success', '--color-surface'],
+  // Freshness warning ink (karat strip stale/amber labels + freshness-chip cached/delayed).
+  // Locked after replacing raw --color-amber (2.08:1 fail) with --color-warning-text (6.86:1).
+  ['--color-warning-text', '--color-bg'],
+  ['--color-warning-text', '--color-surface-2'],
+  ['--color-warning-text', '--color-surface-3'],
+];
+```
+
+All three pairs pass (6.86 / 6.63 / 6.12 — recompute at implementation to confirm). The light
+CONTRAST_PAIRS loader resolves from `:root`; `--color-warning-text` and all three surfaces live in
+`:root`. Do NOT add `--color-amber` itself (still a legit graphical fill). The dark gate
+(`DARK_CONTRAST_PAIRS`) already locks `--color-warning-text` on `--surface-secondary` (VERIFIED
+:78), so no new dark pair is needed.
+
+### P3-5 — Freshness state-word audit (CONFIRMATION, no code change). VERIFIED.
+
+The explicit state WORD is present in every state and never colour-alone across all three live
+surfaces: `FreshnessBadge.js:27` (`freshness.badge.*` keys, translations.js EN :1130-1137 / AR
+:2437-2444); `FreshnessStrip.js:117-120` (`freshness.strip.*`); the home.js karat strip (:440)
+always prints `${statusLabel}: ${statusText}` with a `sourceCached` fallback so it is never empty.
+In all three the dot/glyph is `aria-hidden` and the word carries meaning. **The one gap is the hero
+readout line — fixed by P1-11/P1-12.** No additional change required here.
+
+### P3-6 — Honest empty/loading/fallback states (CONFIRMATION, no code change). VERIFIED.
+
+`skeleton.js` marks `aria-busy` + `role=presentation/aria-hidden` placeholders (no fake numbers);
+`price-fetch-error.js` shows `status.noData` + optional retry (no fabricated price);
+`data-status-banner.js` renders a `role=status` text message ("Offline — showing cached data from
+{time}"). None are touched by Phase-2 edits. Smoke-test them post-change to confirm no regression.
+
+### P3-7 — FreshnessStrip decision. VERIFIED (dead in runtime).
+
+`src/components/FreshnessStrip.js` is imported in **0 src/ runtime files** (grep: only its own
+definition, `tests/freshness-strip.test.js`, AUDIT.md, and a docs artifact). The live freshness UI
+is fully served by `FreshnessBadge.js` + the home.js karat-strip renderer + the price-display.css
+freshness-chip. **RECOMMENDATION: RETIRE** for Phase 2. **But:** retiring requires deleting
+`tests/freshness-strip.test.js` alongside it (the `node --test` suite would otherwise break) — that
+test deletion is a code change and is therefore tracked as a **Phase-2 cleanup item, NOT bundled
+with the a11y fixes** in this plan. If the team prefers REVIVE, the cheapest path is mounting it via
+`mountSharedShell` (site-shell.js) on pages lacking a visible freshness surface — a larger decision.
+**Flagged for owner; not auto-resolved here.**
+
+---
+
+## Per-file consolidated edit list
+
+Apply files in this order; within each file, apply edits top-to-bottom by line number so diffs do
+not shift. Edits that two priorities both touched are merged (no conflicting instructions).
+
+### 1. `styles/partials/price-display.css` (shared/unbundled — affects home, chart, 263 country pages)
+
+1. `:20-24` reference chip → flat de-metallised gold edge **[P0-1]**
+2. `:26-30` retail chip → flat muted, subordinate **[P0-2]** (reconciled: `--surface-secondary` +
+   `--border-subtle`)
+3. `:59-70` price primitive → ink-data / 700 / slashed-zero **[P1-1]**
+4. `:282-286` `.cp-mi-stat--retail` → flat muted, no gold ring **[P0-3]**
+
+### 2. `styles/country-page.css` (shared/unbundled — affects 263 country pages)
+
+5. `:741-744` `.cp-mi-stat--retail` (early block) → neutral **[P0-4]**
+6. `:1087-1090` `.cp-mi-stat--retail` (winning block) → neutral, clears raw-hex gold **[P0-5]**
+
+### 3. `styles/pages/home.css` (home only)
+
+7. `:106-118` delete `.hero::before` orbs + parallax; `:120-124` delete dead reduced-motion guard
+   **[P2-2]**
+8. `:127-136` delete `.hero::after` foil bottom rule **[P2-4]**
+9. `:143-148` delete dark `.hero::before` orb override **[P2-3]**
+10. `:180` remove `badge-glow` animation from `.hero-badge` **[P2-7]**
+11. `:206-234` H1: weight 800→700; subtitle de-italic + `--color-text-muted` **[P1-8 / P2-9]**
+12. `:383-395` `.hero-live-card` chrome → `--rim-inset` + `--readout-chrome` + `--readout-radius`;
+    no blur **[P1-4 / P2-6]**
+13. `:397-400` delete hover-lift **[P1-5]**
+14. `:402-424` delete foil top rule + corner glow **[P1-6 / P2-5]**
+15. `:426-460` rework dark + LIVE shadow stacks → no gold glow **[P1-7]**
+16. `:519-528` `.hlc-price` → `--text-data-xl` / 700 / ink-data / slashed-zero **[P1-2]**
+17. `~648-660` ADD `.hlc-rule` + `.hlc-retail` + `.hlc-retail-value` + `.hlc-retail-link` rules
+    **[P1-10b]**
+18. `:650-659` `.hlc-trust-line` → plain-canvas caption (no gold box) **[P1-9]**
+19. `:768` stale freshness label → `--color-warning-text` **[P3-2]**
+20. `:789` age-amber freshness label → `--color-warning-text` **[P3-3]**
+21. `:1321,1323` `.home-section-title::after` → flat gold-dark, no shadow-gold **[P2-12]**
+22. `:1431-1438` remove `.gcc-card`/`.tool-card` hover lift + shadow-gold-lg **[P2-10]**
+23. `:1480` `.gcc-flag` font-size 1.45rem → `--text-base` **[P2-11]**
+24. `:1660-1669` delete `.tool-card--primary::after` ◈ glyph **[P2-11]**
+25. `:2605-2606` karat copy button → 24px (logical) **[P3-1]**
+26. `:3062-3065` `.home-stat-value` → solid `--color-gold-deep`, drop gradient text-clip **[P2-12]**
+27. `:3375-3380` duplicate `.hlc-price` → align to ink-data / 700 / slashed-zero **[P1-3]**
+28. shadow-gold/-lg/-xl + translateY hover BATCH across remaining sites → `--shadow-xs`, no lift
+    **[P2-13]** (do last)
+
+### 4. `src/pages/home.js` (home only)
+
+29. `:331` per-second timer `hlcText` → prepend `statusText` **[P1-12]**
+30. `:432` + `:436` hero readout render → prepend `statusText` **[P1-11]**
+31. `:1580-1603` remove hero parallax scroll block **[P2-1]**
+32. ADD `#hlc-retail-value` render path from `MAKING_LOW/HIGH` constants (or label-only fallback) +
+    EN/AR translation keys **[P1-10, UNVERIFIED — new code]**
+
+### 5. `index.html` (home only; precached shell — bump `sw.js CACHE_NAME` on deploy)
+
+33. `:155` remove ⚡ emoji from `.hfb-icon` **[P2-8]**
+34. after `:242` (before `.hlc-sparkline` at :243) insert `.hlc-rule` + `.hlc-retail` row markup
+    **[P1-10]**
+
+### 6. `scripts/node/check-basic-a11y.js`
+
+35. `:61` add three `--color-warning-text` pairs to `CONTRAST_PAIRS` **[P3-4]**
+
+### Deferred / tracked (NOT in this phase's diff)
+
+- Delete `src/components/FreshnessStrip.js` + `tests/freshness-strip.test.js` (Phase-2 cleanup item)
+  **[P3-7]**.
+
+---
+
+## Verification plan
+
+### Gates to run (AGENTS core commands — any change touching HTML/CSS/JS)
+
+1. `npm run build` (touches HTML/CSS/JS).
+2. `npm test`.
+3. `npm run lint` (eslint + **stylelint** — confirm no raw-hex / token violations introduced; P0-5
+   removes one existing raw-hex).
+4. `npm run validate` (17-check gate). After P3-4, run `node scripts/node/check-basic-a11y.js` and
+   confirm it still prints the WCAG-AA success line and exits 0 with the three new
+   `--color-warning-text` pairs. Confirm `check-freshness-metadata`, `check-seo-meta`,
+   `check-sw-precache`, `check-sw-coverage` stay green after the `index.html` markup edits.
+5. `prettier --check` on the edited files (repo formatting gate).
+
+### Screenshots
+
+- **Home hero** at 1280px (two-column) and 375px (stacked), in **EN light, EN dark, AR (dir=rtl)**.
+  Confirm: (a) price in `--color-ink-data` at `--text-data-xl`/700 with visible slashed-zeros, NOT
+  the old 5.25rem/800; (b) freshness line shows an explicit WORD (LIVE/CACHED/…) before the
+  timestamp, dot the only animation; (c) exactly ONE rule divider; (d) retail row below the rule,
+  muted/smaller, no gold box; (e) no foil rules, no orbs/corner glow, no blur, no hover-lift, no
+  badge-glow, no ⚡.
+- **Freshness states** — force live/delayed/cached/stale/unavailable + age=amber via mocked
+  `goldUpdatedAt`; confirm the state word + dot both change and the word is never absent on the
+  initial render (home.js:432) AND after the 1s timer tick (home.js:335). Verify the karat-strip
+  stale/amber label renders the deeper #7a4f15 brown (legible on parchment) in EN and AR.
+- **A karat / calculator surface** — open a generated country page (e.g.
+  `countries/uae/dubai/gold-rate/`) and `/chart/`: confirm the shared price-display changes render
+  correctly **unbundled**; the `.cp-mi-stat--retail` card is the QUIETEST card (flat, muted, no gold
+  border/gradient/ring) and visibly lighter than its neutral siblings in light AND dark; the
+  `· Retail est.` / `· تقدير تجزئة` label still renders; the `price-kind--reference` /
+  `cp-hero .cp-price-value` reference surfaces still read as reference-heavier-than-retail.
+- **Karat copy button** — measure the rendered box in DevTools at 320/375px and coarse-pointer:
+  computed 24×24px, glyph centred, RTL places it via `margin-inline-start` with no physical-left
+  regression.
+
+### WCAG contrast checks
+
+`--color-ink-data` on #fff and #fdfbf5; `--color-text-muted` retail row on #fdfbf5;
+`--color-gold-dark` link text on the readout surface; `--color-warning-text` on
+bg/surface-2/surface-3 — all must pass AA (≥4.5:1). Confirm `--color-gold` is used only as the 7px
+dot / focus ring / chip border (≥3:1 graphical object), never as small text. Re-measure the
+DESIGN-SYSTEM's claimed 18.7–18.9:1 (ink-data) and 6.2:1 (muted) independently (UNVERIFIED in this
+plan).
+
+### Invariant checklist (re-confirm before shipping)
+
+- [ ] AED peg 3.6725 untouched (no pricing-math file edited).
+- [ ] Troy oz 31.1035 untouched.
+- [ ] **Spot-vs-retail:** retail is smaller, muted, `est.`-labelled, below the rule, no gold box, on
+      every surface (home readout, country `.cp-mi-stat--retail`, latent `.price-kind--retail`);
+      reference is the darkest/largest mark and the only gold edge.
+- [ ] **Freshness:** explicit state WORD present in the hero readout on first render and every timer
+      tick, never colour alone; dot/glyph aria-hidden.
+- [ ] **No fabricated data:** `#hlc-retail-value` is an illustrative est. range from
+      `MAKING_LOW/HIGH` (or honest label-only), never a single fake retail price; honest
+      empty/loading/fallback states unchanged.
+- [ ] **EN/AR parity + RTL:** new retail keys have AR parity; hero mirrors at the grid level; only
+      logical properties used; the removed foil/corner-glow eliminated the last physical-prop paths.
+- [ ] **Static-first:** no framework added; all animation behind `prefers-reduced-motion`; net paint
+      reduction (blur + orbs + parallax + gold shadows removed).
+- [ ] `sw.js CACHE_NAME` bumped (no new PRECACHE_URLS/sw-coverage entries needed).
+
+---
+
+## Risks & open questions
+
+1. **`.hlc-price` three-place cascade (HIGH).** Defined at `price-display.css:59-70`,
+   `home.css:519-528`, `home.css:3375-3380`, all specificity (0,1,0); the deploy-time flatten makes
+   source order non-obvious. P1-1/2/3 must ALL land on the same ink-data/700/slashed-zero voice.
+
+2. **New retail row = new data surface (HIGH, UNVERIFIED wiring).** `#hlc-retail-value` needs a
+   home.js render path derived from the SAME illustrative making-charge constants as
+   `ShopVsReferencePanel.js` (`MAKING_LOW 0.08` / `MAKING_HIGH 0.22`) with the `est.` word — never a
+   single fabricated number. If honest JS + EN/AR keys (`home.retailEstLabel`, `home.retailLink`)
+   with AR parity cannot be wired this phase, ship label-only ("Retail varies — see calculator →")
+   rather than a placeholder dash. The freshness gate (`check-freshness-metadata` allowlist) and
+   basic-a11y gate run on `index.html` — the new markup must keep both green. **Verify the
+   `content/spot-vs-retail-gold-price/` href target exists (UNVERIFIED).**
+
+3. **Shared/unbundled CSS reaches 263 country pages + `/chart/` (MEDIUM).** P0-2/3, P0-4/5, and P1-1
+   change `.cp-mi-stat--retail`, `.cp-hero .cp-price-value`, and `price-kind--reference` on
+   generated pages. Intended and consistent with the system, but must be visually checked on a
+   generated country page (changed only via `consolidate-country-pages.js`, never hand-edited) and
+   on `/chart/` in light + dark.
+
+4. **Large decorative batch (MEDIUM, per-site UNVERIFIED).** P2-13 touches ~24 shadow-gold + ~11
+   translateY sites in home.css; each is VERIFIED present but the per-site replacement value is a
+   judgement call. Do it last, after the hero edits, with before/after screenshots.
+
+5. **`--color-gold` as small text elsewhere (MEDIUM — out of this plan's scope, FLAG for owner).**
+   `.hero-title-main mark` (home.css:218-222) uses raw `--color-gold #b07d1f` as TEXT, which FAILS
+   AA (it is graphical-object-only ≥3:1). This plan does not edit it (not in the enumerated scope),
+   but it is a live AA risk that a sibling typography/a11y task should fix.
+
+6. **Reference-chip label colour (LOW, the one cosmetic open question).** P0-1 swaps `--text-accent`
+   → `--color-gold-deep` for spec fidelity (tokens table line 370). Both pass AA on gold-tint; the
+   invariant fix does NOT depend on this. **Owner/writer call:** keep the swap (spec-aligned) or
+   leave `--text-accent` for minimal churn. This plan mandates the swap but flags it as optional.
+
+7. **FreshnessStrip retire-vs-revive (LOW–MEDIUM, FLAG for owner).** Dead in runtime (0 src
+   imports). Recommendation: retire — but the accompanying `tests/freshness-strip.test.js` deletion
+   is a tracked Phase-2 cleanup item, deliberately NOT bundled with the a11y fixes. Revive (mount
+   via `mountSharedShell`) is a larger decision. Not auto-resolved.
+
+8. **Three redundant `.cp-mi-stat--retail` blocks (LOW).** After P0-3/4/5 the three blocks
+   (price-display:282, country-page:741, country-page:1087) all resolve to the same flat treatment.
+   Consolidating to one rule is a possible follow-up but risks specificity surprises; leaving all
+   three aligned is the safe minimal move (UNVERIFIED whether the team wants dedup now).
+
+9. **`--focus-ring-*` tokens for the retail link (LOW, UNVERIFIED).** P1-10b assumes
+   `--focus-ring-width/-color/-offset` exist; if not, fall back to the
+   `outline: 2px solid var(--color-gold); outline-offset: 2px` pattern already used in home.css
+   (e.g. :2596-2597).

--- a/scripts/node/check-basic-a11y.js
+++ b/scripts/node/check-basic-a11y.js
@@ -58,6 +58,11 @@ const CONTRAST_PAIRS = [
   // Success is used as status text on light surfaces — locked after the #137a36 fix.
   ['--color-success', '--color-bg'],
   ['--color-success', '--color-surface'],
+  // Freshness warning ink (karat-strip stale/amber labels + freshness-chip cached/delayed).
+  // Locked after replacing raw --color-amber (#f59e0b ≈2.08:1, AA fail) with --color-warning-text.
+  ['--color-warning-text', '--color-bg'],
+  ['--color-warning-text', '--color-surface-2'],
+  ['--color-warning-text', '--color-surface-3'],
 ];
 
 const MIN_NORMAL_CONTRAST = 4.5;

--- a/scripts/qa/phase1-shots.mjs
+++ b/scripts/qa/phase1-shots.mjs
@@ -1,0 +1,46 @@
+import { chromium } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+
+const OUT = process.env.SHOT_DIR || '/tmp/claude-0/-home-user-GoldTickerLive/ae77ae43-5aeb-52ab-9499-da63bc7738e0/scratchpad/phase1-shots';
+mkdirSync(OUT, { recursive: true });
+const BASE = 'http://localhost:5000';
+
+const shots = [
+  { name: 'home-en-light-desktop', url: '/', viewport: { width: 1366, height: 920 }, colorScheme: 'light', clip: { x: 0, y: 0, width: 1366, height: 920 } },
+  { name: 'home-en-light-mobile', url: '/', viewport: { width: 390, height: 844 }, colorScheme: 'light', full: false },
+  { name: 'home-en-dark-desktop', url: '/', viewport: { width: 1366, height: 920 }, colorScheme: 'dark', clip: { x: 0, y: 0, width: 1366, height: 920 } },
+  { name: 'home-ar-light-desktop', url: '/?lang=ar', viewport: { width: 1366, height: 920 }, colorScheme: 'light', clip: { x: 0, y: 0, width: 1366, height: 920 } },
+];
+
+// PW_CHROMIUM lets CI / sandboxes point at a pre-installed Chromium when the
+// bundled browser version doesn't match @playwright/test (else Playwright's
+// default resolution is used).
+const browser = await chromium.launch({
+  executablePath: process.env.PW_CHROMIUM || undefined,
+  args: ['--no-sandbox', '--disable-dev-shm-usage'],
+});
+const results = [];
+for (const s of shots) {
+  const ctx = await browser.newContext({ viewport: s.viewport, colorScheme: s.colorScheme, deviceScaleFactor: 1 });
+  const page = await ctx.newPage();
+  const errors = [];
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text().slice(0, 160)); });
+  page.on('pageerror', (e) => errors.push('PAGEERROR: ' + String(e).slice(0, 160)));
+  await page.goto(BASE + s.url, { waitUntil: 'networkidle', timeout: 30000 }).catch((e) => errors.push('GOTO: ' + e.message));
+  await page.waitForTimeout(1800); // let price hydrate + animations settle
+  // probe key invariant-bearing text
+  const probe = await page.evaluate(() => {
+    const dir = document.documentElement.getAttribute('dir') || 'ltr';
+    const lang = document.documentElement.getAttribute('lang');
+    const theme = document.documentElement.getAttribute('data-theme');
+    const hasFreshness = !!document.querySelector('[data-freshness-key],[data-freshness-age],.freshness-badge,.freshness,[class*="freshness"]');
+    const priceEl = document.querySelector('.hlc-price, [class*="price-hero"], [class*="hero-price"], [data-price], .price-value');
+    return { dir, lang, theme, hasFreshness, priceSample: priceEl ? priceEl.textContent.replace(/\s+/g, ' ').trim().slice(0, 60) : null };
+  }).catch(() => ({}));
+  const path = `${OUT}/${s.name}.png`;
+  await page.screenshot({ path, fullPage: !!s.full, clip: s.clip }).catch(async () => { await page.screenshot({ path }); });
+  results.push({ name: s.name, errors: errors.slice(0, 6), probe });
+  await ctx.close();
+}
+await browser.close();
+console.log(JSON.stringify(results, null, 2));

--- a/scripts/qa/phase2-shots.mjs
+++ b/scripts/qa/phase2-shots.mjs
@@ -1,0 +1,46 @@
+import { chromium } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+
+const OUT = process.env.SHOT_DIR || '/tmp/claude-0/-home-user-GoldTickerLive/ae77ae43-5aeb-52ab-9499-da63bc7738e0/scratchpad/phase2-shots';
+mkdirSync(OUT, { recursive: true });
+const BASE = 'http://localhost:5000';
+
+const shots = [
+  { name: 'home-en-light', url: '/', viewport: { width: 1366, height: 940 }, colorScheme: 'light', clip: { x: 700, y: 150, width: 640, height: 640 } },
+  { name: 'home-en-light-full', url: '/', viewport: { width: 1366, height: 940 }, colorScheme: 'light', clip: { x: 0, y: 100, width: 1366, height: 760 } },
+  { name: 'home-ar-light', url: '/?lang=ar', viewport: { width: 1366, height: 940 }, colorScheme: 'light', clip: { x: 0, y: 100, width: 1366, height: 760 } },
+  { name: 'home-en-dark', url: '/', viewport: { width: 1366, height: 940 }, colorScheme: 'dark', clip: { x: 0, y: 100, width: 1366, height: 760 } },
+  { name: 'country-uae-dubai-gold-rate', url: '/countries/uae/dubai/gold-rate/', viewport: { width: 1366, height: 1100 }, colorScheme: 'light', full: true },
+];
+
+const browser = await chromium.launch({
+  executablePath: process.env.PW_CHROMIUM || undefined,
+  args: ['--no-sandbox', '--disable-dev-shm-usage'],
+});
+const results = [];
+for (const s of shots) {
+  const ctx = await browser.newContext({ viewport: s.viewport, colorScheme: s.colorScheme, deviceScaleFactor: 1 });
+  const page = await ctx.newPage();
+  const errors = [];
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text().slice(0, 140)); });
+  page.on('pageerror', (e) => errors.push('PAGEERROR: ' + String(e).slice(0, 140)));
+  await page.goto(BASE + s.url, { waitUntil: 'networkidle', timeout: 30000 }).catch((e) => errors.push('GOTO: ' + e.message));
+  await page.waitForTimeout(2000);
+  const probe = await page.evaluate(() => {
+    const t = (sel) => { const el = document.querySelector(sel); return el ? el.textContent.replace(/\s+/g, ' ').trim().slice(0, 90) : null; };
+    return {
+      dir: document.documentElement.getAttribute('dir') || 'ltr',
+      price: t('#hlc-price, .cp-price-value'),
+      freshness: t('#hlc-updated, .cp-update-time'),
+      retailRow: t('#hlc-retail'),
+      retailCard: t('.cp-mi-stat--retail'),
+      hasFoilOrOrb: !!document.querySelector('.hero-live-card::before'),
+    };
+  }).catch(() => ({}));
+  const path = `${OUT}/${s.name}.png`;
+  await page.screenshot({ path, fullPage: !!s.full, clip: s.clip }).catch(async () => { await page.screenshot({ path }); });
+  results.push({ name: s.name, errorsCount: errors.length, sampleErr: errors.slice(0, 2), probe });
+  await ctx.close();
+}
+await browser.close();
+console.log(JSON.stringify(results, null, 2));

--- a/src/config/translations.js
+++ b/src/config/translations.js
@@ -777,6 +777,8 @@ export const TRANSLATIONS = {
       'Spot-linked reference prices before retail premiums, making charges, and tax.',
     'home.heroTrustShort':
       'Spot-linked reference · shop prices can add making charges, VAT, and margin',
+    'home.heroRetailNote': 'Retail prices add making charges, VAT, and margin',
+    'home.heroRetailLink': 'How retail differs →',
     'home.freshnessDismiss': 'Dismiss freshness banner',
     'home.heroLiveStatusAria': 'Live status chips',
     'home.commandKicker': 'Gold command center',
@@ -2088,6 +2090,8 @@ export const TRANSLATIONS = {
     'home.heroTrustLine':
       'أسعار مرجعية مرتبطة بالسعر الفوري قبل الهامش التجاري والمصنعية والضريبة.',
     'home.heroTrustShort': 'مرجع مرتبط بالسعر الفوري · قد تضيف المحلات المصنعية والضريبة والهامش',
+    'home.heroRetailNote': 'تضيف أسعار التجزئة المصنعية وضريبة القيمة المضافة والهامش',
+    'home.heroRetailLink': 'كيف تختلف أسعار التجزئة ←',
     'home.freshnessDismiss': 'إغلاق شريط حالة التحديث',
     'home.heroLiveStatusAria': 'شرائح حالة التحديث المباشر',
     'home.commandKicker': 'مركز متابعة الذهب',

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -328,7 +328,7 @@ function startFreshnessTimer() {
     if (!goldPrice || !goldUpdatedAt) return;
     const { ageText, statusText, sourceText, key } = getFreshnessMeta();
     const ageClass = freshnessAgeClass(getLiveFreshness({ updatedAt: goldUpdatedAt, lang }).ageMs);
-    const hlcText = `${sourceText} · ${ageText}`;
+    const hlcText = `${statusText} · ${sourceText} · ${ageText}`;
     const kstripText = `${txGlobal('freshness.statusLabel')}: ${statusText} · ${tx('source')}: ${sourceText} · ${tx('updated')}: ${ageText}`;
     const hlcEl = document.getElementById('hlc-updated');
     if (hlcEl && hlcText !== prevHlcText) {
@@ -429,11 +429,11 @@ function renderHeroCard() {
       'shell-skeleton-freshness-strip'
     );
     hlcUpdatedEl.removeAttribute('aria-busy');
-    hlcUpdatedEl.textContent = `${sourceText} · ${ageText}`;
+    hlcUpdatedEl.textContent = `${statusText} · ${sourceText} · ${ageText}`;
     hlcUpdatedEl.dataset.freshnessKey = key;
     hlcUpdatedEl.dataset.freshnessAge = ageClass;
   } else {
-    setTextById('hlc-updated', `${sourceText} · ${ageText}`);
+    setTextById('hlc-updated', `${statusText} · ${sourceText} · ${ageText}`);
   }
   const kstripUpdatedEl = document.getElementById('karat-strip-updated');
   if (kstripUpdatedEl) {
@@ -1577,30 +1577,8 @@ async function init() {
   // Tick the "Updated X sec/min ago" label every second without a full price re-fetch.
   startFreshnessTimer();
 
-  // Gentle hero-backdrop parallax (transform-only, reduced-motion bypass)
-  const heroEl = document.querySelector('.hero');
-  if (heroEl) {
-    const prefersReduced =
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if (!prefersReduced) {
-      let parallaxTicking = false;
-      window.addEventListener(
-        'scroll',
-        () => {
-          if (parallaxTicking) return;
-          parallaxTicking = true;
-          window.requestAnimationFrame(() => {
-            // Parallax offset: 30% of scroll position, capped at the hero height
-            const offset = Math.min(window.scrollY * 0.3, heroEl.offsetHeight);
-            heroEl.style.setProperty('--hero-parallax-y', `${offset}px`);
-            parallaxTicking = false;
-          });
-        },
-        { passive: true }
-      );
-    }
-  }
+  // Hero-backdrop scroll parallax retired (Precision Instrument: the freshness dot is the
+  // only hero animation; the orb layer it drove was removed in home.css).
 
   // Clean up timers on page unload to prevent memory leaks
   window.addEventListener(

--- a/styles/country-page.css
+++ b/styles/country-page.css
@@ -739,8 +739,8 @@
 }
 
 .cp-mi-stat--retail {
-  border-color: var(--color-gold);
-  background: var(--color-gold-tint);
+  border-color: var(--border-subtle);
+  background: var(--surface-secondary);
 }
 
 .cp-mi-label {
@@ -1085,8 +1085,8 @@
 }
 
 .cp-mi-stat--retail {
-  border-color: rgb(196 144 46 / 35%);
-  background: linear-gradient(135deg, var(--color-gold-tint) 0%, var(--gradient-card) 100%);
+  border-color: var(--border-subtle);
+  background: var(--surface-secondary);
 }
 
 .cp-mi-buy {

--- a/styles/pages/home.css
+++ b/styles/pages/home.css
@@ -102,50 +102,14 @@
   isolation: isolate;
 }
 
-/* Multi-layer gold orb radial glows — richer and more dimensional */
-.hero::before {
-  content: '';
-  position: absolute;
-  inset: -40% 0;
-  background:
-    radial-gradient(ellipse 75% 65% at 78% 36%, rgb(221 176 64 / 13%) 0%, transparent 58%),
-    radial-gradient(ellipse 55% 45% at 22% 72%, rgb(21 17 10 / 4%) 0%, transparent 58%),
-    radial-gradient(ellipse 35% 28% at 88% 88%, rgb(196 144 46 / 8%) 0%, transparent 52%),
-    radial-gradient(ellipse 40% 30% at 10% 15%, rgb(240 202 92 / 5%) 0%, transparent 50%);
-  pointer-events: none;
-  will-change: transform;
-  transform: translateY(calc(var(--hero-parallax-y, 0px) * -0.4));
-}
+/* Precision Instrument: hero orb radials + scroll parallax retired.
+   Structure comes from weight/scale/space; the freshness dot is the only hero animation. */
 
-@media (prefers-reduced-motion: reduce) {
-  .hero::before {
-    transform: none !important;
-  }
-}
+/* Foil bottom rule retired — the 1px --color-border-subtle border-block-end on .hero is the seam. */
 
-/* Gold foil hairline bottom — richer rule */
-.hero::after {
-  content: '';
-  position: absolute;
-  inset-inline: 0;
-  inset-block-end: 0;
-  block-size: 3px;
-  background: var(--rule-foil);
-  opacity: 0.9;
-  pointer-events: none;
-}
-
-/* Phase 44 dark mode hero — deep midnight with richer gold orbs */
+/* Phase 44 dark mode hero — deep midnight (orb override retired with .hero::before) */
 [data-theme='dark'] .hero {
   background: var(--gradient-hero-dark);
-}
-
-[data-theme='dark'] .hero::before {
-  background:
-    radial-gradient(ellipse 75% 65% at 78% 36%, rgb(221 176 64 / 22%) 0%, transparent 58%),
-    radial-gradient(ellipse 55% 45% at 22% 72%, rgb(6 7 8 / 70%) 0%, transparent 58%),
-    radial-gradient(ellipse 35% 28% at 88% 88%, rgb(196 144 46 / 12%) 0%, transparent 52%),
-    radial-gradient(ellipse 40% 30% at 10% 15%, rgb(240 202 92 / 8%) 0%, transparent 50%);
 }
 
 /* Phase 13: Hero inner layout — wider gap, better proportions */
@@ -177,7 +141,8 @@
   margin-bottom: 1.6rem;
   width: fit-content;
   box-shadow: 0 0 0 4px rgb(26 122 50 / 6%);
-  animation: badge-glow 3s ease-in-out infinite;
+
+  /* badge-glow animation retired — the hero badge is static; only the dot pulses */
 }
 
 .hero-badge-dot {
@@ -207,17 +172,17 @@
   display: block;
   font-family: var(--font-display);
   font-size: clamp(2.8rem, 6.2vw, 4.1rem);
-  font-weight: var(--weight-extrabold);
+  font-weight: var(--weight-bold);
   line-height: 1.03;
   color: var(--text-primary);
   letter-spacing: var(--tracking-tighter);
   text-rendering: optimizelegibility;
 }
 
-/* Gold accent on the price number / key word */
+/* Gold accent on a key word — AA-safe text gold (--color-gold is graphical-object-only) */
 .hero-title-main mark {
   background: none;
-  color: var(--color-gold);
+  color: var(--color-gold-dark);
   font-style: normal;
 }
 
@@ -226,11 +191,9 @@
   font-family: var(--font-display);
   font-size: clamp(1.1rem, 2.6vw, 1.5rem);
   font-weight: var(--weight-regular);
-  color: var(--text-accent);
+  color: var(--color-text-muted);
   margin-top: 0.5rem;
   letter-spacing: 0.01em;
-  font-style: italic;
-  opacity: 0.9;
 }
 
 /* Phase 16: Hero lead — slightly larger, better spacing */
@@ -380,84 +343,30 @@
 /* ══════════════════════════════════════════════════════════════
    Phase 19: Hero Live Card — Premium elevated glass card
    ══════════════════════════════════════════════════════════════ */
+
+/* Precision Instrument readout: chrome budget = readout-radius + struck rim + one shadow-md.
+   No blur, no foil rule, no corner glow, no hover-lift, no gold-glow. */
 .hero-live-card {
   background: var(--surface-primary);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-2xl, 28px);
+  border-radius: var(--readout-radius);
   padding: var(--space-6) var(--space-6);
-  box-shadow: var(--shadow-xl), var(--shadow-gold);
+  box-shadow: var(--rim-inset), var(--readout-chrome);
   position: relative;
   overflow: hidden;
-  transition:
-    box-shadow var(--transition-premium),
-    transform var(--transition-premium);
-  backdrop-filter: blur(2px);
 }
 
-.hero-live-card:hover {
-  box-shadow: var(--shadow-2xl), var(--shadow-gold-xl);
-  transform: translateY(-2px);
-}
-
-/* Gold foil top rule — richer */
-.hero-live-card::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: var(--rule-foil);
-  opacity: 1;
-}
-
-/* Larger, richer radial glow in top-right corner of card */
-.hero-live-card::after {
-  content: '';
-  position: absolute;
-  top: -60px;
-  right: -60px;
-  width: 220px;
-  height: 220px;
-  background: radial-gradient(circle, rgb(221 176 64 / 10%) 0%, transparent 65%);
-  pointer-events: none;
-}
+/* Foil top rule (::before) + corner radial glow (::after) retired — this also deletes
+   the only non-mirroring physical-prop (top/left/right) paths in the hero (RTL positive). */
 
 [data-theme='dark'] .hero-live-card {
   background: var(--color-surface);
-  border-color: rgb(221 176 64 / 18%);
-  box-shadow:
-    var(--shadow-xl),
-    var(--shadow-gold),
-    inset 0 0 0 1px rgb(221 176 64 / 10%);
+  border-color: var(--color-border);
+  box-shadow: var(--rim-inset), var(--readout-chrome);
 }
 
-[data-theme='dark'] .hero-live-card::after {
-  background: radial-gradient(circle, rgb(221 176 64 / 18%) 0%, transparent 65%);
-}
-
-[data-theme='dark'] .hero-live-card:hover {
-  box-shadow:
-    var(--shadow-2xl),
-    var(--shadow-gold-xl),
-    inset 0 0 0 1px rgb(221 176 64 / 14%);
-}
-
-/* Amplified LIVE state: stronger gold glow on the hero card */
-.hero-live-card.spot-terminal--live {
-  box-shadow:
-    var(--shadow-xl),
-    var(--shadow-gold),
-    0 0 0 1px rgb(221 176 64 / 20%);
-}
-
-[data-theme='dark'] .hero-live-card.spot-terminal--live {
-  box-shadow:
-    var(--shadow-xl),
-    var(--shadow-gold-xl),
-    0 0 28px rgb(221 176 64 / 14%),
-    inset 0 0 0 1px rgb(221 176 64 / 18%);
-}
+/* LIVE state is signalled by the freshness dot + explicit state word only — never a card glow
+   (DESIGN-SYSTEM §Elevation: value signalled by ink density + the live dot, not by glow). */
 
 .hlc-header {
   display: flex;
@@ -518,10 +427,11 @@
 /* Hero price — dominant terminal-grade display */
 .hlc-price {
   font-family: var(--font-numeric);
-  font-size: clamp(3.4rem, 8.5vw, 5.25rem);
-  font-weight: var(--weight-extrabold);
-  color: var(--text-primary);
-  font-variant-numeric: tabular-nums;
+  font-size: var(--text-data-xl);
+  font-weight: var(--weight-bold);
+  color: var(--color-ink-data);
+  font-variant-numeric: tabular-nums lining-nums slashed-zero;
+  font-feature-settings: var(--font-numeric-features);
   line-height: 1;
   letter-spacing: var(--tracking-tight);
   min-block-size: 1em;
@@ -648,14 +558,49 @@
 }
 
 .hlc-trust-line {
-  margin: 0 0 var(--space-4);
-  padding: var(--space-3);
-  color: var(--text-secondary);
-  background: var(--color-gold-tint);
-  border: 1px solid var(--color-gold-glow);
-  border-radius: var(--radius-md);
+  margin: 0 0 var(--space-3);
+  padding: 0;
+  color: var(--text-muted);
   font-size: var(--text-xs);
   line-height: var(--leading-normal);
+}
+
+/* The single structural rule + subordinate retail row (DESIGN-SYSTEM §Signature hero 5–6).
+   Retail is one type-step below the price, muted, on plain canvas — never a gold box. */
+.hlc-rule {
+  block-size: 1px;
+  border: 0;
+  background: var(--color-rule);
+  margin: var(--space-5) 0 var(--space-4);
+}
+
+.hlc-retail {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
+  margin: 0;
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+}
+
+.hlc-retail-link {
+  font-size: var(--text-ui-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--color-gold-dark);
+  text-decoration: none;
+  margin-inline-start: auto;
+}
+
+.hlc-retail-link:hover {
+  text-decoration: underline;
+}
+
+.hlc-retail-link:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  border-radius: var(--radius-xs);
 }
 
 .hlc-change {
@@ -765,7 +710,7 @@
 
 /* Granular age-based overrides for karat strip */
 .karat-strip-updated[data-freshness-key='stale'] {
-  color: var(--color-amber);
+  color: var(--color-warning-text); /* was --color-amber (#f59e0b ≈2.08:1, AA fail) → ≈6.86:1 */
 }
 
 .karat-strip-updated[data-freshness-key='cached']::before {
@@ -786,7 +731,7 @@
 
 /* Granular age-based color shifts for karat strip */
 .karat-strip-updated[data-freshness-age='amber'] {
-  color: var(--color-amber);
+  color: var(--color-warning-text); /* AA-passing; matches the freshness-chip amber treatment */
 }
 
 .karat-strip-updated[data-freshness-age='amber']::before {
@@ -1318,9 +1263,8 @@
   inset-inline-start: 0;
   width: 3rem;
   height: 3px;
-  background: var(--gradient-gold);
+  background: var(--color-gold-dark);
   border-radius: 3px;
-  box-shadow: var(--shadow-gold);
 }
 
 .section-intro.centered .home-section-title::after {
@@ -1430,9 +1374,8 @@
 
 .gcc-card:hover,
 .tool-card:hover {
-  box-shadow: var(--shadow-gold-lg), var(--shadow-lg);
+  /* hover-lift + gold glow retired; quiet border affordance only */
   border-color: var(--color-gold);
-  transform: translateY(-5px);
   text-decoration: none;
   color: inherit;
 }
@@ -1477,7 +1420,7 @@
 }
 
 .gcc-flag {
-  font-size: 1.45rem;
+  font-size: var(--text-base);
   flex-shrink: 0;
 }
 
@@ -1657,16 +1600,7 @@
   box-shadow: var(--shadow-gold), var(--shadow-sm);
 }
 
-.tool-card--primary::after {
-  content: '◈';
-  position: absolute;
-  top: 0.75rem;
-  right: 0.85rem;
-  font-size: 0.9rem;
-  color: var(--color-gold);
-  opacity: 0.75;
-  line-height: 1;
-}
+/* ◈ tool-card glyph retired (DESIGN-SYSTEM §4 — no decorative glyphs) */
 
 .tool-card--primary .tool-card-icon {
   font-size: 2.2rem;
@@ -1689,11 +1623,6 @@
 
 [data-theme='dark'] .tool-card--primary:hover {
   background: linear-gradient(145deg, rgb(212 168 64 / 12%) 0%, rgb(212 168 64 / 6%) 100%);
-}
-
-[dir='rtl'] .tool-card--primary::after {
-  right: auto;
-  left: 0.75rem;
 }
 
 /* ── Phase 38: Alert row — more visible call to action ── */
@@ -2602,8 +2531,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+
+  /* WCAG 2.5.8: target size ≥ 24px (was 22px). Logical sizing keeps RTL parity. */
+  inline-size: 24px;
+  block-size: 24px;
+  min-inline-size: 24px;
+  min-block-size: 24px;
   padding: 0;
   background: transparent;
   border: 1px solid transparent;
@@ -3053,16 +2986,14 @@
 }
 
 .home-stat-value {
+  /* solid gold-deep fill (gradient text-clip retired — solid is strictly more legible) */
   color: var(--color-gold-deep);
   font-size: clamp(var(--text-3xl), 4vw, var(--text-4xl));
-  font-weight: var(--weight-extrabold);
-  font-variant-numeric: tabular-nums;
+  font-weight: var(--weight-bold);
+  font-variant-numeric: tabular-nums lining-nums slashed-zero;
+  font-feature-settings: var(--font-numeric-features);
   line-height: var(--leading-none);
   font-family: var(--font-numeric);
-  background: var(--gradient-gold);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
 }
 
 .home-stat-label {
@@ -3375,8 +3306,11 @@
 .hlc-price {
   font-family: var(--font-numeric);
   font-size: var(--text-data-xl);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -0.02em;
+  font-weight: var(--weight-bold);
+  color: var(--color-ink-data);
+  font-variant-numeric: tabular-nums lining-nums slashed-zero;
+  font-feature-settings: var(--font-numeric-features);
+  letter-spacing: var(--tracking-tight);
 }
 
 .hlc-stat-value,

--- a/styles/partials/price-display.css
+++ b/styles/partials/price-display.css
@@ -18,15 +18,18 @@
 }
 
 .price-kind--reference {
-  color: var(--text-accent);
+  color: var(--color-gold-deep);
   background: var(--color-gold-tint);
-  border: 1px solid color-mix(in srgb, var(--color-gold) 35%, transparent);
+
+  /* De-metallised "certified mark": one flat low-alpha gold edge, no foil/gradient */
+  border: 1px solid color-mix(in srgb, var(--color-gold) 30%, transparent);
 }
 
 .price-kind--retail {
-  color: var(--color-gold-deep);
-  background: linear-gradient(135deg, var(--color-gold-bg) 0%, var(--surface-secondary) 100%);
-  border: 1.5px solid color-mix(in srgb, var(--color-gold) 50%, transparent);
+  /* Subordinate to reference: flat muted, no gold gradient, no thick gold border */
+  color: var(--color-text-muted);
+  background: var(--surface-secondary);
+  border: 1px solid var(--border-subtle);
 }
 
 /* ── Price hero block ── */
@@ -61,10 +64,10 @@
 .cp-hero .cp-price-value,
 .order-price-badge {
   font-family: var(--font-numeric);
-  font-variant-numeric: tabular-nums lining-nums;
-  font-feature-settings: var(--font-feature-tabular);
-  font-weight: var(--weight-extrabold);
-  color: var(--text-primary);
+  font-variant-numeric: tabular-nums lining-nums slashed-zero;
+  font-feature-settings: var(--font-numeric-features);
+  font-weight: var(--weight-bold);
+  color: var(--color-ink-data);
   line-height: var(--leading-none);
   letter-spacing: var(--tracking-tight);
 }
@@ -280,9 +283,10 @@
 
 /* Retail estimate surfaces — visually distinct from reference hero cards */
 .cp-mi-stat--retail {
-  border: 1.5px solid color-mix(in srgb, var(--color-gold) 55%, transparent);
-  background: linear-gradient(160deg, var(--color-gold-bg) 0%, var(--surface-secondary) 100%);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-gold) 12%, transparent);
+  /* Retail estimate: subordinate to the reference cards — flat, muted, no gold, no ring */
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-secondary);
+  box-shadow: none;
 }
 
 .cp-mi-stat--retail .cp-mi-label::after {

--- a/styles/partials/tokens.css
+++ b/styles/partials/tokens.css
@@ -11,20 +11,21 @@
   color-scheme: light;
 
   /* ── Phase 1: Richer background layers — warm parchment ── */
-  --color-bg: #fefcf7;
+  --color-bg: #fdfbf5; /* Phase 1: parchment cooled ~1.5% off "cream" toward "paper" */
   --color-surface: #fff;
   --color-surface-2: #faf7ee;
   --color-surface-3: #f3eedd;
-  --color-border: #e4d9c0;
+  --color-border: #d9cfb6; /* Phase 1: calmed warm-tan rule colour */
   --color-border-subtle: #ece5d2;
 
   /* ── Phase 2: Deeper warm ink text ── */
   --color-text: #15110a;
   --color-text-muted: #6a5c48;
   --color-text-faint: #6f6350; /* WCAG AA ≥4.5:1 on all light surfaces incl. surface-3 (≈5:1 headroom) */
+  --color-ink-data: #0f0c06; /* Phase 1: darkest mark on the page — live spot price value + tracker readout (≈18.7:1 on bg) */
 
   /* ── Phase 3: Richer metallic gold palette ── */
-  --color-gold: #c4902e;
+  --color-gold: #b07d1f; /* Phase 1: desaturated/deepened struck-metal gold — value signal only, never a fill; only ever a graphical object (dot/ring/border) at ≥3:1, never small text */
   --color-gold-light: #ddb040;
   --color-gold-bright: #f0ca5c;
   --color-gold-dark: #7e5912; /* text/accent gold — darkened for AA on tinted surfaces (surface-2/3) */
@@ -200,7 +201,8 @@
   /* ── Typography — modular scale (ratio 1.25 from 16px base) ── */
   --type-ratio: 1.25;
   --type-base: 1rem;
-  --font-latin: 'Source Sans 3', system-ui, -apple-system, blinkmacsystemfont, 'Segoe UI', sans-serif;
+  --font-latin:
+    'Source Sans 3', system-ui, -apple-system, blinkmacsystemfont, 'Segoe UI', sans-serif;
   --font-arabic: 'Cairo', 'Source Sans 3', system-ui, sans-serif;
   --font-main: var(--font-latin);
   --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
@@ -218,7 +220,10 @@
   --text-lg: calc(var(--type-base) * var(--type-ratio));
   --text-xl: calc(var(--type-base) * var(--type-ratio) * var(--type-ratio));
   --text-2xl: calc(var(--type-base) * var(--type-ratio) * var(--type-ratio) * var(--type-ratio));
-  --text-3xl: 2.4375rem;
+  --text-3xl: calc(
+    var(--type-base) * var(--type-ratio) * var(--type-ratio) * var(--type-ratio) * var(--type-ratio)
+  ); /* Phase 1 fix: ×1.25^4 ≈ 2.441rem — restores the modular ratio (was hand-set 2.4375) */
+
   --text-4xl: 3.0625rem;
   --text-5xl: 3.8125rem;
   --text-6xl: 4.75rem;
@@ -343,7 +348,11 @@
   --text-data-sm: var(--text-base);
   --text-data-md: var(--text-xl);
   --text-data-lg: clamp(1.95rem, 3.6vw, 2.75rem);
-  --text-data-xl: clamp(2.5rem, 4.8vw, 3.85rem);
+  --text-data-xl: clamp(
+    2.6rem,
+    5vw,
+    3.9rem
+  ); /* Phase 1: hero spot price (caps the old 5.25rem/800 .hlc-price override) */
 
   /* Component primitive tokens */
   --control-height: 44px;
@@ -359,6 +368,22 @@
   --badge-height: 28px;
   --section-fade-height: 48px;
   --section-gap: var(--space-6);
+
+  /* ── Phase 1 redesign — Precision Instrument tokens (see redesign/DESIGN-SYSTEM.md) ── */
+  --color-rule: var(
+    --color-border
+  ); /* the single structural seam — readout spot/retail divider, table baseline */
+
+  --readout-radius: var(
+    --radius-lg
+  ); /* hero live-price readout corner (16px — sharper than 2xl=28) */
+
+  --readout-chrome: var(--shadow-md); /* the hero readout's entire elevation budget */
+  --rim-inset:
+    inset 0 1px 0 rgb(255 255 255 / 70%), inset 0 -1px 0 rgb(21 17 10 / 8%); /* struck/milled edge — block-axis only, no RTL mirroring */
+
+  --font-numeric-features:
+    'tnum' 1, 'lnum' 1, 'zero' 1; /* tabular + lining + slashed-zero — the data voice, zero new font bytes */
 }
 
 /* ═══════════════════════════════════════════════
@@ -380,6 +405,7 @@
   --color-text: #f2eedd;
   --color-text-muted: #a09890;
   --color-text-faint: #8f857a; /* WCAG AA ≥4.5:1 on all dark surfaces incl. surface-3 */
+  --color-ink-data: #f7f3e6; /* Phase 1: brightest readout ink on dark — live spot price value */
   --color-gold: #ddb040;
   --color-gold-light: #f0ca5c;
   --color-gold-bright: #fad97a;
@@ -447,6 +473,9 @@
   --shadow-gold-lg: 0 8px 36px rgb(221 176 64 / 32%), 0 3px 12px rgb(221 176 64 / 18%);
   --shadow-gold-xl: 0 16px 56px rgb(221 176 64 / 38%), 0 6px 20px rgb(221 176 64 / 22%);
   --shadow-card-hover: 0 14px 44px rgb(0 0 0 / 55%), 0 4px 12px rgb(0 0 0 / 28%);
+  --rim-inset:
+    inset 0 1px 0 rgb(255 255 255 / 6%), inset 0 -1px 0 rgb(0 0 0 / 40%); /* Phase 1: struck edge on dark */
+
   --gradient-surface: linear-gradient(180deg, #0c0e14 0%, #090b10 100%);
   --gradient-paper: linear-gradient(180deg, #0c0e14 0%, #08090e 100%);
   --gradient-hero-light: linear-gradient(160deg, #08090e 0%, #0e1326 40%, #121830 100%);
@@ -484,6 +513,7 @@
     --color-text: #f2eedd;
     --color-text-muted: #a09890;
     --color-text-faint: #8f857a;
+    --color-ink-data: #f7f3e6; /* Phase 1: readout ink for no-JS dark-OS first paint */
     --color-gold: #ddb040;
     --color-gold-light: #f0ca5c;
     --color-gold-bright: #fad97a;

--- a/sw.js
+++ b/sw.js
@@ -11,8 +11,8 @@
  * Deployment base path: '/' (custom domain goldtickerlive.com).
  */
 
-const CACHE_NAME = 'goldtickerlive-v17';
-const RUNTIME_CACHE = 'goldtickerlive-runtime-v17';
+const CACHE_NAME = 'goldtickerlive-v18';
+const RUNTIME_CACHE = 'goldtickerlive-runtime-v18';
 
 // Static assets to pre-cache on install — kept intentionally small.
 // Country/city/guide pages are added lazily to RUNTIME_CACHE on first visit.


### PR DESCRIPTION
## Summary

Implements Phase 2 of the design system overhaul: rebuilds the signature live-price readout as a Precision Instrument (flat parchment panel, struck rim, one shadow, explicit freshness state word) and fixes the active spot-vs-retail invariant violation by removing gold gradients and thick borders from retail surfaces.

**Key changes:**
- **Priority 0 (Invariant fix):** Removes gold gradient + 1.5px gold border from `.price-kind--retail` and `.cp-mi-stat--retail` across all surfaces, making retail provably subordinate via four independent signals (ink weight, fill, border mass, label + position).
- **Priority 1 (Signature readout):** Collapses `.hero-live-card` chrome to design-system budget (`--readout-radius` 16px + `--rim-inset` struck edge + `--readout-chrome` one shadow-md); removes backdrop-blur, foil rule, corner glow, hover-lift, and gold-glow stacks. Adds explicit freshness state word (LIVE/DELAYED/CACHED/STALE/UNAVAILABLE) on the readout's second line.
- **Typography:** Re-points shared price primitive (`.price-hero__value`, `.hlc-price`, `.cp-hero .cp-price-value`) to `--color-ink-data` (darkest mark) + `--weight-bold` (retires faux-800) + `slashed-zero` numeric feature.
- **Token tuning:** Cools `--color-bg` ~1.5% (#fefcf7 → #fdfbf5), calms `--color-border` (#e4d9c0 → #d9cfb6), introduces `--color-ink-data` (#0f0c06) for data voice.
- **RTL positive:** Deletes the only non-mirroring physical-prop code paths (`top/left/right`) in the hero.
- **Dark mode:** All changes use tokens with existing dark overrides; dark theme inherits flat treatment automatically.

**Files touched (apply order):**
1. `styles/partials/tokens.css` — token tuning
2. `styles/partials/price-display.css` — reference chip de-metallise + retail chip flatten + shared price primitive re-voice
3. `styles/pages/home.css` — hero chrome collapse, title demotion, trust-line simplification, dark/LIVE variant cleanup
4. `styles/country-page.css` — retail card cascade defense-in-depth
5. `src/pages/home.js` — freshness word wiring
6. `index.html` — retail row markup + emoji cleanup
7. `sw.js` — cache version bump
8. `.stylelintrc.json` — custom-property-pattern rule

**Verification:** All edits tagged VERIFIED (exact lines read) except JS retail-render wiring and per-site replacement values (flagged UNVERIFIED, must confirm at implementation).

**Hard invariants upheld:**
- AED peg 3.6725, troy oz 31.1035 — untouched
- STRICT spot-vs-retail subordination — retail smaller/muted/`est.`/below rule, never equal-or-greater weight
- Freshness always visible with explicit state WORD, never colour alone
- No fabricated data
- EN/AR parity + RTL via logical properties only
- Static-first vanilla ES6 + Vite

## Implementation notes

- Phase 2 is greenfield **application** of Phase 1 tokens already present in `styles/partials/tokens.css`. No raw hex introduced anywhere.
- `styles/partials/price-display.css` is shared, unbundled CSS loaded by 263 country pages + `/chart/`. No generated HTML is hand-edited; retail card is JS-injected at runtime.
- `styles/pages/home.css` is loaded only by `index.html`; all home-hero/decorative edits scoped to homepage.
- `index.html` is already `/` in `sw.js PRECACHE_URLS`; no top-

https://claude.ai/code/session_015YSkYVHrMnUGApr1RaWyng

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect trust-critical homepage and unbundled `price-display.css` / `country-page.css` on many country pages (visual regression risk) but do not touch pricing math or peg constants.
> 
> **Overview**
> Delivers **Phase 2** of the warm-parchment redesign: the homepage live-price readout and shared price surfaces are restyled as a calmer “Precision Instrument,” and retail is visually demoted relative to spot/reference everywhere those primitives apply.
> 
> **Trust & pricing presentation.** Retail chips and country `.cp-mi-stat--retail` cards lose gold gradients and heavy gold borders in favor of flat muted surfaces so retail cannot outweigh reference. Shared price typography moves to **`--color-ink-data`**, **bold (not extrabold)**, and **slashed-zero** tabular numerals. The hero freshness line now includes an explicit **state word** (`LIVE` / `DELAYED` / etc.) on initial render and on the 1s timer tick, not only color/dot.
> 
> **Home hero.** `.hero-live-card` drops blur, foil rules, corner glows, hover lift, and gold shadow stacks in favor of **`--readout-radius`**, **`--rim-inset`**, and a single **`--readout-chrome`** shadow. Decorative hero orbs, parallax JS, badge-glow, and the freshness-banner ⚡ are removed. A muted **retail disclaimer row** (rule + i18n label + “How retail differs” link) sits under the readout; EN/AR keys were added. Karat-strip stale/amber labels use **`--color-warning-text`** for AA; the copy button target is **24px**.
> 
> **Tokens & rollout.** `tokens.css` adds readout tokens, cools the canvas/border slightly, retunes light gold, fixes **`--text-3xl`** on the modular scale, and bumps **`sw.js`** to **v18**. Stylelint gains a **`custom-property-pattern`** rule. Large **`redesign/`** audit/design/plan docs and Playwright screenshot helpers are added for governance/QA—not runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb2d37af8651659f870da22e7fdf25fe9bdef90b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->