### PR TITLE
fix(offline): root-absolute asset paths in SW fallback page

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -28,10 +28,6 @@
     <meta name="robots" content="noindex" />
     <meta name="theme-color" content="#b08a3e" />
     <link rel="manifest" href="/manifest.json" />
-    <link rel="icon" href="favicon.svg" type="image/svg+xml" />
-    <link rel="preload" as="style" href="styles/critical.css" />
-<link rel="stylesheet" href="styles/critical.css" />
-    <link rel="stylesheet" href="styles/global.css" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="preload" as="style" href="/styles/critical.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Fix: offline.html SW-fallback asset paths (restores red-main test)

### Problem
`offline.html` is served by the service worker as the fallback for **arbitrary** URLs, so any **relative** asset path resolves against the requested URL's directory and 404s. The page carried stale **relative duplicates** (`favicon.svg`, `styles/critical.css`, `styles/global.css`) alongside the correct root-absolute links — tripping the **D2 regression guard** `tests/fallback-page-asset-paths.test.js`, which is **failing on `main` today**.

### Fix
Remove the 4 redundant relative `<link>`s. The root-absolute equivalents (`/favicon.svg`, `/styles/critical.css` ×2, `/styles/global.css`) were already present, so **no asset is dropped** — this only de-dupes. Mirrors the passing `404.html` pattern.

### Verification (local)
- `node --test tests/fallback-page-asset-paths.test.js` → **both pages pass** (was failing for offline.html)
- Full `npm test`: failures **3 → 2** (the 2 remaining are unrelated `nav.js` banner/skip-link guards — separate PR coming)
- `check-seo-meta.js` → pass (390 files)

Part of restoring a green `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markup-only deduplication on a static fallback page; root-absolute assets were already present, so runtime behavior is unchanged aside from fixing broken relative resolution.
> 
> **Overview**
> **`offline.html`** is served by the service worker for arbitrary URLs, so relative asset URLs resolve against the request path and break styling. This change **removes four redundant relative** `<link>` tags (`favicon.svg`, `styles/critical.css` twice, `styles/global.css`) that duplicated **root-absolute** links already on the page.
> 
> No assets are dropped—the page keeps `/favicon.svg`, `/styles/critical.css`, and `/styles/global.css`, matching the **`404.html`** pattern. That restores **`tests/fallback-page-asset-paths.test.js`** (D2 guard) for `offline.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0f822b273677141f656c814a2a80d890cd7398. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->