### PR TITLE
fix(ci): unblock GitHub Pages deploy (stale SEO inventory) — publishes the backlog of merged PRs

### DIFF
--- a/reports/seo/inventory.json
+++ b/reports/seo/inventory.json
@@ -428,7 +428,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "WebApplication"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null
@@ -12483,7 +12484,8 @@
         }
       ],
       "jsonLdTypes": [
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "WebApplication"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null


### PR DESCRIPTION
## Summary

The live site has not been updating because **the `Deploy to GitHub Pages` workflow has been failing on every push since ~07:52 UTC**, so merged work never reaches production.

Root cause (from the failed deploy logs on the #466 merge): `npm run validate` runs all the way through and then fails at the last step group:

```
[inventory-seo:check] reports/seo/inventory.json is stale.
Run `node scripts/node/inventory-seo.js` and commit.
##[error]Process completed with exit code 1.
```

The committed SEO inventory snapshot drifted out of sync with the live page set, and `inventory-seo --check` (part of `validate`, which the deploy gates on) rejects it. This blocked **every** deploy, not just one PR.

**This is a pre-existing `main` breakage — not caused by any single feature PR.** The same Deploy job failed on:
- `906ce38` — merge of **#465** (08:46)
- `4f315fa` — scheduled run (09:11)
- `520505f` — merge of **#466** (09:15, icon system)

Last green deploy was `3ed9963` at **07:52**, so the production site is frozen there. **Merging this PR makes `validate` pass end-to-end → the deploy succeeds → every PR merged since 07:52 (incl. #465 and #466's icon/flag/imagery work) publishes to the live site in one shot.** No manual re-application of those PRs is needed; they are already in `main`.

## Implementation notes

- Regenerated `reports/seo/inventory.json` via `node scripts/node/inventory-seo.js` (the exact remediation the check prints). Diff is 4 lines — **no page content, canonical, hreflang, or schema changes** — purely refreshing the snapshot the gate compares against.

> Heads-up: SEO inventory can drift again whenever pages change without re-running the generator. A longer-term option is to regenerate it inside the build step so the snapshot can never go stale; happy to do that as a follow-up if you want.

## Checklist
- [x] `npm run validate` passes end-to-end locally (exit 0), including `inventory-seo --check` and `sync-icon-sprite --check`
- [x] Diff is the inventory snapshot only — no runtime, pricing, schema, or copy changes

## Test Plan
- Ran `node scripts/node/inventory-seo.js` then `npm run validate` → exit 0.
- After merge, the `Deploy to GitHub Pages` run on the merge commit should pass and publish the current `main` (which already contains #465 + #466).

## Gold provider bakeoff checklist

N/A — this PR does not touch the gold provider adapters, bakeoff scripts, the X duplicate-post guard, or production gold-price workflows.

---

Follow-on polish (nav page-body de-emoji + the review-suggested parity fixes: search-result flags, AR aria-labels, mobile "More"→"Menu") will be stacked as additional commits on this branch — but **this deploy fix stands alone and is safe to merge now** to get the site updating again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5TfF5PosiPdzAkFG7reVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5TfF5PosiPdzAkFG7reVH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Snapshot-only change to a generated report file; no runtime, pricing, or page content changes.
> 
> **Overview**
> **Regenerates `reports/seo/inventory.json`** so `inventory-seo --check` (inside `npm run validate`) matches the current built pages and **GitHub Pages deploy can pass again**.
> 
> The snapshot diff only updates recorded **`jsonLdTypes`** for **`compare.html`** and **`tracker.html`**: each entry now lists **`WebApplication`** alongside **`BreadcrumbList`**, aligning the inventory with structured data already on those pages. No HTML, copy, canonical, or hreflang edits in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0392d523faaf11fe1a2a2a30175738f73a0da8c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->