### PR TITLE
fix(nav): single banner landmark + NAV_DATA skip-link

### DIFF
--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -353,7 +353,7 @@ export function injectNav(lang = 'en', depth = 0) {
 
   const html = `
 ${spriteMarkupIfAbsent()}
-<a class="nav-skip-link" href="#main-content">${lang === 'ar' ? 'تخطي إلى المحتوى' : 'Skip to main content'}</a>
+<a class="nav-skip-link" href="#main-content">${data.skipLink}</a>
 <header class="site-header" role="banner">
 <nav class="site-nav site-nav--premium" role="navigation" aria-label="${data.mainNav}" dir="${isRtl ? 'rtl' : 'ltr'}">
   <div class="nav-inner">
@@ -505,7 +505,7 @@ ${spriteMarkupIfAbsent()}
   const nodes = Array.from(wrapper.children);
   const anchor = document.querySelector('main') || document.body.firstElementChild;
   for (const n of nodes) document.body.insertBefore(n, anchor);
-  // The <nav> now lives inside the <header class="site-header" role="banner"> wrapper.
+  // The <nav> now lives inside the site-header banner wrapper.
   const headerEl = nodes.find((n) => n.matches && n.matches('header.site-header'));
   const navEl =
     (headerEl && headerEl.querySelector('nav.site-nav')) ||


### PR DESCRIPTION
## Fix: nav.js banner landmark + skip-link (restores 2 red-main tests)

Two source-level a11y regression guards fail on `main` today. Both are in `src/components/nav.js`.

### 1. Duplicate `<header role="banner">` landmark
The guard counts occurrences of the literal `<header class="site-header" role="banner">`. A **trailing code comment** repeated that exact string, so the count was **2** (one real element + one comment) → fail. Reworded the comment. Now exactly **1**.

### 2. Hard-coded skip-link string
The skip-link used an inline `lang === 'ar' ? '…' : '…'` ternary. `NAV_DATA` already defines `en.skipLink` / `ar.skipLink`, so the guard forbids the inline literal. Swapped to `${data.skipLink}` (single source of truth; AR now uses the canonical `تخطّ إلى المحتوى الرئيسي`).

### Verification (local)
- `node --test tests/nav-banner-landmark.test.js` → **all pass** (banner count = 1, skip-link sourced from NAV_DATA)
- `node --test tests/a11y-landmarks-headings.test.js` → banner/skip assertions **pass**
- `npx eslint src/components/nav.js` → clean
- `npm run validate` → **pass**

Together with #472 (offline.html), this brings `main`'s test suite to **green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny nav template and comment-only changes; no auth, data, or layout logic touched.
> 
> **Overview**
> Fixes two **source-level a11y regression guards** in `nav.js` without changing rendered DOM structure.
> 
> The skip link text now uses **`${data.skipLink}`** from `NAV_DATA` instead of an inline EN/AR ternary, so copy stays centralized and Arabic uses the canonical string from nav-data.
> 
> A **mount comment** was reworded so it no longer contains the exact substring `<header class="site-header" role="banner">`, which had inflated the banner landmark count to 2 and failed `nav-banner-landmark.test.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13fadb09ef84e9ad53ff27cc6813b2f9c4b9079e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->