### PR TITLE
Phase 27 — Unique location-guide checklist headings (a11y/SEO)

### DIFF
--- a/src/components/LocationGuideSection.js
+++ b/src/components/LocationGuideSection.js
@@ -22,7 +22,7 @@ export function renderLocationGuideSection({ lang = 'en', t = (key) => key, clas
       el(
         'h4',
         { class: 'location-guide-card__checklist-title' },
-        t('locationGuides.checklistTitle')
+        `${pickText(guide, lang, 'city', 'cityAr')} — ${t('locationGuides.checklistTitle')}`
       ),
       el(
         'ul',


### PR DESCRIPTION
## Phase 27 — unique location-guide checklist headings (P2 a11y/SEO)

### Problem
On the homepage, every location-guide card rendered the **same** `<h4>` "Quote verification checklist" (`src/components/LocationGuideSection.js`). Identical repeated headings hurt the screen-reader heading outline and look like duplicate-content to crawlers.

### Fix
Scope each checklist heading to its city using the localized name already on the card:
`"Dubai — Quote verification checklist"` (EN) / `"دبي — قائمة التحقق من العرض"` (AR). One-line change, no new strings, no behavior change.

### Verification (run locally)
- `npx eslint src/components/LocationGuideSection.js` → **clean**
- `npm run validate` (full governance suite: SEO/schema/shell-guard/a11y/unsafe-dom) → **pass**
- `npm test` → **no new failures.** Note: `main` currently has **3 pre-existing failing tests** (`nav skip-link`, `nav header banner landmark`, `offline.html asset paths`) unrelated to this change — verified byte-identical failures on `main` vs this branch. See note below.

> ⚠️ Heads-up (separate from this PR): `main` is red on 3 regression tests today. Worth a dedicated fix PR — happy to open one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line presentation change to heading text in a homepage section; no auth, data, or workflow impact.
> 
> **Overview**
> Each homepage location-guide card used the same **h4** for the quote verification checklist, which duplicated headings in the document outline and for crawlers.
> 
> The checklist **h4** now prefixes the existing localized city name (`pickText` for `city` / `cityAr`) before the translated `locationGuides.checklistTitle`, e.g. **Dubai — Quote verification checklist**. No new copy keys or functional changes—only how that heading is composed in `LocationGuideSection.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7dbe3f5588643e429834ea05345200d337bcb4c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->