### PR TITLE
Revamp planning: audit + 50-phase execution pack

### DIFF
--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -1,0 +1,39 @@
+# Agent workflows
+
+Reusable multi-agent [Workflow](https://docs.claude.com/claude-code) scripts tailored to this repo's
+recurring, trust-critical work. Invoke from Claude Code **at the repo root** with the `Workflow`
+tool.
+
+## Available
+
+| Workflow             | What it does                                                                                                                                                                                                                                                  | Invoke                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| **`pre-pr-review`**  | Runs the repo verification suite (`validate` + `test` + `lint`), then fans out adversarial reviewers over the branch diff across **correctness / trust-integrity / SEO / i18n-RTL-a11y**, verifies each finding before reporting, and returns a **go/no-go**. | `Workflow({ name: 'pre-pr-review' })` (or `{ name, args: 'origin/main' }` to set the base) |
+| **`audit-reverify`** | Classifies a list of audit/plan findings **OPEN / PARTIAL / FIXED / NOT_A_BUG** against _current_ code with `file:line` evidence + a minimal safe fix. Stops you shipping no-op PRs for already-fixed items.                                                  | `Workflow({ name: 'audit-reverify' })` or `{ name, args: [{key,title,focus}, …] }`         |
+
+Both are pure JavaScript using the Workflow DSL (`agent` / `parallel` / `pipeline` / `phase` /
+`log`). They spawn read-only sub-agents; `pre-pr-review` runs the repo's own npm checks via a
+sub-agent (no mutation of tracked files).
+
+### Why these exist
+
+This repo's bar is **trust + clarity** (spot vs retail, AED peg 3.6725, freshness labelling, EN/AR
+parity, SEO governance). These two workflows encode the loop that's worked well here:
+
+1. **Verify before you fix** — `audit-reverify` (the repo evolves fast; many "open" items are
+   already fixed).
+2. **Verify before you ship** — `pre-pr-review` (run the suite + an adversarial review, get a
+   go/no-go) before every PR.
+
+## Routine (optional, recommended)
+
+A daily **PR + green-main babysitter** keeps the PR queue and `main` test health visible. To enable
+it, run the `/schedule` skill in Claude Code (or ask Claude to "schedule a daily PR babysitter"),
+with a prompt like:
+
+> Check open PRs on vctb12/GoldTickerLive: for each, report CI status and whether it's mergeable.
+> Then run `npm test` on `main` and report if the suite is red (with failing test names). Summarize
+> as a short digest. Don't change code.
+
+Suggested cadence: weekday mornings (`0 8 * * 1-5`). Delete it any time with the schedule skill /
+`CronDelete`.

--- a/.claude/workflows/audit-reverify.js
+++ b/.claude/workflows/audit-reverify.js
@@ -1,0 +1,66 @@
+export const meta = {
+  name: 'audit-reverify',
+  description:
+    'Re-verify a list of audit/review findings against the CURRENT GoldTickerLive code. Returns OPEN / PARTIAL / FIXED / NOT_A_BUG per item with file evidence and a minimal safe fix — so you never ship a no-op PR for an already-fixed item.',
+  whenToUse:
+    'Before executing a batch of fixes from an older audit/plan. Pass args as a JSON array of items: [{ "key": "...", "title": "...", "focus": "what to check + where to look" }]. With no args it re-checks the docs/revamp audit items.',
+  phases: [{ title: 'Reverify', detail: 'one agent per item, code-level verdict' }],
+};
+
+const DEFAULT_ITEMS = [
+  {
+    key: 'ar-indexable',
+    title: 'Arabic /ar/ indexability',
+    focus:
+      'Is the /ar/ homepage a real indexable page (no noindex, self-canonical /ar/, hreflang ar→/ar/), or a noindex stub redirecting to ?lang=ar? Check ar/index.html, index.html hreflang, src/seo/hreflang.js, build/generatePages.js.',
+  },
+  {
+    key: 'freshness',
+    title: 'Freshness labelling integrity',
+    focus:
+      'Does any component show "Live" on stale data, or a badge/ticker disagree on state for the same data? Check src/lib/formatter.js, src/lib/freshness.js, src/lib/realtime-pricing-engine.js, the ticker components.',
+  },
+  {
+    key: 'trust-retail',
+    title: 'Spot vs retail separation',
+    focus:
+      'Is any reference/spot price presented without making clear it is not a retail/jewelry quote? Check homepage, calculator, country pages, methodology.',
+  },
+];
+
+const items = Array.isArray(args) && args.length ? args : DEFAULT_ITEMS;
+
+const CTX = `Repo: GoldTickerLive (run from the repo root; if cwd is not the repo, \`cd ~/GoldTickerLive\`). Bilingual EN/AR static gold-price site (vanilla ES6 + Vite, Express, Supabase). The item below was flagged earlier, but the repo is actively worked on, so it may ALREADY be fixed. Open the CURRENT files and determine the true status. Read-only — do not modify. Cite exact \`file:line\` evidence. If OPEN/PARTIAL, give the smallest safe fix that won't trip the repo's checks (check-seo-meta, seo-governance, check-shell-guard, check-freshness-metadata, lint, vite build). Use docs/REPO-MAP.md to navigate fast.`;
+
+phase('Reverify');
+const results = await parallel(
+  items.map(
+    (it) => () =>
+      agent(`${CTX}\n\nITEM: ${it.title || it.key}\nFocus: ${it.focus || ''}`, {
+        label: `reverify:${it.key || (it.title || 'item').slice(0, 20)}`,
+        phase: 'Reverify',
+        agentType: 'Explore',
+        schema: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['item', 'status', 'confidence', 'evidence', 'minimalFix', 'risk'],
+          properties: {
+            item: { type: 'string' },
+            status: { type: 'string', enum: ['OPEN', 'PARTIAL', 'FIXED', 'NOT_A_BUG'] },
+            confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+            evidence: { type: 'array', items: { type: 'string' } },
+            minimalFix: { type: 'string' },
+            risk: { type: 'string', enum: ['low', 'med', 'high'] },
+          },
+        },
+      }).then((r) => ({ key: it.key, ...r }))
+  )
+);
+
+const ok = results.filter(Boolean);
+const open = ok.filter((r) => r.status === 'OPEN' || r.status === 'PARTIAL');
+log(
+  `audit-reverify: ${ok.length} checked · ${open.length} genuinely open (${open.map((o) => o.key).join(', ') || 'none'}) · ${ok.length - open.length} already fixed / not-a-bug`
+);
+
+return { results: ok, open };

--- a/.claude/workflows/pre-pr-review.js
+++ b/.claude/workflows/pre-pr-review.js
@@ -1,0 +1,132 @@
+export const meta = {
+  name: 'pre-pr-review',
+  description:
+    'Pre-PR gate for GoldTickerLive: run the repo verification suite, then adversarially review the branch diff across correctness / trust / SEO / i18n-RTL / a11y, and return a go/no-go.',
+  whenToUse:
+    'Before opening any PR. Run from the repo root on your feature branch. Pass the base branch as args (default "origin/main").',
+  phases: [
+    { title: 'Verify', detail: 'npm run validate + npm test + npm run lint' },
+    { title: 'Review', detail: 'parallel reviewers, one per dimension, over the diff' },
+    { title: 'Confirm', detail: 'adversarially verify each finding before reporting' },
+  ],
+};
+
+const BASE = typeof args === 'string' && args.trim() ? args.trim() : 'origin/main';
+
+const CTX = `You are reviewing a change on the GoldTickerLive repo (run from the repo root; if your cwd is not the repo, cd to it first — try \`cd ~/GoldTickerLive\`). It is a bilingual EN/AR static gold-price site (vanilla ES6 + Vite, Express, Supabase, ~390 pages). NON-NEGOTIABLES: spot/reference price must never read as retail; AED/USD peg is 3.6725; non-live values must stay labelled (live/delayed/cached/stale/fallback/unavailable); RTL + hreflang + canonical + JSON-LD are first-class. The branch diff under review is \`git diff ${BASE}...HEAD\` (also useful: \`git diff ${BASE}...HEAD --stat\`).`;
+
+phase('Verify');
+const verify = await agent(
+  `${CTX}\n\nRun the repo's own verification suite and report results precisely. Run, in order, capturing the REAL exit code of each (do not pipe through tail/head — that masks exit codes):\n- \`npm run validate\`  (read-only governance: SEO/schema/shell-guard/a11y/unsafe-dom)\n- \`npm test\`  (node --test)\n- \`npm run lint\`  (eslint)\nFor npm test, list any failing test names and whether they also fail on ${BASE} (check out ${BASE} in a scratch worktree or compare known-red tests — a pre-existing red main is not this branch's fault). Report which suites passed, which failed, and the failing test names with a one-line cause each.`,
+  {
+    label: 'verify:suite',
+    phase: 'Verify',
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['validate', 'test', 'lint', 'newFailuresFromThisBranch', 'notes'],
+      properties: {
+        validate: { type: 'string', enum: ['pass', 'fail', 'skipped'] },
+        test: { type: 'string', enum: ['pass', 'fail', 'skipped'] },
+        lint: { type: 'string', enum: ['pass', 'fail', 'skipped'] },
+        newFailuresFromThisBranch: { type: 'array', items: { type: 'string' } },
+        notes: { type: 'string' },
+      },
+    },
+  }
+);
+
+const DIMENSIONS = [
+  {
+    key: 'correctness',
+    focus:
+      'Logic bugs, regressions, broken imports/exports, null/undefined hazards, event-listener or state-capture mistakes (e.g. a value captured once in a closure that should be read live). Does the change do what its message claims without breaking adjacent behaviour?',
+  },
+  {
+    key: 'trust-integrity',
+    focus:
+      'Price/trust integrity: spot vs retail separation; AED peg 3.6725 untouched; freshness labelling (live/delayed/cached/stale/fallback/unavailable) preserved; no unlabelled stale/estimated value presented as live; karat math (XAU/USD ÷ 31.1035 × karat/24 × FX) intact.',
+  },
+  {
+    key: 'seo',
+    focus:
+      'SEO: canonical (one per page, production host), hreflang EN/AR pairing and /ar/ vs ?lang=ar consistency, JSON-LD validity, sitemap/noindex governance. Will this change get flagged by check-seo-meta / seo-governance / inject-schema --check?',
+  },
+  {
+    key: 'i18n-rtl-a11y',
+    focus:
+      'Bilingual EN/AR + RTL + accessibility: hard-coded user-facing strings that should come from translations/NAV_DATA; numerals/bidi; dir=rtl correctness; landmark/heading/contrast/focus regressions; safe-dom usage (el()/no raw innerHTML).',
+  },
+];
+
+phase('Review');
+const reviewed = await pipeline(
+  DIMENSIONS,
+  (d) =>
+    agent(
+      `${CTX}\n\nReview the diff ONLY through the ${d.key} lens.\nFocus: ${d.focus}\nReport concrete findings tied to \`file:line\` in the diff. Prefer few high-confidence findings over many speculative ones. If clean, return an empty findings array.`,
+      {
+        label: `review:${d.key}`,
+        phase: 'Review',
+        schema: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['dimension', 'findings'],
+          properties: {
+            dimension: { type: 'string' },
+            findings: {
+              type: 'array',
+              items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['title', 'file', 'severity', 'detail'],
+                properties: {
+                  title: { type: 'string' },
+                  file: { type: 'string' },
+                  severity: { type: 'string', enum: ['blocker', 'major', 'minor', 'nit'] },
+                  detail: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      }
+    ),
+  // Verify each finding adversarially as soon as its dimension is reviewed.
+  (review) =>
+    parallel(
+      (review.findings || []).map(
+        (f) => () =>
+          agent(
+            `${CTX}\n\nAdversarially VERIFY this review finding against the actual diff + surrounding code. Try to REFUTE it. Default to refuted=true if you cannot clearly confirm it is real and caused by this change.\nFinding: [${f.severity}] ${f.title} (${f.file})\n${f.detail}`,
+            {
+              label: `confirm:${f.file}`,
+              phase: 'Confirm',
+              schema: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['real', 'reason'],
+                properties: { real: { type: 'boolean' }, reason: { type: 'string' } },
+              },
+            }
+          ).then((v) => ({ ...f, confirmed: !!(v && v.real), why: v ? v.reason : 'verifier died' }))
+      )
+    )
+);
+
+const confirmed = reviewed
+  .flat()
+  .filter(Boolean)
+  .filter((f) => f.confirmed);
+
+const blockers = confirmed.filter((f) => f.severity === 'blocker' || f.severity === 'major');
+const suiteGreen =
+  verify && verify.validate !== 'fail' && verify.test !== 'fail' && verify.lint !== 'fail';
+const noNewFailures = !verify || (verify.newFailuresFromThisBranch || []).length === 0;
+const go = suiteGreen && noNewFailures && blockers.length === 0;
+
+log(
+  `pre-pr-review: ${go ? 'GO ✅' : 'NO-GO ⛔'} — suite ${suiteGreen ? 'green' : 'RED'}, ${blockers.length} blocker/major, ${confirmed.length} confirmed findings`
+);
+
+return { go, verify, confirmedFindings: confirmed, blockers };

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ country pages, and Arabic-first accessibility.
 > **For coding agents:** start every session with
 > [`prompts/master-rerun.md`](prompts/master-rerun.md), then [`PLAN.md`](PLAN.md) and
 > [`AGENTS.md`](AGENTS.md). Prompt index: [`docs/AI_PROMPT_LIBRARY.md`](docs/AI_PROMPT_LIBRARY.md).
+> Active revamp: [`docs/revamp/`](docs/revamp/) — audit, 50-phase plan,
+> [progress tracker](docs/revamp/PROGRESS.md), [live QA](docs/revamp/qa/). Reusable agent workflows:
+> [`.claude/workflows/`](.claude/workflows/).
 
 <p>
   <a href="https://goldtickerlive.com/">

--- a/docs/revamp/00-AUDIT.md
+++ b/docs/revamp/00-AUDIT.md
@@ -1,0 +1,101 @@
+# GoldTickerLive.com — Live Site Audit & Improvement Plan
+
+**Mode:** Plan only. No code was changed. Findings come from inspecting the live site in-browser on **2026-06-30**.
+**Scope walked:** Homepage (EN, light + dark), `/calculator`, Arabic toggle (RTL), `/methodology`, plus DOM/source, network, and console inspection.
+**Labeling:** Every claim is tagged **[VERIFIED]** (seen on screen or in page source/DOM/network) or **[UNVERIFIED]** (assumption or not fully confirmed in this session).
+
+**Environment note:** The browser window would not shrink below ~792px CSS width in this session, so true phone-width (≤480px) layout is **[UNVERIFIED]**. All other widths and behaviors were observed directly.
+
+---
+
+## 1. Overall assessment
+
+GoldTickerLive is, on the trust dimension, **well above the bar for a gold-price site**. The methodology page is genuinely excellent, the freshness vocabulary is real and applied, spot-vs-retail separation is repeated everywhere, the AED 3.6725 peg is stated and explained, and the site degrades gracefully to an "Unavailable" state with em-dashes instead of faking numbers. RTL is correctly implemented (`dir=rtl`, mirrored layout). The visual style is restrained and credible — cream/near-black in light mode, dark gold in dark mode, Source Sans 3 + Cairo, no clip-art or generic "AI-looking" gradients.
+
+The problems are concentrated in two places: **(a) the bilingual layer is a client-side toggle with no separate indexable Arabic URL and English `<title>`/meta even in Arabic mode — a major SEO/parity gap for a site whose whole pitch is "bilingual EN/AR,"** and **(b) a handful of trust-label and layout details that undercut the otherwise strong trust story** (a 9-minute-old price labeled "Live," two different "current" gold prices on the homepage, a nav that overlaps the logo at tablet widths, and low-contrast muted text in light mode).
+
+None of the fixes require leaving the static architecture. The biggest one (Arabic indexability) is the most involved but is still a static-site, pre-render/duplicate-page job — **no framework migration, SSR, or build-tool swap is recommended.**
+
+---
+
+## 2. What's working (keep / don't regress)
+
+- **[VERIFIED] Methodology page (`/methodology`) is a standout trust asset.** Full formula `Price/g = (XAU/USD ÷ 31.1035) × (karat ÷ 24) × FX`, AED peg rationale (hardcoded 3.6725, API AED value deleted), 5-tier fallback (gold-api → mintedmetal → committed JSON → localStorage → error), freshness states, karat/fineness table, VAT-by-country, DGJG distinction, and a clear disclaimer.
+- **[VERIFIED] Freshness labeling is real and applied.** Homepage flipped `Cached → Live · Updated 30 Jun 2026, 13:34:50 UTC` on auto-refresh; methodology load showed `UNAVAILABLE` with `—` placeholders rather than stale numbers.
+- **[VERIFIED] Spot-vs-retail separation is everywhere** — hero ("Spot-linked reference prices before retail premiums, making charges, and tax"), spot card ("Retail prices add making charges, VAT, and margin"), calculator ("Reference estimate, not a retail shop quote"), country cards.
+- **[VERIFIED] Calculator works and is correct.** 10 g × 22K @ AED 435.37/g produced **AED 4,353.72**; state is shareable via URL (`/calculator?w=10&k=22&c=AED&mode=value`); quick presets (1g/5g/10g/1 tola/1 oz) and bidirectional Weight↔AED mode.
+- **[VERIFIED] RTL is correct.** Arabic toggle sets `lang=ar` + `dir=rtl`, mirrors the full layout (logo right, nav right-to-left, CTA flipped), localizes body copy and the peg/methodology line; the AR preference persists across navigation.
+- **[VERIFIED] Engineering hygiene:** clean console (no errors), self-hosted `woff2` fonts (Source Sans 3 Latin, Cairo Arabic/Latin — no external font request), WebP hero, `:focus-visible` styles present, JSON-LD on homepage (`Organization`, `WebSite`, `FAQPage`), canonical + hreflang tags present.
+
+---
+
+## 3. Prioritized improvements
+
+### P0 — Critical (trust / core SEO)
+
+**P0-1. Arabic has no separately indexable URL, and `<title>`/meta stay English in Arabic mode.**
+- **Problem [VERIFIED]:** The language switch is a client-side `<button>` with no `href`. Toggling to Arabic does **not** change the URL (`urlChanged: no`), and `document.title` remained `Gold Calculator — Value, Scrap, Zakat | Gold Ticker Live` while `lang=ar`/`dir=rtl`. Meanwhile the homepage declares `<link rel="alternate" hreflang="ar" href="/?lang=ar">` — a URL the toggle never actually produces.
+- **Why it matters:** For a site whose differentiator is "bilingual EN/AR," roughly half the content is effectively invisible to search engines: there is no crawlable Arabic page, the Arabic pages share English titles/descriptions, and the hreflang target doesn't match the real toggle mechanism. This is the single highest-leverage fix for Arabic-market discovery (the actual GCC/Arab audience).
+- **Proposed fix (static-friendly):** Pre-render a distinct Arabic URL per page at build time — e.g. `/ar/` and `/ar/calculator.html` (or `/calculator.ar.html`) — each served with `<html lang="ar" dir="rtl">`, Arabic `<title>`/meta description, and **reciprocal** hreflang pairs (`en` ↔ `ar` ↔ `x-default`) whose hrefs are the real static URLs. Keep the in-page toggle as a convenience, but make it navigate to the static AR URL so the crawlable page and the toggle agree. No framework needed — this is a duplicate-page generation step in the existing Vite build.
+
+**P0-2. Canonical strategy is inconsistent (`/` vs `/calculator.html`).**
+- **Problem [VERIFIED]:** Homepage canonical resolves to `/`, but `/calculator` (the live, linked URL) declares canonical `/calculator.html`. So the URL users and internal links use (`/calculator`) is not the canonical the page names.
+- **Why it matters:** Mismatched canonical vs. requested URL invites duplicate-URL ambiguity (`/calculator`, `/calculator.html`, `/calculator?…` all potentially live), splitting signals and risking the wrong URL being indexed on a site where SEO is a first-class concern.
+- **Proposed fix:** Pick one canonical form sitewide (recommend extensionless `/calculator`) and make every page's canonical equal its own clean URL; 301/normalize the `.html` and trailing-slash variants to it. Verify the homepage and inner pages use the *same* convention.
+
+---
+
+### P1 — High (trust + UX correctness)
+
+**P1-1. A 9-minute-old price is labeled "Live."**
+- **Problem [VERIFIED]:** On `/calculator` the top ticker read `05:29:50 PM · 9 min. ago` while the freshness badge read `Live · Updated 30 Jun 2026, 13:29:50 UTC`. The methodology documents a **12-minute** "Stale" threshold, so 9 minutes is technically still "Live" by design.
+- **Why it matters:** The product's core promise is trustworthy freshness. "Live" next to "9 min. ago" reads as self-contradictory and quietly erodes the very trust the rest of the site works hard to build. A 12-minute window for a "Live" claim is generous for a price surface.
+- **Proposed fix:** Tighten the "Live" window (e.g. ≤90s–2min, matching the documented ~90s re-poll), and relabel the intermediate band (≈2–12 min) as **"Delayed"** with the age shown. Keep "Stale" for older. This costs nothing in architecture and makes the badge and the "x min ago" stamp agree.
+
+**P1-2. The homepage shows two different "current" gold prices.**
+- **Problem [VERIFIED]:** The site spot card showed **$4,022.90 / $4,015–$4,022** range, while the embedded TradingView "Gold Price Chart" plotted a last-price marker of **5059.30** on the same screen. Two conflicting "now" prices appear within one viewport.
+- **Why it matters:** On a price-trust site, a visitor who notices the chart says ~5,059 and the headline says ~4,022 has no way to reconcile them — it reads as one of the numbers being wrong. The chart almost certainly uses TradingView's own/independent feed [UNVERIFIED as to cause], but the user can't know that.
+- **Proposed fix:** Either (a) feed the chart from the same gold-api series the rest of the site uses, or (b) clearly label the chart as an independent third-party feed and visually separate it from the official spot value, or (c) pin the chart's last value to the site's spot. Add a one-line freshness/source caption to the chart consistent with the sitewide vocabulary.
+
+**P1-3. Header nav overlaps the logo at tablet / small-laptop widths.**
+- **Problem [VERIFIED]:** At ~792–1240px the desktop nav renders on top of the logo — "Live Prices" overlaps "Gold Ticker Live," and "Discover" overlaps the search icon (mirrored in Arabic: "استكشف" over the logo). At 792px the hamburger toggle (`aria-label="فتح القائمة"`) is `display:none` while 14 desktop nav links are still shown.
+- **Why it matters:** Overlapping header text is the most visible "this site is broken" signal a first-time visitor gets, and it appears across a very common width range (tablets, small laptops, split-screen). It directly contradicts the "premium/trustworthy" goal.
+- **Proposed fix:** Raise the nav collapse breakpoint (switch to the hamburger at ~1024–1100px instead of below 792px), or let the nav wrap/condense before it collides. No new components — the hamburger already exists; it just engages too late.
+
+**P1-4. Muted secondary text fails WCAG AA contrast in light mode.**
+- **Problem [VERIFIED, computed]:** The dominant muted text color is `rgb(160,152,144)` (312 elements). On the light-mode cream background `rgb(253,251,245)` that is ≈ **2.7:1**, below the 4.5:1 AA threshold for normal text. The gold/amber accent `rgb(196,144,46)` on cream is similarly low (~2.8:1) and was used for the "Status: Cached…" banner text, which looked faint.
+- **Why it matters:** Secondary text (subtitles, card descriptions, freshness sub-labels, disclaimers) is exactly the content that carries the trust nuance — it should be the *most* readable, not the least. Low contrast also hurts on mobile in sunlight, common for a UAE/GCC audience.
+- **Proposed fix:** Darken muted text in light mode to meet ≥4.5:1 (e.g. move toward `rgb(110,102,94)` or darker) and verify the amber used for small text/labels on cream; reserve the lighter gold for large headings/icons only. Re-check dark mode separately (the same token reads fine on the dark background).
+
+**P1-5. Inline "Quick convert" reference value rendered blank on first paint.**
+- **Problem [UNVERIFIED]:** On the homepage Quick-convert (10 g, 24K), the "Reference value" row showed only a gold underline with no number in the captured frames. It may populate after the first price fetch or on input; this was not confirmed to persist.
+- **Why it matters:** An empty result in the headline conversion tool, even briefly, reads as broken on the most-seen part of the page and is a layout-shift moment.
+- **Proposed fix:** Confirm whether it populates; if it's waiting on the live fetch, seed it from the cached price immediately (the site already caches in localStorage for exactly this) and label freshness, so a number is always visible on first paint.
+
+---
+
+### P2 — Polish
+
+- **P2-1. `favicon.svg` returns 404. [VERIFIED]** `https://goldtickerlive.com/assets/favicon.svg` → 404 on load. Add the asset (or fix the reference) — a missing favicon is a small but visible polish/trust tell in the browser tab.
+- **P2-2. ~30+ separate JS module chunks on first load. [VERIFIED]** 47 requests including granular modules (`nav`, `footer`, `ticker`, `spotBar`, `reveal`, `count-up`, `freshness-pulse`, `price-motion`, `RealtimeSlaPanel`, etc.) plus an inline `data:` module. All 200, no errors, but consider consolidating the critical-path bundle to reduce request overhead and perceived load on slower mobile connections. **Stay within the current Vite setup** — this is chunking config, not an architecture change.
+- **P2-3. "Quote verification checklist" heading repeats identically on 3 cards. [VERIFIED]** Three side-by-side cards share the exact same H-title with different bullets. Give each a distinct sub-heading (e.g. "On the invoice," "On charges," "Against the reference") or merge into one grouped block.
+- **P2-4. Methodology exposes internal build paths. [VERIFIED]** User-facing copy names `.github/workflows/gold-price-fetch.yml`, `data/gold_price.json`, `data/last_gold_price.json`, and "no API keys in the client bundle." It's not a security leak (no secrets), but for a premium finance brand it reads as internal plumbing. Reframe in user terms ("an automated hourly job refreshes our committed price snapshot") and drop literal repo filenames.
+- **P2-5. Freshness vocabulary isn't 100% consistent across surfaces. [VERIFIED]** The homepage "About Our Prices" card lists `Live, Delayed, Cached/Fallback, Estimated, Historical baseline`; the methodology states box lists `Live / Cached / Delayed / Stale / Fallback`; the ticker also uses `Unavailable`. Unify one canonical set of state names and use it identically everywhere (legend, badges, exports).
+- **P2-6. Numeral system differs between surfaces. [VERIFIED]** EN homepage country cards render Eastern Arabic-Indic numerals (e.g. ٤٣٥.٣٧ with native currency glyphs) while the AR calculator shows Latin digits (435.37). Pick one convention per locale and apply consistently; document the choice.
+- **P2-7. Tracker-handoff text column wraps too narrowly. [VERIFIED]** On `/calculator`, the "Compare this in the live tracker" block wraps ~3 words per line in a narrow left column with large empty space to the right. Widen the text column / rebalance the grid.
+- **P2-8. Mixed-direction (bidi) glitch in helper text. [VERIFIED]** The calculator helper rendered `AED 435.37 د.إ per gram` with the Arabic currency glyph embedded mid-sentence and slightly out of order. Wrap the currency token in an explicit bidi isolate (`<bdi>` / `&#8296;`) to fix ordering in mixed EN/AR strings.
+
+---
+
+## 4. Suggested sequence
+
+1. **P0-1 / P0-2** together (Arabic static pages + canonical normalization) — one SEO workstream, highest impact, fully static.
+2. **P1-1, P1-2, P1-3** — the trust/credibility quick wins (freshness label window, chart price reconciliation, nav breakpoint). Low effort, high perceived-quality return.
+3. **P1-4 / P1-5** — contrast token + ensure the headline converter never shows blank.
+4. **P2** batch — favicon, bundle consolidation, copy/vocabulary consistency, bidi/numeral polish.
+
+---
+
+## 5. One idea beyond the brief (optional)
+
+Because the methodology and freshness system are already this strong, consider surfacing a small, persistent **"freshness + source" chip on every price card** that links straight to the relevant methodology anchor (e.g. spot → `#live-formula`, AED → `#aed-peg`). It turns the site's best asset (transparency) into a repeated trust touchpoint exactly where buyers hesitate, and it's pure internal linking — no new infrastructure. **[suggestion, not a verified gap]**

--- a/docs/revamp/COWORK-TASK.md
+++ b/docs/revamp/COWORK-TASK.md
@@ -1,0 +1,69 @@
+# Cowork task — live-site QA tracker + Wave-6 brand assets
+
+> **Paste this whole block into a Claude Cowork session** (the one with Claude-in-Chrome +
+> Higgsfield). It runs _in parallel_ with the code revamp, which a local Claude Code session is
+> shipping as PRs against `vctb12/GoldTickerLive`. **Do NOT touch the repo.** Save every output to
+> your outputs folder — the Claude Code session will commit them into `docs/revamp/qa/` and
+> `src/assets/brand/`.
+
+---
+
+## Why you (Cowork) and not Claude Code
+
+The Claude Code session has the repo + GitHub and is doing all code/PR work. You have the live
+browser and image/video generation. Do the two things it can't easily do from a headless repo
+checkout: **verify the live site** and **produce brand assets**.
+
+## Part A — Live-site verification tracker (Claude-in-Chrome)
+
+1. Open https://goldtickerlive.com. If the Chrome extension isn't connected, say so and stop.
+2. Walk and screenshot each surface: homepage **EN + AR**, `/calculator` **EN + AR**, one country
+   page (e.g. `/countries/uae/dubai/gold-rate`), `/methodology`, a chart page, and the **404** page.
+   Resize toward ~390px where the environment allows; note if you can't.
+3. Log every issue in one table — **quote real on-screen text/values**, don't paraphrase:
+
+   | Surface | Issue (quote it) | Severity P0/P1/P2 | Trust-impacting? | Maps-to-phase | Screenshot
+   |
+
+   Cross-reference `Maps-to-phase` to the phase numbers in `docs/revamp/phases/`.
+
+4. **Re-verify the original audit's open items** and mark each `STILL-PRESENT` / `FIXED` /
+   `CHANGED`:
+   - canonical `/calculator.html` vs clean `/calculator`
+   - "Live" label shown on stale (>~10 min) data
+   - homepage **chart value vs spot-card value** mismatch
+   - header nav **overlaps logo** ~768–1240px
+   - muted text contrast (~2.7:1) in light mode
+   - quick-convert **blank reference value**
+   - **Arabic not separately indexable** (title/meta stay EN, no distinct URL, hreflang points at a
+     URL the toggle never produces)
+   - `/assets/favicon.svg` **404**
+5. Flag any **NEW** issues not in the original audit → list them as candidate new phases (they'll be
+   appended to `PROGRESS.md`).
+6. Save the table as `cowork-live-qa-tracker.md` plus the screenshots.
+
+## Part B — Wave-6 brand assets (Higgsfield)
+
+On-brand = **premium gold, trustworthy, finance-grade — not generic stock**. Generate:
+
+- **favicon master** — square, one simple gold mark, legible at 16px
+- **OG / Twitter card** — 1200×630, safe area for brand + headline
+- **hero background** — desktop (wide) **and** mobile (9:16)
+- _(optional)_ **5s looping hero video** — muted, subtle motion, with a 4K still as poster (gate
+  behind `prefers-reduced-motion`)
+
+Save each asset + a manifest `cowork-asset-manifest.md` mapping
+`filename → intended use → dimensions/format`. Prefer **WebP/AVIF** for raster.
+
+## Non-negotiables (verify, don't restyle away)
+
+- Spot/reference price **must never** read as a retail/jewelry price.
+- AED/USD peg is **3.6725**.
+- Non-live values (estimated/derived/delayed/fallback/cached) must stay clearly labeled.
+- Static stack only — no framework/SSR/build-tool proposals.
+
+## Handback
+
+Tell the Claude Code session (or the user) when outputs are in your outputs folder. Claude Code will
+commit `cowork-live-qa-tracker.md` → `docs/revamp/qa/`, append new issues to
+`docs/revamp/PROGRESS.md`, and place brand assets under `src/assets/brand/` via their own PRs.

--- a/docs/revamp/MASTER-50-PHASE-PLAN.md
+++ b/docs/revamp/MASTER-50-PHASE-PLAN.md
@@ -1,0 +1,471 @@
+# GoldTickerLive — 50-Phase Revamp Execution Pack
+
+**Purpose:** A complete A-to-Z revamp broken into 50 phases. **Each phase = exactly one PR.** Every phase ships a paste-ready Claude Code prompt you run inside your repo. Phases are ordered so dependencies come first; you can also run any phase standalone.
+
+**Built from:** the live-site audit (`goldtickerlive-audit-plan.md`). Architecture stays static: vanilla ES6 + Vite + Express + Supabase. **No framework migration, no SSR, no build-tool swap** — that guardrail is baked into every prompt.
+
+---
+
+## How to use this pack
+
+1. Open Claude Code in the GoldTickerLive repo, on an up-to-date `main`.
+2. Copy the **PROMPT** block for the phase and paste it in. It already tells Claude Code to read first, branch, implement the smallest correct change, self-verify, and open the PR.
+3. Review the PR, merge, pull `main`, move to the next phase.
+4. Asset phases (43–47) include **Higgsfield generation prompts** — generate the asset, drop it in `/public` or `/src/assets`, then run the phase prompt to wire it in.
+
+**Conventions used in every prompt**
+- Branch: `phaseNN-short-slug` off latest `main`.
+- One PR per phase; PR body must list: what changed, files touched, audit finding addressed, how it was verified, and any risk/rollback.
+- Guardrails (repeat in each): *stay on the current static stack; do not add a frontend framework, SSR, or new build tool; do not change unrelated files; preserve existing working behavior; never label non-live data as live.*
+- Verification: run the existing build + lint + any tests; for UI, take before/after screenshots at 390px, 768px, 1024px, 1440px in both EN and AR; for SEO, validate generated HTML/JSON-LD.
+
+**Shared kickoff prompt (run ONCE before Phase 1)**
+```
+You are doing a phased revamp of GoldTickerLive (static: vanilla ES6 + Vite, Express, Supabase, bilingual EN/AR, ~390 pages, gold price reference site). Trust and clarity are the top priority; spot/reference prices must never be confused with retail; the AED/USD peg is fixed at 3.6725; non-live values must be clearly labeled.
+
+First, with NO code changes, produce a short repo map: where pages are generated, where the nav/footer/ticker shell lives, where the price/FX fetch + freshness logic lives, where i18n/Arabic strings live, where SEO meta/canonical/hreflang/JSON-LD are emitted, the Vite config + build output structure, and how routes map to files. Save it as docs/REPO-MAP.md and open a PR `phase00-repo-map`. Do not change app behavior.
+```
+Run Phase 00 first so later prompts can reference real paths.
+
+---
+
+# WAVE 0 — Foundation & safety (Phases 1–5)
+
+## Phase 1 — Regression safety net
+- **Maps to:** "preserve existing working behavior" guardrail.
+- **Branch:** `phase01-baseline-tests` · **PR:** Add smoke + price-math + freshness tests
+```
+Read docs/REPO-MAP.md and the price/FX/freshness modules. WITHOUT changing app behavior, add a lightweight test harness using the project's existing tooling (or Vitest if none exists) covering: (1) the core price formula (XAU/USD ÷ 31.1035 × karat/24 × FX), asserting 24K/22K/21K/18K and the AED peg 3.6725 produce exact known values; (2) freshness-state resolution (live/delayed/cached/stale/fallback/unavailable) given timestamps; (3) a DOM smoke test that the homepage shell (nav, ticker, footer) mounts. Add an npm script `test`. Do not refactor app code; only add tests + minimal exports if needed. Open PR phase01-baseline-tests with coverage notes. Stay on the current static stack; no framework migration.
+```
+- **Accept:** `npm run build` + `npm test` green; tests fail if the peg or formula is altered.
+
+## Phase 2 — CI pipeline (build + lint + test on PR)
+- **Branch:** `phase02-ci` · **PR:** GitHub Actions CI for PRs
+```
+Read .github/workflows. Add a CI workflow that runs install, build, lint, and the Phase 1 tests on every PR and on main. Do not touch the existing hourly gold-price fetch workflow. Cache node_modules. Fail the PR on build/lint/test errors. Open PR phase02-ci. No app behavior changes; static stack only.
+```
+- **Accept:** CI runs and is required; existing price-fetch cron untouched.
+
+## Phase 3 — Design tokens single source of truth
+- **Maps to:** P1-4 contrast, P2-5 vocabulary, brand consistency.
+- **Branch:** `phase03-design-tokens` · **PR:** Centralize color/spacing/type tokens
+```
+Read the CSS (critical.css, global.css, index.css) and any inline styles. Extract the de-facto design system into a single tokens layer (CSS custom properties): color (light + dark themes), spacing scale, type scale, radii, shadows, z-index, and freshness-state colors. Replace hardcoded hex/spacing in the shared shell (nav/footer/ticker/spot bar) with tokens. DO NOT change visual output yet — this is a refactor; screenshots before/after must match. Document tokens in docs/DESIGN-TOKENS.md. Open PR phase03-design-tokens. Static stack only; no visual regressions.
+```
+- **Accept:** Pixel-equivalent before/after; all shell colors reference tokens.
+
+## Phase 4 — Lighthouse + a11y CI budget (report-only)
+- **Branch:** `phase04-quality-budgets` · **PR:** Lighthouse CI + axe report (non-blocking)
+```
+Add Lighthouse CI and axe-core accessibility checks that run against the built site for homepage, /calculator, /methodology, and one country page, in EN and AR. Output reports as CI artifacts; set them report-only (non-blocking) for now with target budgets (Perf ≥85 mobile, A11y ≥95, CLS <0.1). Do not change app code. Open PR phase04-quality-budgets. Static stack only.
+```
+- **Accept:** Reports generated as artifacts; baselines recorded in PR.
+
+## Phase 5 — Page/route inventory + audit map
+- **Branch:** `phase05-page-inventory` · **PR:** Generate page inventory + redirect/canonical map
+```
+Crawl the built output (or the generation config) and produce docs/PAGE-INVENTORY.csv listing every generated URL, its EN/AR status, current <title>, meta description, canonical, and hreflang. Flag: extensionless vs .html mismatches, missing AR counterpart, duplicate canonicals, and missing meta. This is documentation only — no app changes. Open PR phase05-page-inventory. It will drive Waves 1–2.
+```
+- **Accept:** Complete CSV; flags match audit (canonical `/` vs `/calculator.html`, AR gaps).
+
+---
+
+# WAVE 1 — P0 Bilingual & SEO foundation (Phases 6–14)
+
+## Phase 6 — Canonical strategy normalization
+- **Maps to:** P0-2 (canonical `/` vs `/calculator.html`).
+- **Branch:** `phase06-canonical` · **PR:** One canonical convention sitewide
+```
+Per docs/PAGE-INVENTORY.csv, every page must declare a canonical equal to its own clean, extensionless URL (e.g. https://goldtickerlive.com/calculator). Fix the generator/template so canonicals are self-referential and consistent. Add server/host redirects (or static redirect config) so /calculator.html and trailing-slash variants 301 to the canonical form. Read how canonicals are currently emitted before editing. Open PR phase06-canonical with a table of before/after canonicals. Static stack only.
+```
+- **Accept:** Each page's canonical = its own clean URL; `.html` 301s to clean URL.
+
+## Phase 7 — Distinct Arabic URLs (static pre-render)
+- **Maps to:** P0-1 (Arabic not indexable).
+- **Branch:** `phase07-ar-routes` · **PR:** Generate static `/ar/...` pages
+```
+Today the Arabic experience is a client-side toggle with no separate URL (title/meta stay English). Without leaving the static Vite build, generate a distinct Arabic URL for every page at build time under /ar/ (e.g. /ar/, /ar/calculator, /ar/methodology, /ar/<country>). Each AR page must render server-side HTML with <html lang="ar" dir="rtl">, fully translated visible content reusing the existing AR string set, and the same data/freshness logic. Keep the in-page language toggle but make it NAVIGATE between the EN and AR URLs (not just swap client state). Read the i18n/string modules and the generation pipeline first. Open PR phase07-ar-routes. Do not regress EN pages; static stack only.
+```
+- **Accept:** `/ar/calculator` loads server-rendered Arabic with `lang=ar dir=rtl`; toggle navigates between EN/AR URLs.
+
+## Phase 8 — Localized titles & meta per locale
+- **Maps to:** P0-1 (English title in AR mode).
+- **Branch:** `phase08-localized-meta` · **PR:** Per-locale `<title>`/description/OG
+```
+For every AR page from Phase 7, emit Arabic <title>, meta description, og:title/description/locale (ar_AE), and twitter card. EN pages keep English equivalents with og:locale en_AE plus og:locale:alternate ar_AE. Centralize the per-page, per-locale metadata in one data source so titles/descriptions are authored once. Read how meta is emitted before editing. Open PR phase08-localized-meta. Static stack; no behavior change beyond meta.
+```
+- **Accept:** `document.title` is Arabic on AR pages; OG locale correct both sides.
+
+## Phase 9 — Reciprocal hreflang + x-default
+- **Maps to:** P0-1 (hreflang points to non-existent `/?lang=ar`).
+- **Branch:** `phase09-hreflang` · **PR:** Correct bilingual hreflang pairs
+```
+Replace the current hreflang (which points ar to /?lang=ar that the toggle never produces) with reciprocal, self-consistent pairs on EVERY page: en -> clean EN URL, ar -> the new /ar/ URL, x-default -> EN. Both the EN and AR versions of a page must reference each other identically. Read Phase 6/7 outputs first. Validate all pairs resolve (200, not redirected). Open PR phase09-hreflang with a validation table. Static stack only.
+```
+- **Accept:** Every EN/AR pair cross-references; no hreflang targets 404/redirect.
+
+## Phase 10 — XML sitemap(s) with locale alternates
+- **Branch:** `phase10-sitemap` · **PR:** Build-time sitemap with hreflang
+```
+Generate sitemap.xml (split if >50k URLs) at build time from PAGE-INVENTORY, including every EN and AR clean URL with xhtml:link alternate (hreflang) entries. Add lastmod. Reference it from robots.txt. Do not include redirect/.html variants. Open PR phase10-sitemap. Static stack only.
+```
+- **Accept:** Sitemap lists clean EN+AR URLs with alternates; linked from robots.
+
+## Phase 11 — robots.txt + indexing hygiene
+- **Branch:** `phase11-robots` · **PR:** robots.txt + noindex on thin/util URLs
+```
+Add/curate robots.txt: allow content, point to sitemap, disallow query-param duplicates and any utility endpoints. Ensure parametered URLs (e.g. /calculator?w=10) are canonicalized to the clean page (not separately indexed). Read current robots and how query state is reflected in canonical. Open PR phase11-robots. Static stack only.
+```
+- **Accept:** Param URLs canonicalize to base; sitemap referenced; no content blocked.
+
+## Phase 12 — JSON-LD expansion & validation
+- **Maps to:** strengthens existing Organization/WebSite/FAQPage.
+- **Branch:** `phase12-jsonld` · **PR:** Add/repair structured data
+```
+Audit existing JSON-LD (homepage has Organization, WebSite, FAQPage). Add appropriate schema sitewide: BreadcrumbList on inner pages, WebSite SearchAction, Organization with logo/sameAs, and on price/country pages a suitable Dataset or Product-style schema for the reference price WITH clear "reference price, not retail" semantics (do not imply a purchasable offer/price you don't sell). Localize where relevant. Validate every type against schema.org and Google Rich Results. Read current JSON-LD emission first. Open PR phase12-jsonld. Use the `schema` skill conventions. Static stack only.
+```
+- **Accept:** All pages emit valid JSON-LD; no Rich Results errors; no misleading Offer.
+
+## Phase 13 — AR content parity sweep
+- **Maps to:** P0-1 parity, P2-6 numerals.
+- **Branch:** `phase13-ar-parity` · **PR:** Fill AR translation gaps
+```
+Compare EN vs AR strings across all surfaces; list any untranslated/missing AR copy (headings, buttons, freshness labels, disclaimers, methodology). Fill gaps with proper Arabic (do not leave English fallback visible in AR mode). Decide and document one numeral convention per locale (recommend Arabic-Indic for AR, Latin for EN) and apply consistently. Read the i18n source. Open PR phase13-ar-parity with a parity checklist. Static stack only.
+```
+- **Accept:** No English leakage in AR; numerals consistent per locale.
+
+## Phase 14 — Methodology page localized + indexable (EN/AR)
+- **Branch:** `phase14-methodology-i18n` · **PR:** AR methodology + anchors
+```
+Ensure /methodology and /ar/methodology both exist as indexable pages with full translated content, stable section anchors (#live-formula, #aed-peg, #freshness-states, #disclaimer), and correct meta/hreflang. Keep the (excellent) EN content intact. Open PR phase14-methodology-i18n. Static stack only.
+```
+- **Accept:** Both methodology URLs index; anchors stable for cross-linking (used in Phase 20).
+
+---
+
+# WAVE 2 — Trust & freshness integrity (Phases 15–22)
+
+## Phase 15 — Freshness label thresholds (fix "Live" on stale)
+- **Maps to:** P1-1 (9-min-old shown "Live").
+- **Branch:** `phase15-freshness-thresholds` · **PR:** Tighten Live window, add Delayed band
+```
+Read the freshness-state logic and methodology thresholds. Change the rules so "Live" only applies within ~2 minutes (aligned to the ~90s re-poll); 2–12 min becomes "Delayed" (show age); >12 min "Stale"; failures "Cached/Fallback"; total failure "Unavailable". Update the methodology copy to match the new thresholds. Ensure the top ticker "x min ago" and the badge can never disagree. Add/extend tests from Phase 1. Open PR phase15-freshness-thresholds. Never present non-live data as live.
+```
+- **Accept:** A value older than ~2 min never reads "Live"; badge and "x ago" agree; tests cover bands.
+
+## Phase 16 — Chart price reconciliation
+- **Maps to:** P1-2 (TradingView ~5059 vs spot ~4022).
+- **Branch:** `phase16-chart-source` · **PR:** Reconcile/label homepage chart
+```
+The homepage chart (TradingView) shows a "last" price that differs from the site's spot value, creating two conflicting current prices. Read how the chart is embedded. Implement the cleanest option that keeps the static stack: prefer feeding the chart from the same gold-api series used sitewide; if not feasible, clearly label the chart as an independent third-party feed, visually separate it from the official spot value, and add a freshness/source caption using the sitewide vocabulary. The headline spot must remain the single source of truth. Open PR phase16-chart-source. Static stack only.
+```
+- **Accept:** No two unlabeled conflicting "current" prices; chart has source/freshness caption.
+
+## Phase 17 — Unified freshness vocabulary + legend component
+- **Maps to:** P2-5 (vocabulary drift across surfaces).
+- **Branch:** `phase17-freshness-vocab` · **PR:** One freshness vocabulary everywhere
+```
+Define one canonical freshness vocabulary (Live, Delayed, Cached, Stale, Fallback, Unavailable) with one color token each (from Phase 3). Replace divergent terms (e.g. the "About Our Prices" card mentions "Estimated/Historical baseline"; the states box differs). Build a single reusable FreshnessBadge + a small legend, used by homepage, calculator, country pages, ticker, and exports. Localize labels. Open PR phase17-freshness-vocab. Static stack only.
+```
+- **Accept:** Identical state names/colors on every surface and in CSV/JSON exports.
+
+## Phase 18 — Quick-convert never blank (seed from cache)
+- **Maps to:** P1-5 (blank reference value on first paint).
+- **Branch:** `phase18-quickconvert-seed` · **PR:** Instant cached value + freshness
+```
+On the homepage inline Quick-convert, ensure a numeric reference value is shown on first paint by seeding from the localStorage cached price (the site already caches), labeled with freshness, then updating on live fetch. Eliminate the empty/underline-only state. Add a CLS-safe reserved space for the number. Read the quick-convert + cache modules first. Open PR phase18-quickconvert-seed. Never show a cached number unlabeled.
+```
+- **Accept:** A labeled number always visible immediately; no layout shift when live value lands.
+
+## Phase 19 — Spot-vs-retail trust chip (sitewide)
+- **Maps to:** strengthens core trust promise (audit §5 idea).
+- **Branch:** `phase19-trust-chip` · **PR:** Persistent freshness+source chip linking methodology
+```
+Add a small, consistent "reference price · source · freshness" chip to every price card (homepage spot, calculator result, country cards) that deep-links to the relevant methodology anchor (spot -> #live-formula, AED -> #aed-peg). Reuse FreshnessBadge from Phase 17. Keep it lightweight and accessible. Localize. Open PR phase19-trust-chip. Static stack only.
+```
+- **Accept:** Every price card shows source+freshness and links to methodology; works EN/AR.
+
+## Phase 20 — Methodology copy de-jargon
+- **Maps to:** P2-4 (exposes repo paths).
+- **Branch:** `phase20-methodology-copy` · **PR:** User-facing methodology language
+```
+Rewrite the methodology sections that expose internal build mechanics (.github/workflows/gold-price-fetch.yml, data/gold_price.json, "no API keys in client bundle", localStorage) into user-facing language ("an automated hourly job refreshes our committed price snapshot", "your browser keeps a labeled local copy so you always see a number"). Keep all the substance and transparency; drop literal repo filenames. Apply to EN and AR. Open PR phase20-methodology-copy. Content only.
+```
+- **Accept:** No literal repo paths/workflow filenames in user copy; substance preserved EN+AR.
+
+## Phase 21 — Disclaimer & "not retail" consistency pass
+- **Branch:** `phase21-disclaimer-consistency` · **PR:** Standardize disclaimers
+```
+Audit every surface for the spot-vs-retail / not-financial-advice disclaimer. Standardize one short inline disclaimer + one full disclaimer block, placed consistently (price cards, calculator, country pages, exports, footer). Ensure VAT-by-country and making-charge notes match the methodology figures. Localize. Open PR phase21-disclaimer-consistency. Content + small template edits only.
+```
+- **Accept:** Consistent disclaimer wording/placement sitewide; figures match methodology.
+
+## Phase 22 — Stale/unavailable visual states polish
+- **Branch:** `phase22-degraded-states` · **PR:** Clear degraded-state UI
+```
+Harden the degraded states: when data is Stale/Fallback/Unavailable, show the labeled state, age, and an em-dash for missing numbers (already done on methodology — generalize it) with an accessible, non-alarming style. Ensure no surface ever shows a stale number styled as live. Add tests. Open PR phase22-degraded-states. Static stack only.
+```
+- **Accept:** All surfaces degrade gracefully and identically; tests assert no "live" styling on stale.
+
+---
+
+# WAVE 3 — Layout, responsive & RTL (Phases 23–30)
+
+## Phase 23 — Header nav breakpoint (stop logo overlap)
+- **Maps to:** P1-3 (nav overlaps logo ~792–1240px).
+- **Branch:** `phase23-nav-breakpoint` · **PR:** Raise hamburger breakpoint
+```
+The desktop nav overlaps the logo between ~768px and ~1240px because the hamburger only engages below ~792px. Read the header/nav component + its CSS. Raise the collapse breakpoint (switch to the existing hamburger at ~1024–1100px) or let the nav condense before it collides; verify no overlap of logo, links, search icon, theme toggle, language button, or CTA at 768/900/1024/1200/1280/1440 in BOTH EN and AR (RTL). Open PR phase23-nav-breakpoint with screenshots at those widths in both languages. Static stack only.
+```
+- **Accept:** No header element overlap at any width in EN or AR; hamburger works.
+
+## Phase 24 — Mobile header & ticker density
+- **Branch:** `phase24-mobile-header` · **PR:** ≤480px header/ticker
+```
+Verify and fix the header, the scrolling price ticker, and the status banner at 320/360/390/414px in EN and AR. Ensure tap targets ≥44px, the ticker is readable and pausable, and the status banner is dismissible without covering content. Open PR phase24-mobile-header with mobile screenshots EN/AR. Static stack only.
+```
+- **Accept:** Clean header/ticker at phone widths both languages; 44px targets.
+
+## Phase 25 — Tracker-handoff layout rebalance
+- **Maps to:** P2-7 (narrow text column, big empty space).
+- **Branch:** `phase25-handoff-layout` · **PR:** Rebalance calculator handoff grid
+```
+On /calculator the "Compare this in the live tracker" block wraps ~3 words per line in a narrow column with large empty space. Read the section's grid/flex CSS and rebalance so the text column has a comfortable measure (~60–75ch) and the CTAs sit logically. Check EN + AR. Open PR phase25-handoff-layout. Static stack only.
+```
+- **Accept:** Comfortable line length; balanced layout EN/AR.
+
+## Phase 26 — Bidi isolation for mixed EN/AR strings
+- **Maps to:** P2-8 (`AED 435.37 د.إ per gram` glitch).
+- **Branch:** `phase26-bidi` · **PR:** Wrap currency/number tokens in bidi isolates
+```
+Fix mixed-direction rendering where currency glyphs/numbers are embedded in opposite-direction sentences (e.g. helper text "AED 435.37 د.إ per gram"). Wrap currency/amount tokens in <bdi> / unicode isolates and verify ordering in EN and AR across ticker, cards, calculator helper, exports. Read the formatting/number helper module first. Add a couple of tests. Open PR phase26-bidi. Static stack only.
+```
+- **Accept:** Currency+number tokens order correctly in both directions.
+
+## Phase 27 — Repeated "Quote verification checklist" headings
+- **Maps to:** P2-3.
+- **Branch:** `phase27-checklist-headings` · **PR:** Differentiate or merge checklist cards
+```
+The three "Quote verification checklist" cards share an identical heading. Either give each a distinct sub-heading reflecting its bullets (e.g. "On the invoice", "On the charges", "Against the reference") or merge into one grouped block. Keep content; fix EN + AR. Open PR phase27-checklist-headings. Content/template only.
+```
+- **Accept:** No duplicate identical headings; content intact EN/AR.
+
+## Phase 28 — Country/price page responsive QA
+- **Branch:** `phase28-country-responsive` · **PR:** Country page layout pass
+```
+Pick representative country pages (UAE, Saudi, Kuwait + one MENA + one Global) and QA their layout/tables at 360/768/1024/1440 in EN and AR, fixing overflow, table scroll, and currency-symbol alignment. Apply fixes via the shared template so all ~24 countries benefit. Open PR phase28-country-responsive with screenshots. Static stack only.
+```
+- **Accept:** No overflow/misalignment on sampled pages; fix is template-level.
+
+## Phase 29 — Theme toggle correctness (light/dark/system)
+- **Branch:** `phase29-theme-toggle` · **PR:** Robust theme switching
+```
+Audit the theme toggle: ensure it respects system preference on first load, persists choice, applies before first paint (no flash), and that BOTH themes meet the contrast targets from Phase 30. Verify the toggle icon state matches actual theme. Read the theme module. Open PR phase29-theme-toggle. Static stack only.
+```
+- **Accept:** No theme flash; persisted; icon matches state.
+
+## Phase 30 — Layout-shift (CLS) hardening
+- **Branch:** `phase30-cls` · **PR:** Reserve space for async data
+```
+Identify CLS sources: price values arriving after first paint, the chart loading, the quick-convert number, country cards. Reserve fixed space / use skeletons (the project already has skeleton modules) so numbers swap in without shifting layout. Target CLS <0.1 on homepage, calculator, a country page (per Phase 4 reports). Open PR phase30-cls with before/after CLS numbers. Static stack only.
+```
+- **Accept:** CLS <0.1 on the three pages; values swap without shift.
+
+---
+
+# WAVE 4 — Accessibility (Phases 31–36)
+
+## Phase 31 — Light-mode contrast fix
+- **Maps to:** P1-4 (muted `rgb(160,152,144)` ≈ 2.7:1 on cream).
+- **Branch:** `phase31-contrast` · **PR:** WCAG AA text contrast (light theme)
+```
+Using the Phase 3 tokens, darken muted/secondary text so it meets ≥4.5:1 on the cream light background (current ~2.7:1) and fix small gold/amber label text on cream (~2.8:1). Re-verify dark mode separately. Run axe + a contrast checker on homepage, calculator, methodology, a country page in EN/AR. Open PR phase31-contrast with computed ratios before/after. Use the `a11y-audit` skill conventions. Static stack only.
+```
+- **Accept:** All body/secondary text ≥4.5:1, large text ≥3:1, both themes.
+
+## Phase 32 — Focus states & keyboard nav
+- **Branch:** `phase32-focus-keyboard` · **PR:** Visible focus + full keyboard path
+```
+Ensure every interactive element (nav, hamburger, language/theme toggles, calculator inputs, tabs, chart controls, dismiss buttons) has a visible :focus-visible style and a logical tab order, including in the mobile menu and in RTL. Add skip-to-content link. Test keyboard-only EN/AR. Open PR phase32-focus-keyboard. Static stack only.
+```
+- **Accept:** Keyboard-only operable; visible focus everywhere; skip link present.
+
+## Phase 33 — Semantic structure & landmarks
+- **Branch:** `phase33-semantics` · **PR:** Headings, landmarks, labels
+```
+Audit heading hierarchy (single h1/page, no skipped levels), landmark roles (header/nav/main/footer), and form labels on the calculator. Fix the calculator inputs to have programmatic labels and the tab groups to use proper ARIA tablist semantics. Verify with axe. Open PR phase33-semantics EN/AR. Static stack only.
+```
+- **Accept:** Clean heading outline; labeled inputs; ARIA tabs valid.
+
+## Phase 34 — Screen-reader pass for live prices
+- **Branch:** `phase34-sr-live` · **PR:** aria-live for price/freshness updates
+```
+Make auto-updating prices and freshness changes announce sensibly to screen readers using polite aria-live regions (avoid spamming on every ~1s tick — throttle/announce meaningful changes). Ensure the ticker is labeled and not a focus trap. Test with VoiceOver/NVDA notes. Open PR phase34-sr-live. Static stack only.
+```
+- **Accept:** Meaningful, non-spammy SR announcements; ticker labeled.
+
+## Phase 35 — Reduced motion & animation hygiene
+- **Branch:** `phase35-reduced-motion` · **PR:** Respect prefers-reduced-motion
+```
+The site uses reveal-on-scroll, count-up, price-motion, freshness-pulse. Gate all non-essential animation behind prefers-reduced-motion: reduce (no count-up, no pulsing, instant reveals) while keeping content fully visible. Read the animation modules. Open PR phase35-reduced-motion. Static stack only.
+```
+- **Accept:** With reduced-motion on, no animations; content fully shown.
+
+## Phase 36 — Alt text & non-text content
+- **Branch:** `phase36-alt-text` · **PR:** Decorative vs informative media
+```
+Audit imagery (CSS-background hero, country flags, icons, generated OG assets). Ensure informative graphics have text alternatives and decorative ones are correctly hidden from AT (aria-hidden / empty alt). Country flags should expose the country name. Open PR phase36-alt-text. Static stack only.
+```
+- **Accept:** Flags/icons have correct names or are properly decorative; axe clean.
+
+---
+
+# WAVE 5 — Performance & infra (Phases 37–42)
+
+## Phase 37 — Bundle consolidation
+- **Maps to:** P2-2 (~30+ JS chunks).
+- **Branch:** `phase37-bundle` · **PR:** Consolidate critical-path JS
+```
+The homepage loads ~30+ small JS modules plus an inline data: module. Review the Vite chunking config and consolidate critical-path modules (shell: nav/footer/ticker/spotBar + price/freshness) into fewer, cache-efficient chunks while keeping non-critical features (chart, SLA panel, exports) lazy-loaded. Measure requests + transfer before/after. Do not change behavior. Open PR phase37-bundle. Stay on Vite; no build-tool swap.
+```
+- **Accept:** Fewer critical requests, equal behavior, Perf score not lower.
+
+## Phase 38 — favicon & PWA icon fix
+- **Maps to:** P2-1 (favicon.svg 404).
+- **Branch:** `phase38-favicon` · **PR:** Add favicon + manifest icons
+```
+/assets/favicon.svg returns 404. Add a proper favicon set (SVG + ICO + apple-touch + maskable PNGs) and wire them in <head> and the web manifest. Verify no 404s in network. Open PR phase38-favicon. Static stack only.
+```
+- **Accept:** No favicon 404; tab/PWA icons present.
+
+## Phase 39 — Font loading optimization
+- **Branch:** `phase39-fonts` · **PR:** font-display + preload + subset
+```
+Fonts are self-hosted woff2 (Source Sans 3 + Cairo). Add font-display: swap, preload the critical Latin + Arabic subsets used above the fold, and verify subsetting trims unused glyphs. Avoid FOIT; keep CLS stable with size-adjust if needed. Open PR phase39-fonts. Static stack only.
+```
+- **Accept:** No invisible-text flash; reduced font bytes; CLS unaffected.
+
+## Phase 40 — Image & hero optimization
+- **Branch:** `phase40-images` · **PR:** Responsive images + lazy + dimensions
+```
+Audit images (WebP hero background, flags, generated assets). Serve responsive sizes, set explicit width/height (or aspect-ratio) to prevent CLS, lazy-load below the fold, and preload the LCP image. Add AVIF alongside WebP where it helps. Open PR phase40-images with LCP before/after. Static stack only.
+```
+- **Accept:** LCP image preloaded; below-fold lazy; no CLS from images.
+
+## Phase 41 — Caching, headers & service worker
+- **Branch:** `phase41-caching` · **PR:** Cache headers + offline SW review
+```
+Review Express/static hosting headers: long cache for hashed assets, short/validated cache for HTML, correct content-types. Review the existing service worker/offline behavior so cached prices are served labeled and the SW never serves stale HTML indefinitely. Add a cache-busting/version strategy. Open PR phase41-caching. Static stack only; never serve stale data as live.
+```
+- **Accept:** Correct cache headers; SW serves labeled offline data; HTML updates on deploy.
+
+## Phase 42 — Analytics & consent (privacy-safe)
+- **Branch:** `phase42-analytics-consent` · **PR:** Consent-gated analytics + ad-slot review
+```
+There are analytics scripts and ad slots present. Add a privacy-respectful consent mechanism (region-aware; default to least data), gate analytics/ads behind consent, ensure no PII in URLs, and keep the page fast when consent is denied. Document what is collected in a privacy page (EN/AR). Read current analytics/adSlot modules. Open PR phase42-analytics-consent. Static stack only.
+```
+- **Accept:** Analytics/ads load only after consent; privacy page live EN/AR.
+
+---
+
+# WAVE 6 — Visual & brand polish (Phases 43–47)
+
+> Asset phases. Generate the asset with the **Higgsfield** prompt, commit it, then run the phase prompt to wire it in.
+
+### Asset library (already generated via Higgsfield — on-brand, ready to use)
+
+These are produced and brand-consistent (deep charcoal, antique gold, GCC lattice, no text/logos — safe for text overlay). Download and commit to `/src/assets/brand/`.
+
+| Asset | Use | Ratio / size | URL |
+|---|---|---|---|
+| Heritage hero (4K) | Primary hero / OG base | 16:9 · 5504×3072 | `https://d8j0ntlcm91z4.cloudfront.net/user_3CwVNntXsFJIp1sYyG8gGyvB5Ma/hf_20260629_170603_cb1eaee9-4038-4b89-b006-5374faee4808.png` |
+| Hero w/ faint market glow (4K) | Alt hero / section bg | 16:9 · 5504×3072 | `https://d8j0ntlcm91z4.cloudfront.net/user_3CwVNntXsFJIp1sYyG8gGyvB5Ma/hf_20260629_164252_0c53565e-11c0-4347-8319-081f3bd58232.png` |
+| Molten-gold abstract | Section divider / bg | 16:9 · 2688×1536 | `https://d8j0ntlcm91z4.cloudfront.net/user_3CwVNntXsFJIp1sYyG8gGyvB5Ma/hf_20260630_071122_47c183e8-5980-485b-a55e-ba1c483439f3.png` |
+| Default OG banner | og:image / twitter | 16:9 · 1376×768 | `https://d8j0ntlcm91z4.cloudfront.net/user_3CwVNntXsFJIp1sYyG8gGyvB5Ma/hf_20260630_135029_36799a81-3b2d-48ec-add5-4eb355a72a03.png` |
+| Vertical hero | Mobile hero / story OG | 9:16 · 768×1344 | (job `0e75884a` — rendering) |
+| Animated gold hero loop | Hero background video / social | 16:9 · 5s 720p | `https://d8j0ntlcm91z4.cloudfront.net/user_3CwVNntXsFJIp1sYyG8gGyvB5Ma/hf_20260630_135509_0234b3e1-5213-464d-8ffc-af283e1eaa50.mp4` |
+
+**Usage guidance:** serve hero/section images as WebP+AVIF with explicit dimensions (Phase 40); keep text on the dark left/upper negative space; the 5s loop should be muted, `playsinline`, `loop`, lazy-loaded, and gated by `prefers-reduced-motion` (Phase 35) with a static poster = the 4K heritage hero.
+
+## Phase 43 — Brand/OG social images
+- **Branch:** `phase43-og-images` · **PR:** Default + per-template OG images
+- **Higgsfield prompt (default OG, 1.91:1 / 1200×630):**
+  > "Premium minimalist OG banner for gold-price reference site 'Gold Ticker Live'. Deep charcoal background, warm antique-gold glow lower-right, a restrained stack of gold bullion bars on the right third, large clean negative space on the left for text, editorial fintech look, palette cream / antique gold #C4902E / charcoal, no text, no logo, no charts, soft studio light."
+```
+Add Open Graph/Twitter images: a default brand image plus a small set of template variants (homepage, calculator, country, methodology). Place generated assets under /public (or /src/assets) and wire og:image/twitter:image per page+locale with correct dimensions and alt. Provide an AR variant if text is overlaid later. Read Phase 8 meta wiring. Open PR phase43-og-images. Static stack only.
+```
+- **Accept:** Valid OG image per template+locale; passes social validators.
+
+## Phase 44 — Hero & section imagery refresh
+- **Branch:** `phase44-hero-art` · **PR:** Optimized hero/section art
+- **Higgsfield prompt (hero, 16:9, dark-mode aware):**
+  > "Subtle hero background texture for a gold finance site, near-black with faint gold bullion bokeh and a soft warm gradient, very low-contrast so white/cream text sits cleanly on top, no focal subject, no text, elegant, premium."
+```
+Replace/optimize the hero and key section imagery with on-brand assets that work in BOTH light and dark themes and don't harm text contrast (coordinate with Phase 31). Export WebP+AVIF, set dimensions, preload LCP. Open PR phase44-hero-art with light/dark screenshots. Static stack only.
+```
+- **Accept:** Hero looks premium in both themes; text contrast preserved; no CLS.
+
+## Phase 45 — Micro-interactions & motion polish
+- **Branch:** `phase45-motion-polish` · **PR:** Tasteful, reduced-motion-safe interactions
+```
+Refine the existing animations (price count-up, freshness pulse, reveal) for tasteful, fast, non-janky motion; ensure price changes use a subtle up/down color flash that is colorblind-safe (not color-only). All gated by Phase 35 reduced-motion. Open PR phase45-motion-polish. Static stack only.
+```
+- **Accept:** Smooth, subtle motion; colorblind-safe direction cues; reduced-motion respected.
+
+## Phase 46 — Dark-mode visual QA
+- **Branch:** `phase46-darkmode-qa` · **PR:** Dark theme contrast + surface polish
+```
+Full dark-mode pass across homepage, calculator, methodology, country pages, EN/AR: verify token-based surfaces, borders, freshness colors, and gold accents meet contrast and look intentional (no muddy grays). Fix any low-contrast dark-mode text. Open PR phase46-darkmode-qa with screenshots. Static stack only.
+```
+- **Accept:** Dark mode consistent and AA-compliant on all key pages.
+
+## Phase 47 — Iconography & visual system consistency
+- **Branch:** `phase47-icons` · **PR:** Unify icons, spacing, card styles
+```
+Audit icons (mixed emoji + line icons were observed) and standardize on one icon set with consistent stroke/size and accessible labels; unify card paddings/radii/shadows via Phase 3 tokens. Replace decorative emoji in primary UI with the icon set (keep them only where intentional). Open PR phase47-icons EN/AR. Static stack only.
+```
+- **Accept:** One coherent icon/card system; emoji removed from primary UI.
+
+---
+
+# WAVE 7 — Content depth, SEO growth & launch (Phases 48–50)
+
+## Phase 48 — Internal linking & programmatic SEO QA
+- **Branch:** `phase48-internal-linking` · **PR:** Cross-links + pSEO template QA
+```
+Strengthen internal linking: every country page links to calculator/methodology/related countries; methodology anchors link from price chips (Phase 19); guides interlink. QA the programmatic country/karat pages for unique titles/meta, no thin-content duplication, correct hreflang, and consistent freshness/disclaimer. Use the `seo-audit` and `programmatic-seo` skill conventions. Open PR phase48-internal-linking with a link-graph summary. Static stack only.
+```
+- **Accept:** No orphan pages; pSEO pages unique + compliant; methodology cross-linked.
+
+## Phase 49 — Full bilingual regression & QA gate
+- **Branch:** `phase49-regression` · **PR:** Cross-browser/device + a11y/SEO regression
+```
+Run a full regression across homepage, calculator, methodology, 3 country pages, EN + AR, in Chromium/Firefox/WebKit at 390/768/1024/1440: verify nav (no overlap), freshness labels (no "live" on stale), calculator math (peg 3.6725 exact), RTL correctness, contrast (AA), CLS <0.1, valid hreflang/canonical/JSON-LD, and no console/network errors (favicon fixed). Promote the Phase 4 budgets to BLOCKING. File issues for any miss. Open PR phase49-regression with the full report. Static stack only.
+```
+- **Accept:** All checks pass; quality budgets now block PRs.
+
+## Phase 50 — Launch, monitoring & docs
+- **Branch:** `phase50-launch` · **PR:** Sitemap submit, monitoring, runbook
+```
+Finalize: confirm sitemaps/robots, prepare Search Console submission notes (EN+AR), add basic uptime/freshness monitoring (alert if all price sources fail or data is "Unavailable" beyond a threshold), and write docs/RUNBOOK.md (data pipeline, freshness logic, deploy, rollback) and docs/CONTRIBUTING.md (the static-stack guardrails). Update README with the new architecture overview. Open PR phase50-launch. Static stack only; no behavior change beyond monitoring.
+```
+- **Accept:** Monitoring live; docs complete; submission checklist ready.
+
+---
+
+## Dependency / sequencing notes
+
+- **Run 00 → 1–5 first** (map + safety + tokens) — everything else leans on tokens (Phase 3) and tests (Phase 1).
+- **Wave 1 (6–14)** is the highest-ROI block (Arabic indexability + canonical/hreflang). Phase 7 blocks 8, 9, 10, 13, 14.
+- **Wave 2 (15–22)** depends on Phase 3 tokens + Phase 1 tests; Phase 17 blocks 19, 22.
+- **Phase 31 (contrast)** should land before/with Phases 44–46 (visual) so art is built against final tokens.
+- **Phase 4 budgets** start report-only and become blocking in Phase 49.
+
+## Skills / connectors to lean on per wave
+- SEO waves: `seo-audit`, `schema`, `programmatic-seo`, `ai-seo` skill conventions.
+- A11y waves: `a11y-audit` / `accesslint-scan`.
+- Assets: **Higgsfield** (`generate_image`) for OG/hero; `image` skill for optimization/export (WebP/AVIF, OG sizing).
+- Testing: `webapp-testing` (Playwright) for the regression gate (Phase 49).
+- Each phase prompt already instructs Claude Code to read first, branch, implement minimally, self-verify, and open one PR.
+```
+```

--- a/docs/revamp/PROGRESS.md
+++ b/docs/revamp/PROGRESS.md
@@ -1,0 +1,69 @@
+# Revamp progress tracker
+
+> Living record of the 50-phase revamp. One phase = its own branch (`phaseNN-slug`) + PR(s). Updated
+> as PRs open.
+
+| Coordination PR                                           | What                                                                   | Status  |
+| --------------------------------------------------------- | ---------------------------------------------------------------------- | ------- |
+| [#469](https://github.com/vctb12/GoldTickerLive/pull/469) | Planning pack (audit + 50-phase prompts + this tracker + Cowork brief) | 🟢 open |
+
+## Phases
+
+| #   | Phase    | Branch      | PR                                                        | Status     |
+| --- | -------- | ----------- | --------------------------------------------------------- | ---------- |
+| 00  | Phase 00 | `phase00-…` | [#470](https://github.com/vctb12/GoldTickerLive/pull/470) | 🟢 PR open |
+| 01  | Phase 01 | `phase01-…` |                                                           | ⏭️ next    |
+| 02  | Phase 02 | `phase02-…` |                                                           | ⬜ todo    |
+| 03  | Phase 03 | `phase03-…` |                                                           | ⬜ todo    |
+| 04  | Phase 04 | `phase04-…` |                                                           | ⬜ todo    |
+| 05  | Phase 05 | `phase05-…` |                                                           | ⬜ todo    |
+| 06  | Phase 06 | `phase06-…` |                                                           | ⬜ todo    |
+| 07  | Phase 07 | `phase07-…` |                                                           | ⬜ todo    |
+| 08  | Phase 08 | `phase08-…` |                                                           | ⬜ todo    |
+| 09  | Phase 09 | `phase09-…` |                                                           | ⬜ todo    |
+| 10  | Phase 10 | `phase10-…` |                                                           | ⬜ todo    |
+| 11  | Phase 11 | `phase11-…` |                                                           | ⬜ todo    |
+| 12  | Phase 12 | `phase12-…` |                                                           | ⬜ todo    |
+| 13  | Phase 13 | `phase13-…` |                                                           | ⬜ todo    |
+| 14  | Phase 14 | `phase14-…` |                                                           | ⬜ todo    |
+| 15  | Phase 15 | `phase15-…` |                                                           | ⬜ todo    |
+| 16  | Phase 16 | `phase16-…` |                                                           | ⬜ todo    |
+| 17  | Phase 17 | `phase17-…` |                                                           | ⬜ todo    |
+| 18  | Phase 18 | `phase18-…` |                                                           | ⬜ todo    |
+| 19  | Phase 19 | `phase19-…` |                                                           | ⬜ todo    |
+| 20  | Phase 20 | `phase20-…` |                                                           | ⬜ todo    |
+| 21  | Phase 21 | `phase21-…` |                                                           | ⬜ todo    |
+| 22  | Phase 22 | `phase22-…` |                                                           | ⬜ todo    |
+| 23  | Phase 23 | `phase23-…` |                                                           | ⬜ todo    |
+| 24  | Phase 24 | `phase24-…` |                                                           | ⬜ todo    |
+| 25  | Phase 25 | `phase25-…` |                                                           | ⬜ todo    |
+| 26  | Phase 26 | `phase26-…` |                                                           | ⬜ todo    |
+| 27  | Phase 27 | `phase27-…` |                                                           | ⬜ todo    |
+| 28  | Phase 28 | `phase28-…` |                                                           | ⬜ todo    |
+| 29  | Phase 29 | `phase29-…` |                                                           | ⬜ todo    |
+| 30  | Phase 30 | `phase30-…` |                                                           | ⬜ todo    |
+| 31  | Phase 31 | `phase31-…` |                                                           | ⬜ todo    |
+| 32  | Phase 32 | `phase32-…` |                                                           | ⬜ todo    |
+| 33  | Phase 33 | `phase33-…` |                                                           | ⬜ todo    |
+| 34  | Phase 34 | `phase34-…` |                                                           | ⬜ todo    |
+| 35  | Phase 35 | `phase35-…` |                                                           | ⬜ todo    |
+| 36  | Phase 36 | `phase36-…` |                                                           | ⬜ todo    |
+| 37  | Phase 37 | `phase37-…` |                                                           | ⬜ todo    |
+| 38  | Phase 38 | `phase38-…` |                                                           | ⬜ todo    |
+| 39  | Phase 39 | `phase39-…` |                                                           | ⬜ todo    |
+| 40  | Phase 40 | `phase40-…` |                                                           | ⬜ todo    |
+| 41  | Phase 41 | `phase41-…` |                                                           | ⬜ todo    |
+| 42  | Phase 42 | `phase42-…` |                                                           | ⬜ todo    |
+| 43  | Phase 43 | `phase43-…` |                                                           | ⬜ todo    |
+| 44  | Phase 44 | `phase44-…` |                                                           | ⬜ todo    |
+| 45  | Phase 45 | `phase45-…` |                                                           | ⬜ todo    |
+| 46  | Phase 46 | `phase46-…` |                                                           | ⬜ todo    |
+| 47  | Phase 47 | `phase47-…` |                                                           | ⬜ todo    |
+| 48  | Phase 48 | `phase48-…` |                                                           | ⬜ todo    |
+| 49  | Phase 49 | `phase49-…` |                                                           | ⬜ todo    |
+| 50  | Phase 50 | `phase50-…` |                                                           | ⬜ todo    |
+
+**Legend:** ⬜ todo · ⏭️ next · 🟢 PR open · ✅ merged
+
+_Nothing is dropped: every phase above becomes a tracked branch + PR. New issues found during live
+QA get appended as new rows._

--- a/docs/revamp/PROGRESS.md
+++ b/docs/revamp/PROGRESS.md
@@ -1,69 +1,108 @@
 # Revamp progress tracker
 
-> Living record of the 50-phase revamp. One phase = its own branch (`phaseNN-slug`) + PR(s). Updated
-> as PRs open.
+> Living record. One phase = its own branch (`phaseNN-slug`) + PR(s). Updated as work lands.
 
-| Coordination PR                                           | What                                                                   | Status  |
-| --------------------------------------------------------- | ---------------------------------------------------------------------- | ------- |
-| [#469](https://github.com/vctb12/GoldTickerLive/pull/469) | Planning pack (audit + 50-phase prompts + this tracker + Cowork brief) | 🟢 open |
+## Coordination & docs
 
-## Phases
+| PR   | What                                                                  | Status  |
+| ---- | --------------------------------------------------------------------- | ------- |
+| #469 | Planning pack: audit + 50 phase prompts + this tracker + Cowork brief | 🟢 open |
+| #470 | Phase 00 — `docs/REPO-MAP.md`                                         | 🟢 open |
 
-| #   | Phase    | Branch      | PR                                                        | Status     |
-| --- | -------- | ----------- | --------------------------------------------------------- | ---------- |
-| 00  | Phase 00 | `phase00-…` | [#470](https://github.com/vctb12/GoldTickerLive/pull/470) | 🟢 PR open |
-| 01  | Phase 01 | `phase01-…` |                                                           | ⏭️ next    |
-| 02  | Phase 02 | `phase02-…` |                                                           | ⬜ todo    |
-| 03  | Phase 03 | `phase03-…` |                                                           | ⬜ todo    |
-| 04  | Phase 04 | `phase04-…` |                                                           | ⬜ todo    |
-| 05  | Phase 05 | `phase05-…` |                                                           | ⬜ todo    |
-| 06  | Phase 06 | `phase06-…` |                                                           | ⬜ todo    |
-| 07  | Phase 07 | `phase07-…` |                                                           | ⬜ todo    |
-| 08  | Phase 08 | `phase08-…` |                                                           | ⬜ todo    |
-| 09  | Phase 09 | `phase09-…` |                                                           | ⬜ todo    |
-| 10  | Phase 10 | `phase10-…` |                                                           | ⬜ todo    |
-| 11  | Phase 11 | `phase11-…` |                                                           | ⬜ todo    |
-| 12  | Phase 12 | `phase12-…` |                                                           | ⬜ todo    |
-| 13  | Phase 13 | `phase13-…` |                                                           | ⬜ todo    |
-| 14  | Phase 14 | `phase14-…` |                                                           | ⬜ todo    |
-| 15  | Phase 15 | `phase15-…` |                                                           | ⬜ todo    |
-| 16  | Phase 16 | `phase16-…` |                                                           | ⬜ todo    |
-| 17  | Phase 17 | `phase17-…` |                                                           | ⬜ todo    |
-| 18  | Phase 18 | `phase18-…` |                                                           | ⬜ todo    |
-| 19  | Phase 19 | `phase19-…` |                                                           | ⬜ todo    |
-| 20  | Phase 20 | `phase20-…` |                                                           | ⬜ todo    |
-| 21  | Phase 21 | `phase21-…` |                                                           | ⬜ todo    |
-| 22  | Phase 22 | `phase22-…` |                                                           | ⬜ todo    |
-| 23  | Phase 23 | `phase23-…` |                                                           | ⬜ todo    |
-| 24  | Phase 24 | `phase24-…` |                                                           | ⬜ todo    |
-| 25  | Phase 25 | `phase25-…` |                                                           | ⬜ todo    |
-| 26  | Phase 26 | `phase26-…` |                                                           | ⬜ todo    |
-| 27  | Phase 27 | `phase27-…` |                                                           | ⬜ todo    |
-| 28  | Phase 28 | `phase28-…` |                                                           | ⬜ todo    |
-| 29  | Phase 29 | `phase29-…` |                                                           | ⬜ todo    |
-| 30  | Phase 30 | `phase30-…` |                                                           | ⬜ todo    |
-| 31  | Phase 31 | `phase31-…` |                                                           | ⬜ todo    |
-| 32  | Phase 32 | `phase32-…` |                                                           | ⬜ todo    |
-| 33  | Phase 33 | `phase33-…` |                                                           | ⬜ todo    |
-| 34  | Phase 34 | `phase34-…` |                                                           | ⬜ todo    |
-| 35  | Phase 35 | `phase35-…` |                                                           | ⬜ todo    |
-| 36  | Phase 36 | `phase36-…` |                                                           | ⬜ todo    |
-| 37  | Phase 37 | `phase37-…` |                                                           | ⬜ todo    |
-| 38  | Phase 38 | `phase38-…` |                                                           | ⬜ todo    |
-| 39  | Phase 39 | `phase39-…` |                                                           | ⬜ todo    |
-| 40  | Phase 40 | `phase40-…` |                                                           | ⬜ todo    |
-| 41  | Phase 41 | `phase41-…` |                                                           | ⬜ todo    |
-| 42  | Phase 42 | `phase42-…` |                                                           | ⬜ todo    |
-| 43  | Phase 43 | `phase43-…` |                                                           | ⬜ todo    |
-| 44  | Phase 44 | `phase44-…` |                                                           | ⬜ todo    |
-| 45  | Phase 45 | `phase45-…` |                                                           | ⬜ todo    |
-| 46  | Phase 46 | `phase46-…` |                                                           | ⬜ todo    |
-| 47  | Phase 47 | `phase47-…` |                                                           | ⬜ todo    |
-| 48  | Phase 48 | `phase48-…` |                                                           | ⬜ todo    |
-| 49  | Phase 49 | `phase49-…` |                                                           | ⬜ todo    |
-| 50  | Phase 50 | `phase50-…` |                                                           | ⬜ todo    |
+## Fix PRs shipped this session
 
-**Legend:** ⬜ todo · ⏭️ next · 🟢 PR open · ✅ merged
+| PR   | Maps to  | What                                                | Verified locally                       | Status  |
+| ---- | -------- | --------------------------------------------------- | -------------------------------------- | ------- |
+| #471 | Phase 27 | Unique location-guide checklist headings (a11y/SEO) | eslint + validate; 0 new test fails    | 🟢 open |
+| #472 | hotfix   | `offline.html` root-absolute asset paths            | fallback guard passes; suite 3→2 fails | 🟢 open |
+| #473 | hotfix   | nav single banner landmark + NAV_DATA skip-link     | nav a11y guards pass; validate         | 🟢 open |
 
-_Nothing is dropped: every phase above becomes a tracked branch + PR. New issues found during live
-QA get appended as new rows._
+> **#472 + #473 restore a green `main`** — the suite was red on 3 pre-existing tests (`offline`
+> asset paths, nav banner, nav skip-link) before this session.
+
+## Audit re-verification (vs current code, 2026-06-30)
+
+The repo was actively improved around the audit, so several flagged items were **already fixed** —
+verified before writing any PR, to avoid no-op churn.
+
+| Audit item                            | Verdict                                       | Action                                 |
+| ------------------------------------- | --------------------------------------------- | -------------------------------------- |
+| Homepage chart vs spot-card mismatch  | ✅ FIXED (unified source)                     | none                                   |
+| Muted-text contrast (light mode)      | ✅ FIXED (`#6a5c48` ≈ 6.27:1)                 | none                                   |
+| "Live" label on stale data            | ✅ FIXED (`<2min` + STALE_LIVE guard)         | none                                   |
+| Canonical `/calculator.html`          | ✅ NOT A BUG (consistent w/ sitemap + og:url) | none                                   |
+| favicon 404                           | ✅ FIXED (assets present)                     | none                                   |
+| Repeated checklist headings           | 🔧 OPEN → **#471**                            | shipped                                |
+| offline fallback asset paths          | 🔧 OPEN → **#472**                            | shipped                                |
+| nav banner / skip-link guards         | 🔧 OPEN → **#473**                            | shipped                                |
+| Quick-convert blank reference value   | 🔧 OPEN                                       | queued (Phase 18)                      |
+| JS chunk consolidation                | 🟡 PARTIAL                                    | queued (Phase 37)                      |
+| Nav overlap breakpoint ~768–1240px    | 🔧 OPEN                                       | queued (Phase 23, needs visual check)  |
+| Arabic `/ar/` indexability + hreflang | 🟡 PARTIAL                                    | queued (Phase 06–14 — biggest SEO win) |
+| Freshness numerals / bidi consistency | 🟡 PARTIAL                                    | queued (Phase 17/26)                   |
+| Methodology internal-path copy        | ➖ editorial                                  | optional (Phase 20)                    |
+
+## Next up
+
+1. **Phase 18** — quick-convert: seed reference value from cached price (never blank).
+2. **Phase 37** — Vite `manualChunks` consolidation (fewer homepage chunks).
+3. **Phase 23** — nav-overlap breakpoint (verify visually before shipping).
+4. **Phase 06–14** — Arabic `/ar/` real indexable pages + reciprocal hreflang (replace `?lang=ar`).
+
+## Full phase list
+
+| #   | Phase    | PR   | Status                   |
+| --- | -------- | ---- | ------------------------ |
+| 00  | Phase 00 | #470 | 🟢 PR                    |
+| 01  | Phase 01 |      | ⬜ todo                  |
+| 02  | Phase 02 |      | ⬜ todo                  |
+| 03  | Phase 03 |      | ⬜ todo                  |
+| 04  | Phase 04 |      | ⬜ todo                  |
+| 05  | Phase 05 |      | ⬜ todo                  |
+| 06  | Phase 06 |      | ⏭️ queued                |
+| 07  | Phase 07 |      | ⏭️ queued                |
+| 08  | Phase 08 |      | ⏭️ queued                |
+| 09  | Phase 09 |      | ⏭️ queued                |
+| 10  | Phase 10 |      | ⬜ todo                  |
+| 11  | Phase 11 |      | ⬜ todo                  |
+| 12  | Phase 12 |      | ⬜ todo                  |
+| 13  | Phase 13 |      | ⏭️ queued                |
+| 14  | Phase 14 |      | ⏭️ queued                |
+| 15  | Phase 15 |      | ⬜ todo                  |
+| 16  | Phase 16 |      | ⬜ todo                  |
+| 17  | Phase 17 |      | ⏭️ queued                |
+| 18  | Phase 18 |      | ⏭️ next                  |
+| 19  | Phase 19 |      | ⬜ todo                  |
+| 20  | Phase 20 |      | ➖ editorial/optional    |
+| 21  | Phase 21 |      | ⬜ todo                  |
+| 22  | Phase 22 |      | ⬜ todo                  |
+| 23  | Phase 23 |      | ⏭️ queued (needs visual) |
+| 24  | Phase 24 |      | ⬜ todo                  |
+| 25  | Phase 25 |      | ⬜ todo                  |
+| 26  | Phase 26 |      | ⏭️ queued                |
+| 27  | Phase 27 | #471 | 🟢 PR                    |
+| 28  | Phase 28 |      | ⬜ todo                  |
+| 29  | Phase 29 |      | ⬜ todo                  |
+| 30  | Phase 30 |      | ⬜ todo                  |
+| 31  | Phase 31 |      | ⬜ todo                  |
+| 32  | Phase 32 |      | ⬜ todo                  |
+| 33  | Phase 33 |      | ⬜ todo                  |
+| 34  | Phase 34 |      | ⬜ todo                  |
+| 35  | Phase 35 |      | ⬜ todo                  |
+| 36  | Phase 36 |      | ⬜ todo                  |
+| 37  | Phase 37 |      | ⏭️ queued                |
+| 38  | Phase 38 |      | ⬜ todo                  |
+| 39  | Phase 39 |      | ⬜ todo                  |
+| 40  | Phase 40 |      | ⬜ todo                  |
+| 41  | Phase 41 |      | ⬜ todo                  |
+| 42  | Phase 42 |      | ⬜ todo                  |
+| 43  | Phase 43 |      | ⬜ todo                  |
+| 44  | Phase 44 |      | ⬜ todo                  |
+| 45  | Phase 45 |      | ⬜ todo                  |
+| 46  | Phase 46 |      | ⬜ todo                  |
+| 47  | Phase 47 |      | ⬜ todo                  |
+| 48  | Phase 48 |      | ⬜ todo                  |
+| 49  | Phase 49 |      | ⬜ todo                  |
+| 50  | Phase 50 |      | ⬜ todo                  |
+
+**Legend:** ⬜ todo · ⏭️ queued/next · 🟢 PR open · ✅ merged · ➖ optional

--- a/docs/revamp/PROGRESS.md
+++ b/docs/revamp/PROGRESS.md
@@ -1,108 +1,104 @@
 # Revamp progress tracker
 
-> Living record. One phase = its own branch (`phaseNN-slug`) + PR(s). Updated as work lands.
+> Living record. One phase = its own branch (`phaseNN-slug`) + PR(s). Updated as work lands. See
+> also [live QA](qa/live-qa-2026-06-30.md) and the reusable
+> [agent workflows](../../.claude/workflows/).
 
 ## Coordination & docs
 
-| PR   | What                                                                  | Status  |
-| ---- | --------------------------------------------------------------------- | ------- |
-| #469 | Planning pack: audit + 50 phase prompts + this tracker + Cowork brief | 🟢 open |
-| #470 | Phase 00 — `docs/REPO-MAP.md`                                         | 🟢 open |
+| PR   | What                                                                   | Status  |
+| ---- | ---------------------------------------------------------------------- | ------- |
+| #469 | Planning pack + tracker + Cowork brief + live-QA + **agent workflows** | 🟢 open |
+| #470 | Phase 00 — `docs/REPO-MAP.md`                                          | 🟢 open |
 
-## Fix PRs shipped this session
+## Fix PRs shipped
 
-| PR   | Maps to  | What                                                | Verified locally                       | Status  |
-| ---- | -------- | --------------------------------------------------- | -------------------------------------- | ------- |
-| #471 | Phase 27 | Unique location-guide checklist headings (a11y/SEO) | eslint + validate; 0 new test fails    | 🟢 open |
-| #472 | hotfix   | `offline.html` root-absolute asset paths            | fallback guard passes; suite 3→2 fails | 🟢 open |
-| #473 | hotfix   | nav single banner landmark + NAV_DATA skip-link     | nav a11y guards pass; validate         | 🟢 open |
+| PR   | Maps to  | What                                                | Verified                     | Status  |
+| ---- | -------- | --------------------------------------------------- | ---------------------------- | ------- |
+| #471 | Phase 27 | Unique location-guide checklist headings (a11y/SEO) | eslint+validate, 0 new fails | 🟢 open |
+| #472 | hotfix   | `offline.html` root-absolute asset paths            | fallback guard ✅            | 🟢 open |
+| #473 | hotfix   | nav single banner landmark + NAV_DATA skip-link     | nav a11y guards ✅           | 🟢 open |
+| #474 | Phase 18 | quick-convert reads live spot (no blank value)      | eslint+validate, 0 new fails | 🟢 open |
 
-> **#472 + #473 restore a green `main`** — the suite was red on 3 pre-existing tests (`offline`
-> asset paths, nav banner, nav skip-link) before this session.
+> **#472 + #473 restored a green `main`** (was red on 3 pre-existing tests at session start).
 
-## Audit re-verification (vs current code, 2026-06-30)
+## Live QA verdict (2026-06-30)
 
-The repo was actively improved around the audit, so several flagged items were **already fixed** —
-verified before writing any PR, to avoid no-op churn.
+Most audit items are **already fixed or not reproducible** — verified vs current code + live site
+before writing any PR (see [qa/](qa/live-qa-2026-06-30.md)). The **one real open P0 is the Arabic
+`/ar/` homepage indexability** (`/ar/` is `noindex` + canonical→EN; homepage
+`hreflang=ar`→`?lang=ar`). The `/ar/` sub-pages already work, so the fix is to make the homepage
+adopt that pattern.
 
-| Audit item                            | Verdict                                       | Action                                 |
-| ------------------------------------- | --------------------------------------------- | -------------------------------------- |
-| Homepage chart vs spot-card mismatch  | ✅ FIXED (unified source)                     | none                                   |
-| Muted-text contrast (light mode)      | ✅ FIXED (`#6a5c48` ≈ 6.27:1)                 | none                                   |
-| "Live" label on stale data            | ✅ FIXED (`<2min` + STALE_LIVE guard)         | none                                   |
-| Canonical `/calculator.html`          | ✅ NOT A BUG (consistent w/ sitemap + og:url) | none                                   |
-| favicon 404                           | ✅ FIXED (assets present)                     | none                                   |
-| Repeated checklist headings           | 🔧 OPEN → **#471**                            | shipped                                |
-| offline fallback asset paths          | 🔧 OPEN → **#472**                            | shipped                                |
-| nav banner / skip-link guards         | 🔧 OPEN → **#473**                            | shipped                                |
-| Quick-convert blank reference value   | 🔧 OPEN                                       | queued (Phase 18)                      |
-| JS chunk consolidation                | 🟡 PARTIAL                                    | queued (Phase 37)                      |
-| Nav overlap breakpoint ~768–1240px    | 🔧 OPEN                                       | queued (Phase 23, needs visual check)  |
-| Arabic `/ar/` indexability + hreflang | 🟡 PARTIAL                                    | queued (Phase 06–14 — biggest SEO win) |
-| Freshness numerals / bidi consistency | 🟡 PARTIAL                                    | queued (Phase 17/26)                   |
-| Methodology internal-path copy        | ➖ editorial                                  | optional (Phase 20)                    |
+## Priority / queue
 
-## Next up
+1. **🎯 Phase 06–14 — Arabic `/ar/` homepage indexability** (the one real P0; biggest SEO win).
+2. ➖ Optional/low-value: JS chunk consolidation (37), freshness AR numerals (17/26), methodology
+   copy (20).
+3. ⏸️ Deferred: nav-overlap (23) — not reproducible at testable widths; needs a real <880px device.
+4. Brand assets (Higgsfield) — reuse existing 4K renders; fill gaps only.
 
-1. **Phase 18** — quick-convert: seed reference value from cached price (never blank).
-2. **Phase 37** — Vite `manualChunks` consolidation (fewer homepage chunks).
-3. **Phase 23** — nav-overlap breakpoint (verify visually before shipping).
-4. **Phase 06–14** — Arabic `/ar/` real indexable pages + reciprocal hreflang (replace `?lang=ar`).
+## Agent workflows (new)
+
+Reusable multi-agent workflows in [`.claude/workflows/`](../../.claude/workflows/):
+**`pre-pr-review`** (verify suite + adversarial diff review → go/no-go) and **`audit-reverify`**
+(classify findings OPEN/FIXED vs current code). See that folder's README to invoke + enable the
+daily PR babysitter routine.
 
 ## Full phase list
 
-| #   | Phase    | PR   | Status                   |
-| --- | -------- | ---- | ------------------------ |
-| 00  | Phase 00 | #470 | 🟢 PR                    |
-| 01  | Phase 01 |      | ⬜ todo                  |
-| 02  | Phase 02 |      | ⬜ todo                  |
-| 03  | Phase 03 |      | ⬜ todo                  |
-| 04  | Phase 04 |      | ⬜ todo                  |
-| 05  | Phase 05 |      | ⬜ todo                  |
-| 06  | Phase 06 |      | ⏭️ queued                |
-| 07  | Phase 07 |      | ⏭️ queued                |
-| 08  | Phase 08 |      | ⏭️ queued                |
-| 09  | Phase 09 |      | ⏭️ queued                |
-| 10  | Phase 10 |      | ⬜ todo                  |
-| 11  | Phase 11 |      | ⬜ todo                  |
-| 12  | Phase 12 |      | ⬜ todo                  |
-| 13  | Phase 13 |      | ⏭️ queued                |
-| 14  | Phase 14 |      | ⏭️ queued                |
-| 15  | Phase 15 |      | ⬜ todo                  |
-| 16  | Phase 16 |      | ⬜ todo                  |
-| 17  | Phase 17 |      | ⏭️ queued                |
-| 18  | Phase 18 |      | ⏭️ next                  |
-| 19  | Phase 19 |      | ⬜ todo                  |
-| 20  | Phase 20 |      | ➖ editorial/optional    |
-| 21  | Phase 21 |      | ⬜ todo                  |
-| 22  | Phase 22 |      | ⬜ todo                  |
-| 23  | Phase 23 |      | ⏭️ queued (needs visual) |
-| 24  | Phase 24 |      | ⬜ todo                  |
-| 25  | Phase 25 |      | ⬜ todo                  |
-| 26  | Phase 26 |      | ⏭️ queued                |
-| 27  | Phase 27 | #471 | 🟢 PR                    |
-| 28  | Phase 28 |      | ⬜ todo                  |
-| 29  | Phase 29 |      | ⬜ todo                  |
-| 30  | Phase 30 |      | ⬜ todo                  |
-| 31  | Phase 31 |      | ⬜ todo                  |
-| 32  | Phase 32 |      | ⬜ todo                  |
-| 33  | Phase 33 |      | ⬜ todo                  |
-| 34  | Phase 34 |      | ⬜ todo                  |
-| 35  | Phase 35 |      | ⬜ todo                  |
-| 36  | Phase 36 |      | ⬜ todo                  |
-| 37  | Phase 37 |      | ⏭️ queued                |
-| 38  | Phase 38 |      | ⬜ todo                  |
-| 39  | Phase 39 |      | ⬜ todo                  |
-| 40  | Phase 40 |      | ⬜ todo                  |
-| 41  | Phase 41 |      | ⬜ todo                  |
-| 42  | Phase 42 |      | ⬜ todo                  |
-| 43  | Phase 43 |      | ⬜ todo                  |
-| 44  | Phase 44 |      | ⬜ todo                  |
-| 45  | Phase 45 |      | ⬜ todo                  |
-| 46  | Phase 46 |      | ⬜ todo                  |
-| 47  | Phase 47 |      | ⬜ todo                  |
-| 48  | Phase 48 |      | ⬜ todo                  |
-| 49  | Phase 49 |      | ⬜ todo                  |
-| 50  | Phase 50 |      | ⬜ todo                  |
+| #   | Phase    | PR   | Status                         |
+| --- | -------- | ---- | ------------------------------ |
+| 00  | Phase 00 | #470 | 🟢 PR                          |
+| 01  | Phase 01 |      | ⬜ todo                        |
+| 02  | Phase 02 |      | ⬜ todo                        |
+| 03  | Phase 03 |      | ⬜ todo                        |
+| 04  | Phase 04 |      | ⬜ todo                        |
+| 05  | Phase 05 |      | ⬜ todo                        |
+| 06  | Phase 06 |      | 🎯 priority                    |
+| 07  | Phase 07 |      | 🎯 priority                    |
+| 08  | Phase 08 |      | 🎯 priority                    |
+| 09  | Phase 09 |      | 🎯 priority                    |
+| 10  | Phase 10 |      | ⬜ todo                        |
+| 11  | Phase 11 |      | ⬜ todo                        |
+| 12  | Phase 12 |      | ⬜ todo                        |
+| 13  | Phase 13 |      | 🎯 priority                    |
+| 14  | Phase 14 |      | 🎯 priority                    |
+| 15  | Phase 15 |      | ⬜ todo                        |
+| 16  | Phase 16 |      | ⬜ todo                        |
+| 17  | Phase 17 |      | ➖ optional                    |
+| 18  | Phase 18 | #474 | 🟢 PR                          |
+| 19  | Phase 19 |      | ⬜ todo                        |
+| 20  | Phase 20 |      | ➖ editorial                   |
+| 21  | Phase 21 |      | ⬜ todo                        |
+| 22  | Phase 22 |      | ⬜ todo                        |
+| 23  | Phase 23 |      | ⏸️ deferred (not reproducible) |
+| 24  | Phase 24 |      | ⬜ todo                        |
+| 25  | Phase 25 |      | ⬜ todo                        |
+| 26  | Phase 26 |      | ➖ optional                    |
+| 27  | Phase 27 | #471 | 🟢 PR                          |
+| 28  | Phase 28 |      | ⬜ todo                        |
+| 29  | Phase 29 |      | ⬜ todo                        |
+| 30  | Phase 30 |      | ⬜ todo                        |
+| 31  | Phase 31 |      | ⬜ todo                        |
+| 32  | Phase 32 |      | ⬜ todo                        |
+| 33  | Phase 33 |      | ⬜ todo                        |
+| 34  | Phase 34 |      | ⬜ todo                        |
+| 35  | Phase 35 |      | ⬜ todo                        |
+| 36  | Phase 36 |      | ⬜ todo                        |
+| 37  | Phase 37 |      | ➖ optional (perf, subjective) |
+| 38  | Phase 38 |      | ⬜ todo                        |
+| 39  | Phase 39 |      | ⬜ todo                        |
+| 40  | Phase 40 |      | ⬜ todo                        |
+| 41  | Phase 41 |      | ⬜ todo                        |
+| 42  | Phase 42 |      | ⬜ todo                        |
+| 43  | Phase 43 |      | ⬜ todo                        |
+| 44  | Phase 44 |      | ⬜ todo                        |
+| 45  | Phase 45 |      | ⬜ todo                        |
+| 46  | Phase 46 |      | ⬜ todo                        |
+| 47  | Phase 47 |      | ⬜ todo                        |
+| 48  | Phase 48 |      | ⬜ todo                        |
+| 49  | Phase 49 |      | ⬜ todo                        |
+| 50  | Phase 50 |      | ⬜ todo                        |
 
-**Legend:** ⬜ todo · ⏭️ queued/next · 🟢 PR open · ✅ merged · ➖ optional
+**Legend:** ⬜ todo · 🎯 priority · 🟢 PR open · ✅ merged · ⏸️ deferred · ➖ optional

--- a/docs/revamp/README.md
+++ b/docs/revamp/README.md
@@ -1,0 +1,28 @@
+# GoldTickerLive Revamp
+
+A-to-Z revamp derived from a live-site audit (2026-06-30). Stays on the existing static stack (vanilla ES6 + Vite, Express, Supabase) — **no framework migration, SSR, or build-tool swap.**
+
+## Contents
+- `00-AUDIT.md` — the live-site audit (findings tagged VERIFIED / UNVERIFIED).
+- `MASTER-50-PHASE-PLAN.md` — all 50 phases in one document + asset library + sequencing.
+- `phases/phase-00.md … phase-50.md` — one file per phase, each with a paste-ready Claude Code PROMPT and acceptance criteria. **A phase may be one or several PRs.**
+
+## How to execute
+1. Open Claude Code in this repo on a fresh `main`.
+2. Run `phases/phase-00.md` (repo map), then proceed in order.
+3. Each phase: copy the PROMPT, let Claude Code branch (`phaseNN-slug`), implement, self-verify, open PR(s). Review + merge before the next.
+
+## Waves
+- **0 (01–05):** foundation & safety — tests, CI, design tokens, budgets, inventory
+- **1 (06–14):** P0 SEO/bilingual — canonical, static `/ar/` pages, meta, hreflang, sitemap, JSON-LD
+- **2 (15–22):** trust & freshness integrity
+- **3 (23–30):** layout, responsive & RTL
+- **4 (31–36):** accessibility (WCAG AA)
+- **5 (37–42):** performance & infra
+- **6 (43–47):** visual & brand polish (Higgsfield assets in MASTER plan)
+- **7 (48–50):** content depth, SEO growth, launch
+
+## Priority map (from audit)
+- **P0:** Arabic not separately indexable (Phases 07–09, 13–14); canonical `/` vs `/calculator.html` (Phase 06).
+- **P1:** "Live" on 9-min data (15); chart vs spot price mismatch (16); nav overlaps logo ~768–1240px (23); muted text ~2.7:1 contrast (31); quick-convert blank (18).
+- **P2:** favicon 404 (38); ~30 JS chunks (37); repeated checklist headings (27); repo paths in methodology copy (20); freshness-vocab/numeral/bidi consistency (17/13/26).

--- a/docs/revamp/phases/phase-00.md
+++ b/docs/revamp/phases/phase-00.md
@@ -1,0 +1,13 @@
+# Phase 00 — Repo map (run first)
+
+> Run this once before Phase 01. No code changes — documentation only.
+
+## PROMPT
+```
+You are doing a phased revamp of GoldTickerLive (static: vanilla ES6 + Vite, Express, Supabase, bilingual EN/AR, ~390 pages, gold price reference site). Trust and clarity are the top priority; spot/reference prices must never be confused with retail; the AED/USD peg is fixed at 3.6725; non-live values must be clearly labeled.
+
+With NO code changes, produce a short repo map: where pages are generated, where the nav/footer/ticker shell lives, where the price/FX fetch + freshness logic lives, where i18n/Arabic strings live, where SEO meta/canonical/hreflang/JSON-LD are emitted, the Vite config + build output structure, and how routes map to files. Save it as docs/REPO-MAP.md and open a PR `phase00-repo-map`. Do not change app behavior.
+```
+
+## Acceptance
+- `docs/REPO-MAP.md` committed; PR `phase00-repo-map` opened; no behavior change.

--- a/docs/revamp/phases/phase-01.md
+++ b/docs/revamp/phases/phase-01.md
@@ -1,0 +1,12 @@
+# Phase 01 — Regression safety net
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 1 — Regression safety net
+- **Maps to:** "preserve existing working behavior" guardrail.
+- **Branch:** `phase01-baseline-tests` · **PR:** Add smoke + price-math + freshness tests
+```
+Read docs/REPO-MAP.md and the price/FX/freshness modules. WITHOUT changing app behavior, add a lightweight test harness using the project's existing tooling (or Vitest if none exists) covering: (1) the core price formula (XAU/USD ÷ 31.1035 × karat/24 × FX), asserting 24K/22K/21K/18K and the AED peg 3.6725 produce exact known values; (2) freshness-state resolution (live/delayed/cached/stale/fallback/unavailable) given timestamps; (3) a DOM smoke test that the homepage shell (nav, ticker, footer) mounts. Add an npm script `test`. Do not refactor app code; only add tests + minimal exports if needed. Open PR phase01-baseline-tests with coverage notes. Stay on the current static stack; no framework migration.
+```
+- **Accept:** `npm run build` + `npm test` green; tests fail if the peg or formula is altered.

--- a/docs/revamp/phases/phase-02.md
+++ b/docs/revamp/phases/phase-02.md
@@ -1,0 +1,11 @@
+# Phase 02 — CI pipeline (build + lint + test on PR)
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 2 — CI pipeline (build + lint + test on PR)
+- **Branch:** `phase02-ci` · **PR:** GitHub Actions CI for PRs
+```
+Read .github/workflows. Add a CI workflow that runs install, build, lint, and the Phase 1 tests on every PR and on main. Do not touch the existing hourly gold-price fetch workflow. Cache node_modules. Fail the PR on build/lint/test errors. Open PR phase02-ci. No app behavior changes; static stack only.
+```
+- **Accept:** CI runs and is required; existing price-fetch cron untouched.

--- a/docs/revamp/phases/phase-03.md
+++ b/docs/revamp/phases/phase-03.md
@@ -1,0 +1,12 @@
+# Phase 03 — Design tokens single source of truth
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 3 — Design tokens single source of truth
+- **Maps to:** P1-4 contrast, P2-5 vocabulary, brand consistency.
+- **Branch:** `phase03-design-tokens` · **PR:** Centralize color/spacing/type tokens
+```
+Read the CSS (critical.css, global.css, index.css) and any inline styles. Extract the de-facto design system into a single tokens layer (CSS custom properties): color (light + dark themes), spacing scale, type scale, radii, shadows, z-index, and freshness-state colors. Replace hardcoded hex/spacing in the shared shell (nav/footer/ticker/spot bar) with tokens. DO NOT change visual output yet — this is a refactor; screenshots before/after must match. Document tokens in docs/DESIGN-TOKENS.md. Open PR phase03-design-tokens. Static stack only; no visual regressions.
+```
+- **Accept:** Pixel-equivalent before/after; all shell colors reference tokens.

--- a/docs/revamp/phases/phase-04.md
+++ b/docs/revamp/phases/phase-04.md
@@ -1,0 +1,11 @@
+# Phase 04 — Lighthouse + a11y CI budget (report-only)
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 4 — Lighthouse + a11y CI budget (report-only)
+- **Branch:** `phase04-quality-budgets` · **PR:** Lighthouse CI + axe report (non-blocking)
+```
+Add Lighthouse CI and axe-core accessibility checks that run against the built site for homepage, /calculator, /methodology, and one country page, in EN and AR. Output reports as CI artifacts; set them report-only (non-blocking) for now with target budgets (Perf ≥85 mobile, A11y ≥95, CLS <0.1). Do not change app code. Open PR phase04-quality-budgets. Static stack only.
+```
+- **Accept:** Reports generated as artifacts; baselines recorded in PR.

--- a/docs/revamp/phases/phase-05.md
+++ b/docs/revamp/phases/phase-05.md
@@ -1,0 +1,13 @@
+# Phase 05 — Page/route inventory + audit map
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 5 — Page/route inventory + audit map
+- **Branch:** `phase05-page-inventory` · **PR:** Generate page inventory + redirect/canonical map
+```
+Crawl the built output (or the generation config) and produce docs/PAGE-INVENTORY.csv listing every generated URL, its EN/AR status, current <title>, meta description, canonical, and hreflang. Flag: extensionless vs .html mismatches, missing AR counterpart, duplicate canonicals, and missing meta. This is documentation only — no app changes. Open PR phase05-page-inventory. It will drive Waves 1–2.
+```
+- **Accept:** Complete CSV; flags match audit (canonical `/` vs `/calculator.html`, AR gaps).
+
+---

--- a/docs/revamp/phases/phase-06.md
+++ b/docs/revamp/phases/phase-06.md
@@ -1,0 +1,12 @@
+# Phase 06 — Canonical strategy normalization
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 6 — Canonical strategy normalization
+- **Maps to:** P0-2 (canonical `/` vs `/calculator.html`).
+- **Branch:** `phase06-canonical` · **PR:** One canonical convention sitewide
+```
+Per docs/PAGE-INVENTORY.csv, every page must declare a canonical equal to its own clean, extensionless URL (e.g. https://goldtickerlive.com/calculator). Fix the generator/template so canonicals are self-referential and consistent. Add server/host redirects (or static redirect config) so /calculator.html and trailing-slash variants 301 to the canonical form. Read how canonicals are currently emitted before editing. Open PR phase06-canonical with a table of before/after canonicals. Static stack only.
+```
+- **Accept:** Each page's canonical = its own clean URL; `.html` 301s to clean URL.

--- a/docs/revamp/phases/phase-07.md
+++ b/docs/revamp/phases/phase-07.md
@@ -1,0 +1,12 @@
+# Phase 07 — Distinct Arabic URLs (static pre-render)
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 7 — Distinct Arabic URLs (static pre-render)
+- **Maps to:** P0-1 (Arabic not indexable).
+- **Branch:** `phase07-ar-routes` · **PR:** Generate static `/ar/...` pages
+```
+Today the Arabic experience is a client-side toggle with no separate URL (title/meta stay English). Without leaving the static Vite build, generate a distinct Arabic URL for every page at build time under /ar/ (e.g. /ar/, /ar/calculator, /ar/methodology, /ar/<country>). Each AR page must render server-side HTML with <html lang="ar" dir="rtl">, fully translated visible content reusing the existing AR string set, and the same data/freshness logic. Keep the in-page language toggle but make it NAVIGATE between the EN and AR URLs (not just swap client state). Read the i18n/string modules and the generation pipeline first. Open PR phase07-ar-routes. Do not regress EN pages; static stack only.
+```
+- **Accept:** `/ar/calculator` loads server-rendered Arabic with `lang=ar dir=rtl`; toggle navigates between EN/AR URLs.

--- a/docs/revamp/phases/phase-08.md
+++ b/docs/revamp/phases/phase-08.md
@@ -1,0 +1,12 @@
+# Phase 08 — Localized titles & meta per locale
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 8 — Localized titles & meta per locale
+- **Maps to:** P0-1 (English title in AR mode).
+- **Branch:** `phase08-localized-meta` · **PR:** Per-locale `<title>`/description/OG
+```
+For every AR page from Phase 7, emit Arabic <title>, meta description, og:title/description/locale (ar_AE), and twitter card. EN pages keep English equivalents with og:locale en_AE plus og:locale:alternate ar_AE. Centralize the per-page, per-locale metadata in one data source so titles/descriptions are authored once. Read how meta is emitted before editing. Open PR phase08-localized-meta. Static stack; no behavior change beyond meta.
+```
+- **Accept:** `document.title` is Arabic on AR pages; OG locale correct both sides.

--- a/docs/revamp/phases/phase-09.md
+++ b/docs/revamp/phases/phase-09.md
@@ -1,0 +1,12 @@
+# Phase 09 — Reciprocal hreflang + x-default
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 9 — Reciprocal hreflang + x-default
+- **Maps to:** P0-1 (hreflang points to non-existent `/?lang=ar`).
+- **Branch:** `phase09-hreflang` · **PR:** Correct bilingual hreflang pairs
+```
+Replace the current hreflang (which points ar to /?lang=ar that the toggle never produces) with reciprocal, self-consistent pairs on EVERY page: en -> clean EN URL, ar -> the new /ar/ URL, x-default -> EN. Both the EN and AR versions of a page must reference each other identically. Read Phase 6/7 outputs first. Validate all pairs resolve (200, not redirected). Open PR phase09-hreflang with a validation table. Static stack only.
+```
+- **Accept:** Every EN/AR pair cross-references; no hreflang targets 404/redirect.

--- a/docs/revamp/phases/phase-10.md
+++ b/docs/revamp/phases/phase-10.md
@@ -1,0 +1,11 @@
+# Phase 10 — XML sitemap(s) with locale alternates
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 10 — XML sitemap(s) with locale alternates
+- **Branch:** `phase10-sitemap` · **PR:** Build-time sitemap with hreflang
+```
+Generate sitemap.xml (split if >50k URLs) at build time from PAGE-INVENTORY, including every EN and AR clean URL with xhtml:link alternate (hreflang) entries. Add lastmod. Reference it from robots.txt. Do not include redirect/.html variants. Open PR phase10-sitemap. Static stack only.
+```
+- **Accept:** Sitemap lists clean EN+AR URLs with alternates; linked from robots.

--- a/docs/revamp/phases/phase-11.md
+++ b/docs/revamp/phases/phase-11.md
@@ -1,0 +1,11 @@
+# Phase 11 — robots.txt + indexing hygiene
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 11 — robots.txt + indexing hygiene
+- **Branch:** `phase11-robots` · **PR:** robots.txt + noindex on thin/util URLs
+```
+Add/curate robots.txt: allow content, point to sitemap, disallow query-param duplicates and any utility endpoints. Ensure parametered URLs (e.g. /calculator?w=10) are canonicalized to the clean page (not separately indexed). Read current robots and how query state is reflected in canonical. Open PR phase11-robots. Static stack only.
+```
+- **Accept:** Param URLs canonicalize to base; sitemap referenced; no content blocked.

--- a/docs/revamp/phases/phase-12.md
+++ b/docs/revamp/phases/phase-12.md
@@ -1,0 +1,12 @@
+# Phase 12 — JSON-LD expansion & validation
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 12 — JSON-LD expansion & validation
+- **Maps to:** strengthens existing Organization/WebSite/FAQPage.
+- **Branch:** `phase12-jsonld` · **PR:** Add/repair structured data
+```
+Audit existing JSON-LD (homepage has Organization, WebSite, FAQPage). Add appropriate schema sitewide: BreadcrumbList on inner pages, WebSite SearchAction, Organization with logo/sameAs, and on price/country pages a suitable Dataset or Product-style schema for the reference price WITH clear "reference price, not retail" semantics (do not imply a purchasable offer/price you don't sell). Localize where relevant. Validate every type against schema.org and Google Rich Results. Read current JSON-LD emission first. Open PR phase12-jsonld. Use the `schema` skill conventions. Static stack only.
+```
+- **Accept:** All pages emit valid JSON-LD; no Rich Results errors; no misleading Offer.

--- a/docs/revamp/phases/phase-13.md
+++ b/docs/revamp/phases/phase-13.md
@@ -1,0 +1,12 @@
+# Phase 13 — AR content parity sweep
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 13 — AR content parity sweep
+- **Maps to:** P0-1 parity, P2-6 numerals.
+- **Branch:** `phase13-ar-parity` · **PR:** Fill AR translation gaps
+```
+Compare EN vs AR strings across all surfaces; list any untranslated/missing AR copy (headings, buttons, freshness labels, disclaimers, methodology). Fill gaps with proper Arabic (do not leave English fallback visible in AR mode). Decide and document one numeral convention per locale (recommend Arabic-Indic for AR, Latin for EN) and apply consistently. Read the i18n source. Open PR phase13-ar-parity with a parity checklist. Static stack only.
+```
+- **Accept:** No English leakage in AR; numerals consistent per locale.

--- a/docs/revamp/phases/phase-14.md
+++ b/docs/revamp/phases/phase-14.md
@@ -1,0 +1,13 @@
+# Phase 14 — Methodology page localized + indexable (EN/AR)
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 14 — Methodology page localized + indexable (EN/AR)
+- **Branch:** `phase14-methodology-i18n` · **PR:** AR methodology + anchors
+```
+Ensure /methodology and /ar/methodology both exist as indexable pages with full translated content, stable section anchors (#live-formula, #aed-peg, #freshness-states, #disclaimer), and correct meta/hreflang. Keep the (excellent) EN content intact. Open PR phase14-methodology-i18n. Static stack only.
+```
+- **Accept:** Both methodology URLs index; anchors stable for cross-linking (used in Phase 20).
+
+---

--- a/docs/revamp/phases/phase-15.md
+++ b/docs/revamp/phases/phase-15.md
@@ -1,0 +1,12 @@
+# Phase 15 — Freshness label thresholds (fix "Live" on stale)
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 15 — Freshness label thresholds (fix "Live" on stale)
+- **Maps to:** P1-1 (9-min-old shown "Live").
+- **Branch:** `phase15-freshness-thresholds` · **PR:** Tighten Live window, add Delayed band
+```
+Read the freshness-state logic and methodology thresholds. Change the rules so "Live" only applies within ~2 minutes (aligned to the ~90s re-poll); 2–12 min becomes "Delayed" (show age); >12 min "Stale"; failures "Cached/Fallback"; total failure "Unavailable". Update the methodology copy to match the new thresholds. Ensure the top ticker "x min ago" and the badge can never disagree. Add/extend tests from Phase 1. Open PR phase15-freshness-thresholds. Never present non-live data as live.
+```
+- **Accept:** A value older than ~2 min never reads "Live"; badge and "x ago" agree; tests cover bands.

--- a/docs/revamp/phases/phase-16.md
+++ b/docs/revamp/phases/phase-16.md
@@ -1,0 +1,12 @@
+# Phase 16 — Chart price reconciliation
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 16 — Chart price reconciliation
+- **Maps to:** P1-2 (TradingView ~5059 vs spot ~4022).
+- **Branch:** `phase16-chart-source` · **PR:** Reconcile/label homepage chart
+```
+The homepage chart (TradingView) shows a "last" price that differs from the site's spot value, creating two conflicting current prices. Read how the chart is embedded. Implement the cleanest option that keeps the static stack: prefer feeding the chart from the same gold-api series used sitewide; if not feasible, clearly label the chart as an independent third-party feed, visually separate it from the official spot value, and add a freshness/source caption using the sitewide vocabulary. The headline spot must remain the single source of truth. Open PR phase16-chart-source. Static stack only.
+```
+- **Accept:** No two unlabeled conflicting "current" prices; chart has source/freshness caption.

--- a/docs/revamp/phases/phase-17.md
+++ b/docs/revamp/phases/phase-17.md
@@ -1,0 +1,12 @@
+# Phase 17 — Unified freshness vocabulary + legend component
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 17 — Unified freshness vocabulary + legend component
+- **Maps to:** P2-5 (vocabulary drift across surfaces).
+- **Branch:** `phase17-freshness-vocab` · **PR:** One freshness vocabulary everywhere
+```
+Define one canonical freshness vocabulary (Live, Delayed, Cached, Stale, Fallback, Unavailable) with one color token each (from Phase 3). Replace divergent terms (e.g. the "About Our Prices" card mentions "Estimated/Historical baseline"; the states box differs). Build a single reusable FreshnessBadge + a small legend, used by homepage, calculator, country pages, ticker, and exports. Localize labels. Open PR phase17-freshness-vocab. Static stack only.
+```
+- **Accept:** Identical state names/colors on every surface and in CSV/JSON exports.

--- a/docs/revamp/phases/phase-18.md
+++ b/docs/revamp/phases/phase-18.md
@@ -1,0 +1,12 @@
+# Phase 18 — Quick-convert never blank (seed from cache)
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 18 — Quick-convert never blank (seed from cache)
+- **Maps to:** P1-5 (blank reference value on first paint).
+- **Branch:** `phase18-quickconvert-seed` · **PR:** Instant cached value + freshness
+```
+On the homepage inline Quick-convert, ensure a numeric reference value is shown on first paint by seeding from the localStorage cached price (the site already caches), labeled with freshness, then updating on live fetch. Eliminate the empty/underline-only state. Add a CLS-safe reserved space for the number. Read the quick-convert + cache modules first. Open PR phase18-quickconvert-seed. Never show a cached number unlabeled.
+```
+- **Accept:** A labeled number always visible immediately; no layout shift when live value lands.

--- a/docs/revamp/phases/phase-19.md
+++ b/docs/revamp/phases/phase-19.md
@@ -1,0 +1,12 @@
+# Phase 19 — Spot-vs-retail trust chip (sitewide)
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 19 — Spot-vs-retail trust chip (sitewide)
+- **Maps to:** strengthens core trust promise (audit §5 idea).
+- **Branch:** `phase19-trust-chip` · **PR:** Persistent freshness+source chip linking methodology
+```
+Add a small, consistent "reference price · source · freshness" chip to every price card (homepage spot, calculator result, country cards) that deep-links to the relevant methodology anchor (spot -> #live-formula, AED -> #aed-peg). Reuse FreshnessBadge from Phase 17. Keep it lightweight and accessible. Localize. Open PR phase19-trust-chip. Static stack only.
+```
+- **Accept:** Every price card shows source+freshness and links to methodology; works EN/AR.

--- a/docs/revamp/phases/phase-20.md
+++ b/docs/revamp/phases/phase-20.md
@@ -1,0 +1,12 @@
+# Phase 20 — Methodology copy de-jargon
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 20 — Methodology copy de-jargon
+- **Maps to:** P2-4 (exposes repo paths).
+- **Branch:** `phase20-methodology-copy` · **PR:** User-facing methodology language
+```
+Rewrite the methodology sections that expose internal build mechanics (.github/workflows/gold-price-fetch.yml, data/gold_price.json, "no API keys in client bundle", localStorage) into user-facing language ("an automated hourly job refreshes our committed price snapshot", "your browser keeps a labeled local copy so you always see a number"). Keep all the substance and transparency; drop literal repo filenames. Apply to EN and AR. Open PR phase20-methodology-copy. Content only.
+```
+- **Accept:** No literal repo paths/workflow filenames in user copy; substance preserved EN+AR.

--- a/docs/revamp/phases/phase-21.md
+++ b/docs/revamp/phases/phase-21.md
@@ -1,0 +1,11 @@
+# Phase 21 — Disclaimer & "not retail" consistency pass
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 21 — Disclaimer & "not retail" consistency pass
+- **Branch:** `phase21-disclaimer-consistency` · **PR:** Standardize disclaimers
+```
+Audit every surface for the spot-vs-retail / not-financial-advice disclaimer. Standardize one short inline disclaimer + one full disclaimer block, placed consistently (price cards, calculator, country pages, exports, footer). Ensure VAT-by-country and making-charge notes match the methodology figures. Localize. Open PR phase21-disclaimer-consistency. Content + small template edits only.
+```
+- **Accept:** Consistent disclaimer wording/placement sitewide; figures match methodology.

--- a/docs/revamp/phases/phase-22.md
+++ b/docs/revamp/phases/phase-22.md
@@ -1,0 +1,13 @@
+# Phase 22 — Stale/unavailable visual states polish
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 22 — Stale/unavailable visual states polish
+- **Branch:** `phase22-degraded-states` · **PR:** Clear degraded-state UI
+```
+Harden the degraded states: when data is Stale/Fallback/Unavailable, show the labeled state, age, and an em-dash for missing numbers (already done on methodology — generalize it) with an accessible, non-alarming style. Ensure no surface ever shows a stale number styled as live. Add tests. Open PR phase22-degraded-states. Static stack only.
+```
+- **Accept:** All surfaces degrade gracefully and identically; tests assert no "live" styling on stale.
+
+---

--- a/docs/revamp/phases/phase-23.md
+++ b/docs/revamp/phases/phase-23.md
@@ -1,0 +1,12 @@
+# Phase 23 — Header nav breakpoint (stop logo overlap)
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 23 — Header nav breakpoint (stop logo overlap)
+- **Maps to:** P1-3 (nav overlaps logo ~792–1240px).
+- **Branch:** `phase23-nav-breakpoint` · **PR:** Raise hamburger breakpoint
+```
+The desktop nav overlaps the logo between ~768px and ~1240px because the hamburger only engages below ~792px. Read the header/nav component + its CSS. Raise the collapse breakpoint (switch to the existing hamburger at ~1024–1100px) or let the nav condense before it collides; verify no overlap of logo, links, search icon, theme toggle, language button, or CTA at 768/900/1024/1200/1280/1440 in BOTH EN and AR (RTL). Open PR phase23-nav-breakpoint with screenshots at those widths in both languages. Static stack only.
+```
+- **Accept:** No header element overlap at any width in EN or AR; hamburger works.

--- a/docs/revamp/phases/phase-24.md
+++ b/docs/revamp/phases/phase-24.md
@@ -1,0 +1,11 @@
+# Phase 24 — Mobile header & ticker density
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 24 — Mobile header & ticker density
+- **Branch:** `phase24-mobile-header` · **PR:** ≤480px header/ticker
+```
+Verify and fix the header, the scrolling price ticker, and the status banner at 320/360/390/414px in EN and AR. Ensure tap targets ≥44px, the ticker is readable and pausable, and the status banner is dismissible without covering content. Open PR phase24-mobile-header with mobile screenshots EN/AR. Static stack only.
+```
+- **Accept:** Clean header/ticker at phone widths both languages; 44px targets.

--- a/docs/revamp/phases/phase-25.md
+++ b/docs/revamp/phases/phase-25.md
@@ -1,0 +1,12 @@
+# Phase 25 — Tracker-handoff layout rebalance
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 25 — Tracker-handoff layout rebalance
+- **Maps to:** P2-7 (narrow text column, big empty space).
+- **Branch:** `phase25-handoff-layout` · **PR:** Rebalance calculator handoff grid
+```
+On /calculator the "Compare this in the live tracker" block wraps ~3 words per line in a narrow column with large empty space. Read the section's grid/flex CSS and rebalance so the text column has a comfortable measure (~60–75ch) and the CTAs sit logically. Check EN + AR. Open PR phase25-handoff-layout. Static stack only.
+```
+- **Accept:** Comfortable line length; balanced layout EN/AR.

--- a/docs/revamp/phases/phase-26.md
+++ b/docs/revamp/phases/phase-26.md
@@ -1,0 +1,12 @@
+# Phase 26 — Bidi isolation for mixed EN/AR strings
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 26 — Bidi isolation for mixed EN/AR strings
+- **Maps to:** P2-8 (`AED 435.37 د.إ per gram` glitch).
+- **Branch:** `phase26-bidi` · **PR:** Wrap currency/number tokens in bidi isolates
+```
+Fix mixed-direction rendering where currency glyphs/numbers are embedded in opposite-direction sentences (e.g. helper text "AED 435.37 د.إ per gram"). Wrap currency/amount tokens in <bdi> / unicode isolates and verify ordering in EN and AR across ticker, cards, calculator helper, exports. Read the formatting/number helper module first. Add a couple of tests. Open PR phase26-bidi. Static stack only.
+```
+- **Accept:** Currency+number tokens order correctly in both directions.

--- a/docs/revamp/phases/phase-27.md
+++ b/docs/revamp/phases/phase-27.md
@@ -1,0 +1,12 @@
+# Phase 27 — Repeated "Quote verification checklist" headings
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 27 — Repeated "Quote verification checklist" headings
+- **Maps to:** P2-3.
+- **Branch:** `phase27-checklist-headings` · **PR:** Differentiate or merge checklist cards
+```
+The three "Quote verification checklist" cards share an identical heading. Either give each a distinct sub-heading reflecting its bullets (e.g. "On the invoice", "On the charges", "Against the reference") or merge into one grouped block. Keep content; fix EN + AR. Open PR phase27-checklist-headings. Content/template only.
+```
+- **Accept:** No duplicate identical headings; content intact EN/AR.

--- a/docs/revamp/phases/phase-28.md
+++ b/docs/revamp/phases/phase-28.md
@@ -1,0 +1,11 @@
+# Phase 28 — Country/price page responsive QA
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 28 — Country/price page responsive QA
+- **Branch:** `phase28-country-responsive` · **PR:** Country page layout pass
+```
+Pick representative country pages (UAE, Saudi, Kuwait + one MENA + one Global) and QA their layout/tables at 360/768/1024/1440 in EN and AR, fixing overflow, table scroll, and currency-symbol alignment. Apply fixes via the shared template so all ~24 countries benefit. Open PR phase28-country-responsive with screenshots. Static stack only.
+```
+- **Accept:** No overflow/misalignment on sampled pages; fix is template-level.

--- a/docs/revamp/phases/phase-29.md
+++ b/docs/revamp/phases/phase-29.md
@@ -1,0 +1,11 @@
+# Phase 29 — Theme toggle correctness (light/dark/system)
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 29 — Theme toggle correctness (light/dark/system)
+- **Branch:** `phase29-theme-toggle` · **PR:** Robust theme switching
+```
+Audit the theme toggle: ensure it respects system preference on first load, persists choice, applies before first paint (no flash), and that BOTH themes meet the contrast targets from Phase 30. Verify the toggle icon state matches actual theme. Read the theme module. Open PR phase29-theme-toggle. Static stack only.
+```
+- **Accept:** No theme flash; persisted; icon matches state.

--- a/docs/revamp/phases/phase-30.md
+++ b/docs/revamp/phases/phase-30.md
@@ -1,0 +1,13 @@
+# Phase 30 — Layout-shift (CLS) hardening
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 30 — Layout-shift (CLS) hardening
+- **Branch:** `phase30-cls` · **PR:** Reserve space for async data
+```
+Identify CLS sources: price values arriving after first paint, the chart loading, the quick-convert number, country cards. Reserve fixed space / use skeletons (the project already has skeleton modules) so numbers swap in without shifting layout. Target CLS <0.1 on homepage, calculator, a country page (per Phase 4 reports). Open PR phase30-cls with before/after CLS numbers. Static stack only.
+```
+- **Accept:** CLS <0.1 on the three pages; values swap without shift.
+
+---

--- a/docs/revamp/phases/phase-31.md
+++ b/docs/revamp/phases/phase-31.md
@@ -1,0 +1,12 @@
+# Phase 31 — Light-mode contrast fix
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 31 — Light-mode contrast fix
+- **Maps to:** P1-4 (muted `rgb(160,152,144)` ≈ 2.7:1 on cream).
+- **Branch:** `phase31-contrast` · **PR:** WCAG AA text contrast (light theme)
+```
+Using the Phase 3 tokens, darken muted/secondary text so it meets ≥4.5:1 on the cream light background (current ~2.7:1) and fix small gold/amber label text on cream (~2.8:1). Re-verify dark mode separately. Run axe + a contrast checker on homepage, calculator, methodology, a country page in EN/AR. Open PR phase31-contrast with computed ratios before/after. Use the `a11y-audit` skill conventions. Static stack only.
+```
+- **Accept:** All body/secondary text ≥4.5:1, large text ≥3:1, both themes.

--- a/docs/revamp/phases/phase-32.md
+++ b/docs/revamp/phases/phase-32.md
@@ -1,0 +1,11 @@
+# Phase 32 — Focus states & keyboard nav
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 32 — Focus states & keyboard nav
+- **Branch:** `phase32-focus-keyboard` · **PR:** Visible focus + full keyboard path
+```
+Ensure every interactive element (nav, hamburger, language/theme toggles, calculator inputs, tabs, chart controls, dismiss buttons) has a visible :focus-visible style and a logical tab order, including in the mobile menu and in RTL. Add skip-to-content link. Test keyboard-only EN/AR. Open PR phase32-focus-keyboard. Static stack only.
+```
+- **Accept:** Keyboard-only operable; visible focus everywhere; skip link present.

--- a/docs/revamp/phases/phase-33.md
+++ b/docs/revamp/phases/phase-33.md
@@ -1,0 +1,11 @@
+# Phase 33 — Semantic structure & landmarks
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 33 — Semantic structure & landmarks
+- **Branch:** `phase33-semantics` · **PR:** Headings, landmarks, labels
+```
+Audit heading hierarchy (single h1/page, no skipped levels), landmark roles (header/nav/main/footer), and form labels on the calculator. Fix the calculator inputs to have programmatic labels and the tab groups to use proper ARIA tablist semantics. Verify with axe. Open PR phase33-semantics EN/AR. Static stack only.
+```
+- **Accept:** Clean heading outline; labeled inputs; ARIA tabs valid.

--- a/docs/revamp/phases/phase-34.md
+++ b/docs/revamp/phases/phase-34.md
@@ -1,0 +1,11 @@
+# Phase 34 — Screen-reader pass for live prices
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 34 — Screen-reader pass for live prices
+- **Branch:** `phase34-sr-live` · **PR:** aria-live for price/freshness updates
+```
+Make auto-updating prices and freshness changes announce sensibly to screen readers using polite aria-live regions (avoid spamming on every ~1s tick — throttle/announce meaningful changes). Ensure the ticker is labeled and not a focus trap. Test with VoiceOver/NVDA notes. Open PR phase34-sr-live. Static stack only.
+```
+- **Accept:** Meaningful, non-spammy SR announcements; ticker labeled.

--- a/docs/revamp/phases/phase-35.md
+++ b/docs/revamp/phases/phase-35.md
@@ -1,0 +1,11 @@
+# Phase 35 — Reduced motion & animation hygiene
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 35 — Reduced motion & animation hygiene
+- **Branch:** `phase35-reduced-motion` · **PR:** Respect prefers-reduced-motion
+```
+The site uses reveal-on-scroll, count-up, price-motion, freshness-pulse. Gate all non-essential animation behind prefers-reduced-motion: reduce (no count-up, no pulsing, instant reveals) while keeping content fully visible. Read the animation modules. Open PR phase35-reduced-motion. Static stack only.
+```
+- **Accept:** With reduced-motion on, no animations; content fully shown.

--- a/docs/revamp/phases/phase-36.md
+++ b/docs/revamp/phases/phase-36.md
@@ -1,0 +1,13 @@
+# Phase 36 — Alt text & non-text content
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 36 — Alt text & non-text content
+- **Branch:** `phase36-alt-text` · **PR:** Decorative vs informative media
+```
+Audit imagery (CSS-background hero, country flags, icons, generated OG assets). Ensure informative graphics have text alternatives and decorative ones are correctly hidden from AT (aria-hidden / empty alt). Country flags should expose the country name. Open PR phase36-alt-text. Static stack only.
+```
+- **Accept:** Flags/icons have correct names or are properly decorative; axe clean.
+
+---

--- a/docs/revamp/phases/phase-37.md
+++ b/docs/revamp/phases/phase-37.md
@@ -1,0 +1,12 @@
+# Phase 37 — Bundle consolidation
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 37 — Bundle consolidation
+- **Maps to:** P2-2 (~30+ JS chunks).
+- **Branch:** `phase37-bundle` · **PR:** Consolidate critical-path JS
+```
+The homepage loads ~30+ small JS modules plus an inline data: module. Review the Vite chunking config and consolidate critical-path modules (shell: nav/footer/ticker/spotBar + price/freshness) into fewer, cache-efficient chunks while keeping non-critical features (chart, SLA panel, exports) lazy-loaded. Measure requests + transfer before/after. Do not change behavior. Open PR phase37-bundle. Stay on Vite; no build-tool swap.
+```
+- **Accept:** Fewer critical requests, equal behavior, Perf score not lower.

--- a/docs/revamp/phases/phase-38.md
+++ b/docs/revamp/phases/phase-38.md
@@ -1,0 +1,12 @@
+# Phase 38 — favicon & PWA icon fix
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 38 — favicon & PWA icon fix
+- **Maps to:** P2-1 (favicon.svg 404).
+- **Branch:** `phase38-favicon` · **PR:** Add favicon + manifest icons
+```
+/assets/favicon.svg returns 404. Add a proper favicon set (SVG + ICO + apple-touch + maskable PNGs) and wire them in <head> and the web manifest. Verify no 404s in network. Open PR phase38-favicon. Static stack only.
+```
+- **Accept:** No favicon 404; tab/PWA icons present.

--- a/docs/revamp/phases/phase-39.md
+++ b/docs/revamp/phases/phase-39.md
@@ -1,0 +1,11 @@
+# Phase 39 — Font loading optimization
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 39 — Font loading optimization
+- **Branch:** `phase39-fonts` · **PR:** font-display + preload + subset
+```
+Fonts are self-hosted woff2 (Source Sans 3 + Cairo). Add font-display: swap, preload the critical Latin + Arabic subsets used above the fold, and verify subsetting trims unused glyphs. Avoid FOIT; keep CLS stable with size-adjust if needed. Open PR phase39-fonts. Static stack only.
+```
+- **Accept:** No invisible-text flash; reduced font bytes; CLS unaffected.

--- a/docs/revamp/phases/phase-40.md
+++ b/docs/revamp/phases/phase-40.md
@@ -1,0 +1,11 @@
+# Phase 40 — Image & hero optimization
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 40 — Image & hero optimization
+- **Branch:** `phase40-images` · **PR:** Responsive images + lazy + dimensions
+```
+Audit images (WebP hero background, flags, generated assets). Serve responsive sizes, set explicit width/height (or aspect-ratio) to prevent CLS, lazy-load below the fold, and preload the LCP image. Add AVIF alongside WebP where it helps. Open PR phase40-images with LCP before/after. Static stack only.
+```
+- **Accept:** LCP image preloaded; below-fold lazy; no CLS from images.

--- a/docs/revamp/phases/phase-41.md
+++ b/docs/revamp/phases/phase-41.md
@@ -1,0 +1,11 @@
+# Phase 41 — Caching, headers & service worker
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 41 — Caching, headers & service worker
+- **Branch:** `phase41-caching` · **PR:** Cache headers + offline SW review
+```
+Review Express/static hosting headers: long cache for hashed assets, short/validated cache for HTML, correct content-types. Review the existing service worker/offline behavior so cached prices are served labeled and the SW never serves stale HTML indefinitely. Add a cache-busting/version strategy. Open PR phase41-caching. Static stack only; never serve stale data as live.
+```
+- **Accept:** Correct cache headers; SW serves labeled offline data; HTML updates on deploy.

--- a/docs/revamp/phases/phase-42.md
+++ b/docs/revamp/phases/phase-42.md
@@ -1,0 +1,13 @@
+# Phase 42 — Analytics & consent (privacy-safe)
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 42 — Analytics & consent (privacy-safe)
+- **Branch:** `phase42-analytics-consent` · **PR:** Consent-gated analytics + ad-slot review
+```
+There are analytics scripts and ad slots present. Add a privacy-respectful consent mechanism (region-aware; default to least data), gate analytics/ads behind consent, ensure no PII in URLs, and keep the page fast when consent is denied. Document what is collected in a privacy page (EN/AR). Read current analytics/adSlot modules. Open PR phase42-analytics-consent. Static stack only.
+```
+- **Accept:** Analytics/ads load only after consent; privacy page live EN/AR.
+
+---

--- a/docs/revamp/phases/phase-43.md
+++ b/docs/revamp/phases/phase-43.md
@@ -1,0 +1,13 @@
+# Phase 43 — Brand/OG social images
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 43 — Brand/OG social images
+- **Branch:** `phase43-og-images` · **PR:** Default + per-template OG images
+- **Higgsfield prompt (default OG, 1.91:1 / 1200×630):**
+  > "Premium minimalist OG banner for gold-price reference site 'Gold Ticker Live'. Deep charcoal background, warm antique-gold glow lower-right, a restrained stack of gold bullion bars on the right third, large clean negative space on the left for text, editorial fintech look, palette cream / antique gold #C4902E / charcoal, no text, no logo, no charts, soft studio light."
+```
+Add Open Graph/Twitter images: a default brand image plus a small set of template variants (homepage, calculator, country, methodology). Place generated assets under /public (or /src/assets) and wire og:image/twitter:image per page+locale with correct dimensions and alt. Provide an AR variant if text is overlaid later. Read Phase 8 meta wiring. Open PR phase43-og-images. Static stack only.
+```
+- **Accept:** Valid OG image per template+locale; passes social validators.

--- a/docs/revamp/phases/phase-44.md
+++ b/docs/revamp/phases/phase-44.md
@@ -1,0 +1,13 @@
+# Phase 44 — Hero & section imagery refresh
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 44 — Hero & section imagery refresh
+- **Branch:** `phase44-hero-art` · **PR:** Optimized hero/section art
+- **Higgsfield prompt (hero, 16:9, dark-mode aware):**
+  > "Subtle hero background texture for a gold finance site, near-black with faint gold bullion bokeh and a soft warm gradient, very low-contrast so white/cream text sits cleanly on top, no focal subject, no text, elegant, premium."
+```
+Replace/optimize the hero and key section imagery with on-brand assets that work in BOTH light and dark themes and don't harm text contrast (coordinate with Phase 31). Export WebP+AVIF, set dimensions, preload LCP. Open PR phase44-hero-art with light/dark screenshots. Static stack only.
+```
+- **Accept:** Hero looks premium in both themes; text contrast preserved; no CLS.

--- a/docs/revamp/phases/phase-45.md
+++ b/docs/revamp/phases/phase-45.md
@@ -1,0 +1,11 @@
+# Phase 45 — Micro-interactions & motion polish
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 45 — Micro-interactions & motion polish
+- **Branch:** `phase45-motion-polish` · **PR:** Tasteful, reduced-motion-safe interactions
+```
+Refine the existing animations (price count-up, freshness pulse, reveal) for tasteful, fast, non-janky motion; ensure price changes use a subtle up/down color flash that is colorblind-safe (not color-only). All gated by Phase 35 reduced-motion. Open PR phase45-motion-polish. Static stack only.
+```
+- **Accept:** Smooth, subtle motion; colorblind-safe direction cues; reduced-motion respected.

--- a/docs/revamp/phases/phase-46.md
+++ b/docs/revamp/phases/phase-46.md
@@ -1,0 +1,11 @@
+# Phase 46 — Dark-mode visual QA
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 46 — Dark-mode visual QA
+- **Branch:** `phase46-darkmode-qa` · **PR:** Dark theme contrast + surface polish
+```
+Full dark-mode pass across homepage, calculator, methodology, country pages, EN/AR: verify token-based surfaces, borders, freshness colors, and gold accents meet contrast and look intentional (no muddy grays). Fix any low-contrast dark-mode text. Open PR phase46-darkmode-qa with screenshots. Static stack only.
+```
+- **Accept:** Dark mode consistent and AA-compliant on all key pages.

--- a/docs/revamp/phases/phase-47.md
+++ b/docs/revamp/phases/phase-47.md
@@ -1,0 +1,13 @@
+# Phase 47 — Iconography & visual system consistency
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 47 — Iconography & visual system consistency
+- **Branch:** `phase47-icons` · **PR:** Unify icons, spacing, card styles
+```
+Audit icons (mixed emoji + line icons were observed) and standardize on one icon set with consistent stroke/size and accessible labels; unify card paddings/radii/shadows via Phase 3 tokens. Replace decorative emoji in primary UI with the icon set (keep them only where intentional). Open PR phase47-icons EN/AR. Static stack only.
+```
+- **Accept:** One coherent icon/card system; emoji removed from primary UI.
+
+---

--- a/docs/revamp/phases/phase-48.md
+++ b/docs/revamp/phases/phase-48.md
@@ -1,0 +1,11 @@
+# Phase 48 — Internal linking & programmatic SEO QA
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 48 — Internal linking & programmatic SEO QA
+- **Branch:** `phase48-internal-linking` · **PR:** Cross-links + pSEO template QA
+```
+Strengthen internal linking: every country page links to calculator/methodology/related countries; methodology anchors link from price chips (Phase 19); guides interlink. QA the programmatic country/karat pages for unique titles/meta, no thin-content duplication, correct hreflang, and consistent freshness/disclaimer. Use the `seo-audit` and `programmatic-seo` skill conventions. Open PR phase48-internal-linking with a link-graph summary. Static stack only.
+```
+- **Accept:** No orphan pages; pSEO pages unique + compliant; methodology cross-linked.

--- a/docs/revamp/phases/phase-49.md
+++ b/docs/revamp/phases/phase-49.md
@@ -1,0 +1,11 @@
+# Phase 49 — Full bilingual regression & QA gate
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 49 — Full bilingual regression & QA gate
+- **Branch:** `phase49-regression` · **PR:** Cross-browser/device + a11y/SEO regression
+```
+Run a full regression across homepage, calculator, methodology, 3 country pages, EN + AR, in Chromium/Firefox/WebKit at 390/768/1024/1440: verify nav (no overlap), freshness labels (no "live" on stale), calculator math (peg 3.6725 exact), RTL correctness, contrast (AA), CLS <0.1, valid hreflang/canonical/JSON-LD, and no console/network errors (favicon fixed). Promote the Phase 4 budgets to BLOCKING. File issues for any miss. Open PR phase49-regression with the full report. Static stack only.
+```
+- **Accept:** All checks pass; quality budgets now block PRs.

--- a/docs/revamp/phases/phase-50.md
+++ b/docs/revamp/phases/phase-50.md
@@ -1,0 +1,30 @@
+# Phase 50 — Launch, monitoring & docs
+
+> One phase = one or more PRs. Paste the PROMPT block into Claude Code in the GoldTickerLive repo.
+> Guardrail: stay on the static Vite stack — no framework migration, SSR, or build-tool swap.
+
+## Phase 50 — Launch, monitoring & docs
+- **Branch:** `phase50-launch` · **PR:** Sitemap submit, monitoring, runbook
+```
+Finalize: confirm sitemaps/robots, prepare Search Console submission notes (EN+AR), add basic uptime/freshness monitoring (alert if all price sources fail or data is "Unavailable" beyond a threshold), and write docs/RUNBOOK.md (data pipeline, freshness logic, deploy, rollback) and docs/CONTRIBUTING.md (the static-stack guardrails). Update README with the new architecture overview. Open PR phase50-launch. Static stack only; no behavior change beyond monitoring.
+```
+- **Accept:** Monitoring live; docs complete; submission checklist ready.
+
+---
+
+## Dependency / sequencing notes
+
+- **Run 00 → 1–5 first** (map + safety + tokens) — everything else leans on tokens (Phase 3) and tests (Phase 1).
+- **Wave 1 (6–14)** is the highest-ROI block (Arabic indexability + canonical/hreflang). Phase 7 blocks 8, 9, 10, 13, 14.
+- **Wave 2 (15–22)** depends on Phase 3 tokens + Phase 1 tests; Phase 17 blocks 19, 22.
+- **Phase 31 (contrast)** should land before/with Phases 44–46 (visual) so art is built against final tokens.
+- **Phase 4 budgets** start report-only and become blocking in Phase 49.
+
+## Skills / connectors to lean on per wave
+- SEO waves: `seo-audit`, `schema`, `programmatic-seo`, `ai-seo` skill conventions.
+- A11y waves: `a11y-audit` / `accesslint-scan`.
+- Assets: **Higgsfield** (`generate_image`) for OG/hero; `image` skill for optimization/export (WebP/AVIF, OG sizing).
+- Testing: `webapp-testing` (Playwright) for the regression gate (Phase 49).
+- Each phase prompt already instructs Claude Code to read first, branch, implement minimally, self-verify, and open one PR.
+```
+```

--- a/docs/revamp/qa/live-qa-2026-06-30.md
+++ b/docs/revamp/qa/live-qa-2026-06-30.md
@@ -1,0 +1,45 @@
+# Live-site QA — goldtickerlive.com (2026-06-30)
+
+Done from this Claude Code session via Claude-in-Chrome (Browser 1 / macOS). Replaces the deferred
+Cowork live-QA. Window had a ~923px CSS floor, so sub-900px widths could not be tested here (noted
+where relevant).
+
+## Verdicts vs the original audit
+
+| #   | Audit item                      | Live verdict           | Evidence                                                                                                                                                                                                                                 |
+| --- | ------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Arabic not separately indexable | 🔴 **STILL OPEN (P0)** | `/ar/` returns `200` but `<meta robots="noindex,follow">`, `<link canonical=https://goldtickerlive.com/>` (the EN page), `<html lang="ar">`. Homepage `hreflang="ar"` → `https://goldtickerlive.com/?lang=ar` (query param, not `/ar/`). |
+| 2   | Canonical `/calculator.html`    | ✅ NOT A BUG           | `.html` canonicals consistent with sitemap + og:url (code-verified)                                                                                                                                                                      |
+| 3   | "Live" on stale data            | ✅ FIXED               | label is `<2min` only; `STALE_LIVE_PREVENTED` guard (code)                                                                                                                                                                               |
+| 4   | Chart vs spot mismatch          | ✅ FIXED               | unified source (code)                                                                                                                                                                                                                    |
+| 5   | Nav overlaps logo ~768–1240px   | ✅ NOT REPRODUCIBLE    | EN nav content = **867px** in a 923px bar, `brandOverlapsLinks=false`, `linksOverlapActions=false`. Hamburger appears <641px. Any residual is below ~880px (untestable here).                                                            |
+| 6   | Muted-text contrast             | ✅ FIXED               | light token `#6a5c48` ≈ 6.27:1 (code)                                                                                                                                                                                                    |
+| 7   | Quick-convert blank             | 🟡 EDGE CASE           | live value shows `4,757.42 د.إ` (cached price present at boot). Blank only when no fresh cache at first paint → hardened by **#474**.                                                                                                    |
+| 8   | favicon 404                     | ✅ FIXED               | assets present (code)                                                                                                                                                                                                                    |
+
+## Trust layer (live) — strong
+
+- Spot card and top ticker agree: **$4,030.40 XAU/USD**; AED/g shown as reference.
+- Freshness labelled live: status banner "مخزن مؤقتاً · قبل 25 ثانية" (Cached · 25s ago), source
+  **Gold-API.com** attributed.
+- Reference-not-retail language present ("shops add making charges & VAT" equivalent in AR).
+- Graceful: cached values clearly badged, not presented as live.
+
+## The one real P0 — Arabic homepage indexability
+
+- `/ar/` (homepage) is a **noindex redirect stub** that canonicalises to the **English** homepage
+  and bounces to `/?lang=ar`.
+- The EN homepage advertises `hreflang="ar"` → `/?lang=ar`, a URL Google won't treat as a distinct
+  page.
+- BUT the **/ar/ sub-pages already work** (`/ar/methodology/`, `/ar/chart/`, `/ar/gold-price/24k/`
+  are real indexable pages with self-canonical + reciprocal hreflang). So the pattern exists — the
+  homepage just hasn't adopted it.
+- **Fix direction (Phase 06–14):** make `/ar/` a real indexable Arabic homepage (drop noindex,
+  self-canonical `/ar/`, localized `<title>`/meta), point the EN homepage `hreflang="ar"` at `/ar/`,
+  and update `build/generatePages.js` + `src/seo/hreflang.js` + the language toggle to emit
+  `/ar/...` instead of `?lang=ar`. Mirror the existing /ar/ sub-page pattern.
+
+## Not testable in this environment
+
+- Sub-900px mobile widths (window CSS floor ~923px) — the residual nav band <880px and true phone
+  layout need a real device or DPR override.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,8 @@
 export default [
   {
     ignores: [
+      // Agent Workflow-DSL scripts (top-level await/return); not app modules.
+      '.claude/**',
       'dist/**',
       'node_modules/**',
       'build/**',


### PR DESCRIPTION
## What this adds

Planning-only PR. No app code changes — adds `docs/revamp/`:

- **`00-AUDIT.md`** — live-site audit of goldtickerlive.com (2026-06-30). Every claim tagged **VERIFIED** (seen on screen / in source) vs **UNVERIFIED** (assumption).
- **`MASTER-50-PHASE-PLAN.md`** — full A-to-Z revamp: 50 phases in 7 waves, plus the brand/asset library and sequencing/dependencies.
- **`phases/phase-00.md … phase-50.md`** — one paste-ready Claude Code prompt per phase, each with branch name, scope, acceptance criteria, and a hard guardrail. **A phase may be one or several PRs.**
- **`README.md`** — index + priority map.

## Guardrail

Stays on the **existing static stack** (vanilla ES6 + Vite, Express, Supabase). **No** framework migration, SSR, or build-tool swap is proposed anywhere.

## Priority map (from the audit)

- **P0** — Arabic not separately indexable (lang toggle is client-only, no distinct URL, EN `<title>`/meta in AR mode); canonical mismatch (`/` vs `/calculator.html`).
- **P1** — "Live" label on ~9-min-old data; homepage chart vs spot price mismatch; header nav overlaps logo ~768–1240px; muted text ~2.7:1 contrast (fails WCAG AA); quick-convert blank value.
- **P2** — favicon 404; ~30 JS chunks; repeated checklist headings; repo paths leaked in methodology copy; freshness-vocabulary / numeral / bidi consistency.

## How to execute

Open Claude Code on a fresh `main`, run `docs/revamp/phases/phase-00.md`, then proceed in order. Each phase: branch `phaseNN-slug`, implement, self-verify, open PR(s), review + merge before the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent tooling only; no changes to pricing, SEO emission, or user-facing runtime behavior beyond README links and ESLint ignore rules.
> 
> **Overview**
> Adds a **planning-only** revamp execution pack under `docs/revamp/` (no application code changes): a **2026-06-30 live-site audit** with VERIFIED/UNVERIFIED tags, a **50-phase master plan** in seven waves (static-stack guardrails throughout), **per-phase paste prompts** (`phases/phase-00.md` … `phase-50.md`), a **progress tracker**, a **Cowork handoff** for parallel browser/asset work, and **live QA** that re-checks audit items (calling out **Arabic `/ar/` homepage indexability** as the main open P0).
> 
> Introduces reusable **Claude Code workflows** in `.claude/workflows/`: **`pre-pr-review`** (validate + test + lint, then adversarial diff review → go/no-go) and **`audit-reverify`** (OPEN/FIXED/etc. against current code). The root **README** now points agents at the revamp docs and workflows; **ESLint** ignores `.claude/**` so Workflow-DSL scripts are not linted as app modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0816b5d2deeae6ca3dc5e50e5761cb40712d2a01. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->