### PR TITLE
Phase 18 — quick-convert reads live spot (no blank reference value)

### DIFF
--- a/src/components/QuickConvertWidget.js
+++ b/src/components/QuickConvertWidget.js
@@ -17,12 +17,18 @@ const UNIT_TO_GRAMS = {
 /**
  * @param {{
  *   lang: string,
- *   spotUsdPerOz: number,
+ *   spotUsdPerOz?: number,
+ *   getSpot?: () => (number|null),
  *   t: (key: string, params?: Record<string, string>) => string,
  *   mount: HTMLElement,
  * }} options
+ *
+ * Pass `getSpot` when the spot price arrives after mount (the homepage case):
+ * recalc() reads it live, so the widget fills in as soon as a price exists
+ * instead of staying stuck on the placeholder. `spotUsdPerOz` is a static
+ * fallback for callers that already have the value.
  */
-export function mountQuickConvertWidget({ lang, spotUsdPerOz, t, mount }) {
+export function mountQuickConvertWidget({ lang, spotUsdPerOz, getSpot, t, mount }) {
   if (!mount) return null;
 
   let weight = 10;
@@ -52,7 +58,11 @@ export function mountQuickConvertWidget({ lang, spotUsdPerOz, t, mount }) {
 
   const unitSelect = el(
     'select',
-    { class: 'quick-convert-widget__select', id: 'home-quick-unit', 'aria-label': t('quickConvertUnit') },
+    {
+      class: 'quick-convert-widget__select',
+      id: 'home-quick-unit',
+      'aria-label': t('quickConvertUnit'),
+    },
     [
       el('option', { value: 'gram' }, [t('unitGram')]),
       el('option', { value: 'tola' }, [t('unitTola')]),
@@ -62,7 +72,11 @@ export function mountQuickConvertWidget({ lang, spotUsdPerOz, t, mount }) {
 
   const karatSelect = el(
     'select',
-    { class: 'quick-convert-widget__select', id: 'home-quick-karat', 'aria-label': t('quickConvertKarat') },
+    {
+      class: 'quick-convert-widget__select',
+      id: 'home-quick-karat',
+      'aria-label': t('quickConvertKarat'),
+    },
     ['24', '22', '21', '18'].map((code) => {
       const k = KARATS.find((item) => item.code === code);
       const pct = k ? `${(k.purity * 100).toFixed(1)}%` : '';
@@ -70,17 +84,27 @@ export function mountQuickConvertWidget({ lang, spotUsdPerOz, t, mount }) {
     })
   );
 
-  const resultValue = el('div', {
-    class: 'quick-convert-widget__result-value',
-    id: 'home-quick-result',
-  }, ['—']);
-  const resultNote = el('p', { class: 'quick-convert-widget__result-note' }, [t('quickConvertNote')]);
+  const resultValue = el(
+    'div',
+    {
+      class: 'quick-convert-widget__result-value',
+      id: 'home-quick-result',
+    },
+    ['—']
+  );
+  const resultNote = el('p', { class: 'quick-convert-widget__result-note' }, [
+    t('quickConvertNote'),
+  ]);
 
-  const calcLink = el('a', {
-    class: 'btn btn-outline btn-sm quick-convert-widget__cta',
-    id: 'home-quick-calc-link',
-    href: 'calculator.html',
-  }, [t('quickConvertCta')]);
+  const calcLink = el(
+    'a',
+    {
+      class: 'btn btn-outline btn-sm quick-convert-widget__cta',
+      id: 'home-quick-calc-link',
+      href: 'calculator.html',
+    },
+    [t('quickConvertCta')]
+  );
 
   const form = el('div', { class: 'quick-convert-widget__form' }, [
     el('div', { class: 'quick-convert-widget__field' }, [
@@ -115,11 +139,12 @@ export function mountQuickConvertWidget({ lang, spotUsdPerOz, t, mount }) {
     unit = unitSelect.value;
     karat = karatSelect.value;
     const k = KARATS.find((item) => item.code === karat);
-    if (!spotUsdPerOz || !k || gramsFromInput() <= 0) {
+    const spot = typeof getSpot === 'function' ? getSpot() : spotUsdPerOz;
+    if (!spot || !k || gramsFromInput() <= 0) {
       resultValue.textContent = '—';
       return;
     }
-    const aedPerGram = usdPerGram(spotUsdPerOz, k.purity) * CONSTANTS.AED_PEG;
+    const aedPerGram = usdPerGram(spot, k.purity) * CONSTANTS.AED_PEG;
     const total = aedPerGram * gramsFromInput();
     countUp(resultValue, total, {
       decimals: 2,

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -771,7 +771,10 @@ function mountHomeQuickConvert() {
   if (!mount) return;
   _quickConvert = mountQuickConvertWidget({
     lang,
-    spotUsdPerOz: goldPrice,
+    // Pass a live getter, not a snapshot: goldPrice is null until the first
+    // price (cache-boot or live) lands, and the later recalc() calls must see
+    // the current value instead of the null captured at mount time.
+    getSpot: () => goldPrice,
     t: (key) => tx(key),
     mount,
   });


### PR DESCRIPTION
## Phase 18 — quick-convert no longer shows a blank reference value (P1 trust)

### Problem
The homepage **Quick convert** widget showed only the `—` placeholder for its reference value on first paint and **stayed blank** even after live prices appeared elsewhere on the page (the audit's P1-5).

**Root cause:** `mountQuickConvertWidget({ spotUsdPerOz: goldPrice })` captured `goldPrice` **at mount**, but `goldPrice` is `null` until the first cache-boot/live price lands (`src/pages/home.js`). The page calls `_quickConvert.recalc()` on every price update, but `recalc()` read the **null captured in the closure**, so it could never recover.

### Fix
Pass a **getter** (`getSpot: () => goldPrice`) instead of a snapshot. `recalc()` now reads the current price each time it runs, so the value fills in as soon as any price exists — live or cached-boot. `spotUsdPerOz` retained as a static fallback. ~6 lines across 2 files, no behavior change to the math.

### Verification (local)
- `npx eslint src/components/QuickConvertWidget.js src/pages/home.js` → clean
- `npm run validate` → pass
- `npm test` → **0 new failures** (the 3 reds are pre-existing and fixed by #472/#473)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small homepage/widget wiring fix with no auth, security, or pricing-formula changes; behavior only improves when spot arrives after mount.
> 
> **Overview**
> Fixes the homepage **Quick convert** widget staying on `—` after prices load elsewhere.
> 
> **`mountQuickConvertWidget`** now accepts optional **`getSpot`** (alongside optional static **`spotUsdPerOz`**). **`recalc()`** resolves spot with `getSpot()` when provided, otherwise falls back to **`spotUsdPerOz`**, so later recalculations see the current price instead of a **`null` value frozen at mount**.
> 
> **`mountHomeQuickConvert`** passes **`getSpot: () => goldPrice`** instead of **`spotUsdPerOz: goldPrice`**, matching the existing **`_quickConvert.recalc()`** calls on price updates. Pricing math is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9479c74eb4e4792089d4c280758cd2139db74a4e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->