### PR TITLE
feat(seo): indexable Arabic homepage at /ar/ + reciprocal hreflang (P0)

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="ar" dir="rtl">
   <head>
+    <!-- Generated from index.html by scripts/node/generate-ar-homepage.mjs — do not edit by hand. -->
     <meta charset="UTF-8" />
     <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
     <script>
@@ -20,27 +21,1291 @@
         } catch (e) {}
       })();
     </script>
+    <script src="../assets/analytics.js" defer></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#b08a3e" />
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <meta name="robots" content="noindex,follow" />
-    <title>Gold Ticker Live — العربية</title>
-    <link rel="canonical" href="https://goldtickerlive.com/" />
+    <meta name="google-site-verification" content="Sf_5tfVLL-oHt6cc8dnfIELUMbrSR7L5LgxZSYxWvMg" />
+    <meta name="msvalidate.01" content="E88623E4C36CDC8E8D44913FA9192725" />
+    <meta
+      name="description"
+      content="سعر جرام الذهب اليوم في الإمارات بالدرهم — أسعار مرجعية لعيار 24 و22 و21 و18 لدول الخليج وأكثر من 20 دولة عربية، مع تحديث تلقائي ووسم يوضّح حداثة السعر. الأسعار مرجعية وليست أسعار تجزئة."
+    />
+    <meta
+      name="keywords"
+      content="gold price today UAE, gold price Dubai, سعر الذهب اليوم, gold rate per gram AED, 24K gold price, 22K gold UAE, GCC gold prices, live gold tracker"
+    />
+    <meta
+      property="og:title"
+      content="Gold Ticker Live — Reference Gold Prices for GCC &amp; the Arab World | أسعار الذهب المرجعية"
+    />
+    <meta
+      property="og:description"
+      content="Track gold spot prices in 24+ countries. Seven karat grades (14K–24K) from gold-api.com spot + open.er-api.com FX. Source updates hourly; pages re-poll ~90s. Bilingual EN/AR."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="ar_AE" />
+    <meta property="og:locale:alternate" content="en_US" />
+    <meta property="og:url" content="https://goldtickerlive.com/ar/" />
+    <meta property="og:image" content="https://goldtickerlive.com/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gold Ticker Live — Reference Gold Prices for GCC &amp; the Arab World" />
+    <meta
+      name="twitter:description"
+      content="Track reference gold prices in UAE, Saudi Arabia, Kuwait and 20+ countries. Seven karats (14K–24K). Bilingual."
+    />
+    <meta name="twitter:image" content="https://goldtickerlive.com/assets/og-image.png" />
+    <meta property="og:image:alt" content="Gold Ticker Live — reference gold prices for the UAE, GCC and Arab world" />
+    <link rel="canonical" href="https://goldtickerlive.com/ar/" />
     <link rel="alternate" hreflang="x-default" href="https://goldtickerlive.com/" />
     <link rel="alternate" hreflang="en" href="https://goldtickerlive.com/" />
-    <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/?lang=ar" />
-<link rel="stylesheet" href="../styles/critical.css" />
+    <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/ar/" />
+    <title>أسعار الذهب اليوم في الإمارات والخليج | Gold Ticker Live</title>
+
+    <!-- DNS Prefetch -->
+    <link rel="dns-prefetch" href="https://open.er-api.com" />
+
+    <!-- Self-hosted fonts (Area A) — preload critical subsets -->
+    <link rel="preload" href="../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="../assets/fonts/cairo/cairo-arabic.woff2" as="font" type="font/woff2" crossorigin />
+
+    <!-- Critical Preloads -->
+    <link rel="preconnect" href="https://open.er-api.com" />
+    <link rel="preload" as="style" href="../styles/critical.css" />
+    <link rel="preload" as="style" href="../styles/global.css" />
+    <link rel="preload" as="style" href="../styles/pages/home.css" />
+    <link rel="modulepreload" href="../src/pages/home.js" />
+    <link rel="modulepreload" href="../src/lib/api.js" />
+    <link rel="modulepreload" href="../src/lib/realtime-pricing-engine.js" />
+    <link rel="modulepreload" href="../src/components/site-shell.js" />
+
+    <!-- Resource Hints for Prefetching -->
+    <link rel="prefetch" href="../countries/index.html" as="document" />
+
+    <!-- Critical CSS (inlined file to improve FCP) -->
+    <link rel="stylesheet" href="../styles/critical.css" />
+
+    <!-- Stylesheets -->
     <link rel="stylesheet" href="../styles/global.css" />
-    <script>
-      window.location.replace('/?lang=ar');
-    </script>
-    <noscript>
-      <meta http-equiv="refresh" content="0;url=/?lang=ar" />
-    </noscript>
+    <link rel="stylesheet" href="../styles/pages/home.css" />
+    <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png" />
+
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
+    <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32x32.png" />
+    <link rel="manifest" href="../manifest.json" />
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "Gold Ticker Live",
+  "url": "https://goldtickerlive.com",
+  "logo": "https://goldtickerlive.com/assets/logo.png",
+  "description": "Spot-linked reference gold prices for GCC, Arab world and global markets — with visible freshness labels",
+  "sameAs": [
+    "https://twitter.com/goldtickerlive",
+    "https://x.com/GoldTickerLive"
+  ],
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "contactType": "Customer Service",
+    "availableLanguage": [
+      "English",
+      "Arabic"
+    ]
+  }
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "Gold Ticker Live",
+  "url": "https://goldtickerlive.com",
+  "description": "Spot-linked reference gold prices for GCC, Arab world and global markets — with visible freshness labels",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "https://goldtickerlive.com/content/search/?q={search_term_string}"
+    },
+    "query-input": "required name=search_term_string"
+  },
+  "inLanguage": [
+    "en",
+    "ar"
+  ]
+}
+  </script>
   </head>
-  <body>
-    <p style="font-family: Cairo, sans-serif; text-align: center; padding: 2rem;">
-      جارٍ التحويل… <a href="/?lang=ar">انقر هنا إذا لم يتم التحويل تلقائياً</a>
-    </p>
+  <body class="home-page">
+    <a class="skip-link" href="#main-content" data-i18n="skipLink">Skip to main content</a>
+
+    <!-- ═══════ NAV (injected by home.js) ═══════ -->
+
+    <main id="main-content">
+      <div
+        id="home-freshness-bar"
+        class="home-freshness-bar"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        hidden
+      >
+        <span class="hfb-icon" aria-hidden="true"></span>
+        <span id="hfb-text"></span>
+        <button id="hfb-dismiss" class="hfb-dismiss" aria-label="Dismiss freshness banner" type="button">×</button>
+      </div>
+      <section class="hero" aria-labelledby="hero-headline">
+        <div class="hero-inner">
+          <div class="hero-text">
+            <div class="hero-badge" id="hero-live-badge" role="status" aria-live="polite" aria-atomic="true">
+              <span class="hero-badge-dot" aria-hidden="true"></span>
+              <span id="hero-live-label">Auto-refresh · freshness labeled</span>
+            </div>
+            <h1 id="hero-headline">
+              <span class="hero-title-main" id="hero-title-main">Gold Prices Today</span>
+              <span class="hero-title-sub" id="hero-title-sub">UAE, GCC &amp; Arab World</span>
+            </h1>
+            <p class="hero-lead" id="hero-lead">
+              Track spot-linked gold reference prices for the UAE, GCC, and Arab markets across
+              24+ countries, seven karat grades (14K–24K), and local currencies.
+            </p>
+            <p class="hero-trust-line" id="hero-trust-line">
+              Spot-linked reference prices before retail premiums, making charges, and tax.
+            </p>
+            <div class="hero-ctas">
+              <a href="../tracker.html" class="btn btn-primary" id="hero-cta-tracker"
+                >Open Live Tracker</a
+              >
+              <a href="../calculator.html" class="btn btn-outline-light" id="hero-cta-calculator"
+                >Use Gold Calculator</a
+              >
+            </div>
+            <div class="hero-ctas-secondary">
+              <a href="../countries/index.html" class="hero-secondary-link" id="hero-cta-countries"
+                >Browse Countries</a
+              >
+              <span class="hero-secondary-sep" aria-hidden="true">·</span>
+              <a
+                href="../tracker.html#mode=live&panel=alerts"
+                class="hero-secondary-link"
+                id="hero-cta-alert"
+                >Set alerts</a
+              >
+              <span class="hero-secondary-sep" aria-hidden="true">·</span>
+              <a href="../shops.html" class="hero-secondary-link" id="hero-cta-shops"
+                >Find Gold Shops</a
+              >
+              <span class="hero-secondary-sep" aria-hidden="true">·</span>
+              <a
+                href="../methodology.html"
+                class="hero-secondary-link"
+                id="hero-cta-methodology"
+                >How prices work</a
+              >
+            </div>
+          </div>
+          <div
+            class="hero-live-card spot-terminal ds-card"
+            id="hero-live-card"
+            aria-busy="true"
+            aria-describedby="hlc-trust-line"
+          >
+            <div class="hlc-header">
+              <span class="hlc-title price-kind price-kind--reference" id="hlc-title">Gold Spot Price</span>
+              <span class="hlc-market" id="hlc-market-status"></span>
+            </div>
+            <div class="price-hero price-hero--reference">
+              <div class="hlc-price-wrap price-hero__row">
+                <div
+                  class="hlc-price price-hero__value price-hero__value--xl hlc-price--loading"
+                  id="hlc-price"
+                  data-testid="gold-price"
+                >
+                  <span class="skeleton-inline shell-skeleton-price-lg"></span>
+                </div>
+              </div>
+              <div class="hlc-change-row price-hero__meta">
+                <span class="hlc-direction price-hero__direction" id="hlc-direction" hidden aria-hidden="true"></span>
+                <span class="hlc-change price-hero__change" id="hlc-change" hidden>—</span>
+                <span class="hlc-sub price-hero__unit" id="hlc-sub">per troy ounce</span>
+              </div>
+              <span
+                class="hlc-updated freshness-chip skeleton-text"
+                id="hlc-updated"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+                ><span class="skeleton-inline shell-skeleton-freshness-strip" role="presentation" aria-hidden="true"></span></span
+              >
+            </div>
+            <hr class="hlc-rule" aria-hidden="true" />
+            <p class="hlc-retail" id="hlc-retail">
+              <span class="hlc-retail-label" data-i18n="heroRetailNote"
+                >Retail prices add making charges, VAT &amp; margin</span
+              >
+              <a
+                class="hlc-retail-link"
+                href="../content/spot-vs-retail-gold-price/"
+                data-i18n="heroRetailLink"
+                >How retail differs →</a
+              >
+            </p>
+            <div class="hlc-sparkline" id="hlc-sparkline" aria-hidden="true"></div>
+            <div class="hlc-stats-row" id="hlc-stats-row" hidden>
+              <div class="hlc-stat">
+                <span class="hlc-stat-label" data-i18n="statOpenLabel">Open</span>
+                <span class="hlc-stat-value" id="hlc-stat-open">—</span>
+              </div>
+              <div class="hlc-stat">
+                <span class="hlc-stat-label" data-i18n="statHighLabel">High</span>
+                <span class="hlc-stat-value hlc-stat-value--up" id="hlc-stat-high">—</span>
+              </div>
+              <div class="hlc-stat">
+                <span class="hlc-stat-label" data-i18n="statLowLabel">Low</span>
+                <span class="hlc-stat-value hlc-stat-value--down" id="hlc-stat-low">—</span>
+              </div>
+            </div>
+            <div class="hlc-indicators">
+              <span class="hlc-badge" id="hlc-badge">XAU/USD</span>
+              <span class="hlc-high-low" id="hlc-high-low" hidden></span>
+            </div>
+            <p class="hlc-trust-line" id="hlc-trust-line">
+              Spot-linked reference · shops may add making charges, VAT, and margin
+            </p>
+            <p class="hlc-karat-teaser" id="hlc-karat-teaser">
+              <a href="#karat-strip-title" class="hlc-karat-teaser-link" id="hlc-karat-teaser-link"
+                >View all karat prices below</a
+              >
+            </p>
+            <div class="hlc-footer">
+              <div class="hlc-footer-actions">
+                <button
+                  type="button"
+                  class="hlc-export-btn"
+                  id="hlc-export-btn"
+                  aria-label="Export session price history as CSV" data-i18n-aria-label="exportCsvAria"
+                  hidden
+                >⬇ CSV</button>
+                <a href="../tracker.html" class="hlc-tracker-link" id="hlc-tracker-link"
+                  >Full Tracker →</a
+                >
+              </div>
+            </div>
+            <div id="home-freshness-badge-slot" class="home-addon-slot"></div>
+            <div id="home-realtime-sla-slot" class="home-addon-slot" hidden></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="home-chart-section" aria-labelledby="home-chart-title" data-reveal>
+        <div class="home-chart-inner">
+          <div class="home-chart-header">
+            <div class="section-intro section-intro--compact">
+              <span class="section-kicker" id="home-chart-kicker">Interactive</span>
+              <h2 class="home-section-title" id="home-chart-title">Gold Price Chart</h2>
+              <p class="home-section-sub" id="home-chart-sub">XAU/USD spot price — LBMA baseline combined with live session data</p>
+            </div>
+            <div class="home-chart-ranges ds-segmented" role="group" aria-label="Chart time range" id="home-chart-ranges">
+              <button type="button" class="home-chart-range-btn ds-segmented__btn" data-range="1Y" id="home-chart-btn-1y">1Y</button>
+              <button type="button" class="home-chart-range-btn ds-segmented__btn" data-range="3Y" id="home-chart-btn-3y">3Y</button>
+              <button type="button" class="home-chart-range-btn ds-segmented__btn is-active" data-range="ALL" id="home-chart-btn-all">ALL</button>
+            </div>
+          </div>
+          <div class="home-chart-wrap" id="home-chart-wrap">
+            <div id="home-chart-container" class="home-chart-container" aria-busy="true"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="home-price-trend" aria-labelledby="home-trend-title" data-reveal>
+        <div class="home-price-trend-inner">
+          <div class="section-intro section-intro--compact">
+            <span class="section-kicker" id="home-trend-kicker">Historical</span>
+            <h2 class="home-section-title" id="home-trend-title">Price History</h2>
+            <p class="home-section-sub" id="home-trend-sub">Monthly XAU/USD averages · LBMA baseline reference</p>
+          </div>
+          <div class="price-trend-grid" id="home-trend-grid" aria-busy="true"></div>
+        </div>
+      </section>
+
+      <section class="home-tools" aria-labelledby="home-tools-title" data-reveal>
+        <div class="home-tools-inner">
+          <div class="section-intro section-intro--compact">
+            <div>
+              <span class="section-kicker" id="home-tools-kicker">Tools</span>
+              <h2 class="home-section-title" id="home-tools-title">Start from what you need</h2>
+              <p class="home-section-sub" id="home-tools-sub">
+                Calculator, compare, shops, and guides — two clicks from live prices.
+              </p>
+            </div>
+          </div>
+          <div class="home-tools-grid">
+            <div id="home-quick-convert-mount" class="home-quick-convert-mount"></div>
+            <div class="home-tools-actions">
+              <div class="action-rail" id="home-action-rail">
+                <a href="../tracker.html" class="action-rail-link" id="home-action-track">
+                  <span class="action-rail-link__kicker" id="home-action-track-kicker">Live</span>
+                  <span class="action-rail-link__label" id="home-action-track-label">Track live price</span>
+                  <span class="action-rail-link__desc" id="home-action-track-desc"
+                    >Jump straight into the tracker workspace.</span
+                  >
+                </a>
+                <a href="../calculator.html" class="action-rail-link" id="home-action-calc">
+                  <span class="action-rail-link__kicker" id="home-action-calc-kicker">Calculate</span>
+                  <span class="action-rail-link__label" id="home-action-calc-label">Calculate gold value</span>
+                  <span class="action-rail-link__desc" id="home-action-calc-desc"
+                    >Check weight, karat, Zakat, or buying power.</span
+                  >
+                </a>
+                <a href="../tracker.html#mode=compare" class="action-rail-link" id="home-action-compare">
+                  <span class="action-rail-link__kicker" id="home-action-compare-kicker">Compare</span>
+                  <span class="action-rail-link__label" id="home-action-compare-label">Compare countries</span>
+                  <span class="action-rail-link__desc" id="home-action-compare-desc"
+                    >See how one reference price translates across markets.</span
+                  >
+                </a>
+                <a href="../shops.html" class="action-rail-link" id="home-action-shops">
+                  <span class="action-rail-link__kicker" id="home-action-shops-kicker">Directory</span>
+                  <span class="action-rail-link__label" id="home-action-shops-label">Find gold shops</span>
+                  <span class="action-rail-link__desc" id="home-action-shops-desc"
+                    >Browse market areas and listed shop details.</span
+                  >
+                </a>
+                <a
+                  href="../content/spot-vs-retail-gold-price/"
+                  class="action-rail-link"
+                  id="home-action-learn"
+                >
+                  <span class="action-rail-link__kicker" id="home-action-learn-kicker">Trust</span>
+                  <span class="action-rail-link__label" id="home-action-learn-label">Learn spot vs retail</span>
+                  <span class="action-rail-link__desc" id="home-action-learn-desc"
+                    >Understand why shop quotes differ from the reference price.</span
+                  >
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════ LIVE KARAT PRICE STRIP ═══════ -->
+      <section class="karat-strip" aria-labelledby="karat-strip-title">
+        <div class="karat-strip-inner">
+          <div class="karat-strip-copy">
+            <span class="karat-strip-label" id="karat-strip-label">AED / gram</span>
+            <h2 class="karat-strip-title" id="karat-strip-title">Live reference prices by karat</h2>
+            <p class="karat-strip-sub" id="karat-strip-sub">
+              Spot-linked AED gram estimates. Retail jewelry can include making charges and tax.
+            </p>
+            <!-- Unit toggle: gram / tola / troy oz -->
+            <div
+              class="kstrip-unit-toggle"
+              role="group"
+              id="kstrip-unit-group"
+              aria-label="Select price unit"
+            >
+              <button
+                class="kstrip-unit-btn"
+                data-unit="gram"
+                type="button"
+                aria-pressed="true"
+                title="Price per gram"
+              >g</button>
+              <button
+                class="kstrip-unit-btn"
+                data-unit="tola"
+                type="button"
+                aria-pressed="false"
+                title="Price per tola (11.66 g)"
+              >tola</button>
+              <button
+                class="kstrip-unit-btn"
+                data-unit="oz"
+                type="button"
+                aria-pressed="false"
+                title="Price per troy ounce (31.10 g)"
+              >oz</button>
+            </div>
+          </div>
+          <p class="karat-strip-scroll-hint" id="karat-strip-scroll-hint" aria-hidden="true">
+            Swipe for more karats →
+          </p>
+          <div
+            class="karat-strip-prices"
+            id="karat-strip-prices"
+            aria-live="polite"
+            aria-atomic="false"
+          >
+            <div class="karat-strip-item" id="kstrip-24">
+              <span class="karat-strip-k">24K</span>
+              <span
+                class="karat-strip-v skeleton-inline shell-skeleton-karat"
+                id="kstrip-24-val"
+                aria-busy="true"
+              ></span>
+              <button
+                class="kstrip-copy-btn"
+                id="kstrip-24-copy"
+                data-copy=""
+                aria-label="Copy 24K price"
+                type="button"
+              >⎘</button>
+            </div>
+            <div class="karat-strip-item" id="kstrip-22">
+              <span class="karat-strip-k">22K</span>
+              <span
+                class="karat-strip-v skeleton-inline shell-skeleton-karat"
+                id="kstrip-22-val"
+                aria-busy="true"
+              ></span>
+              <button
+                class="kstrip-copy-btn"
+                id="kstrip-22-copy"
+                data-copy=""
+                aria-label="Copy 22K price"
+                type="button"
+              >⎘</button>
+            </div>
+            <div class="karat-strip-item" id="kstrip-21">
+              <span class="karat-strip-k">21K</span>
+              <span
+                class="karat-strip-v skeleton-inline shell-skeleton-karat"
+                id="kstrip-21-val"
+                aria-busy="true"
+              ></span>
+              <button
+                class="kstrip-copy-btn"
+                id="kstrip-21-copy"
+                data-copy=""
+                aria-label="Copy 21K price"
+                type="button"
+              >⎘</button>
+            </div>
+            <div class="karat-strip-item" id="kstrip-18">
+              <span class="karat-strip-k">18K</span>
+              <span
+                class="karat-strip-v skeleton-inline shell-skeleton-karat"
+                id="kstrip-18-val"
+                aria-busy="true"
+              ></span>
+              <button
+                class="kstrip-copy-btn"
+                id="kstrip-18-copy"
+                data-copy=""
+                aria-label="Copy 18K price"
+                type="button"
+              >⎘</button>
+            </div>
+            <div class="karat-strip-item" id="kstrip-14">
+              <span class="karat-strip-k">14K</span>
+              <span
+                class="karat-strip-v skeleton-inline shell-skeleton-karat"
+                id="kstrip-14-val"
+                aria-busy="true"
+              ></span>
+              <button
+                class="kstrip-copy-btn"
+                id="kstrip-14-copy"
+                data-copy=""
+                aria-label="Copy 14K price"
+                type="button"
+              >⎘</button>
+            </div>
+          </div>
+          <div class="karat-strip-actions">
+            <span class="karat-strip-updated" id="karat-strip-updated" aria-live="polite"
+              ><span class="skeleton-inline shell-skeleton-freshness-strip" role="presentation" aria-hidden="true"></span
+            ></span>
+            <a href="../tracker.html" class="karat-strip-link" id="karat-strip-cta">Full tracker →</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════ AD: Leaderboard ═══════ -->
+      <div id="ad-top" class="ad-container" aria-label="Advertisement"></div>
+
+      <!-- ═══════ TRUST STRIP ═══════ -->
+      <section class="trust-strip" aria-label="Key features" data-reveal>
+        <div class="trust-inner">
+          <div class="trust-item">
+            <span class="trust-icon" aria-hidden="true"><svg aria-hidden="true" focusable="false"><use href="#i-bolt"/></svg></span>
+            <div class="trust-content">
+              <span class="trust-label" id="trust-live">Live spot data</span>
+              <span class="trust-sub" id="trust-live-sub">Auto-refresh while open</span>
+            </div>
+          </div>
+          <div class="trust-item">
+            <span class="trust-icon" aria-hidden="true"><svg aria-hidden="true" focusable="false"><use href="#i-globe"/></svg></span>
+            <div class="trust-content">
+              <span class="trust-label" id="trust-countries">24+ countries</span>
+              <span class="trust-sub" id="trust-countries-sub">GCC &amp; Arab world</span>
+            </div>
+          </div>
+          <div class="trust-item">
+            <span class="trust-icon" aria-hidden="true"><svg aria-hidden="true" focusable="false"><use href="#i-scale"/></svg></span>
+            <div class="trust-content">
+              <span class="trust-label" id="trust-karats">7 karats</span>
+              <span class="trust-sub" id="trust-karats-sub">14K through 24K</span>
+            </div>
+          </div>
+          <div class="trust-item">
+            <span class="trust-icon" aria-hidden="true"><svg aria-hidden="true" focusable="false"><use href="#i-lock"/></svg></span>
+            <div class="trust-content">
+              <span class="trust-label" id="trust-aed">AED official peg</span>
+              <span class="trust-sub" id="trust-aed-sub">3.6725 · always exact</span>
+            </div>
+          </div>
+          <div class="trust-item">
+            <span class="trust-icon" aria-hidden="true"><svg aria-hidden="true" focusable="false"><use href="#i-lang"/></svg></span>
+            <div class="trust-content">
+              <span class="trust-label" id="trust-bilingual">Bilingual EN / AR</span>
+              <span class="trust-sub" id="trust-bilingual-sub">Full RTL support</span>
+            </div>
+          </div>
+          <div class="trust-item">
+            <span class="trust-icon" aria-hidden="true"><svg aria-hidden="true" focusable="false"><use href="#i-offline"/></svg></span>
+            <div class="trust-content">
+              <span class="trust-label" id="trust-offline">Works offline</span>
+              <span class="trust-sub" id="trust-offline-sub">Cached price data</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════ BUYING GUIDE INTRO ═══════ -->
+      <!-- Removed: shops, countries & calculator cards are now in the Tools grid below -->
+
+      <!-- ═══════ DATA TRUST BANNER ═══════ -->
+      <section class="home-section home-section--trust-banner" aria-labelledby="trust-banner-title" data-reveal>
+        <div class="home-section-inner home-section-inner--narrow">
+          <div class="trust-banner-box">
+            <div class="trust-banner-icon" aria-hidden="true"><svg aria-hidden="true" focusable="false"><use href="#i-info"/></svg></div>
+            <div class="trust-banner-content">
+              <h3 id="trust-banner-title">About Our Prices</h3>
+              <p>
+                <span id="trust-banner-copy"
+                  >These are spot-linked reference estimates, not final retail or jewelry prices.
+                  Retail quotes usually include making charges, dealer margins, and local taxes.
+                  Freshness labels follow one vocabulary sitewide: Live, Delayed, Cached/Fallback,
+                  Estimated, and Historical baseline. Price source:</span
+                >
+                <a href="https://gold-api.com" target="_blank" rel="nofollow noopener">gold-api.com</a> for
+                <span id="trust-banner-source-tail">XAU/USD · live FX from ExchangeRate-API · AED at fixed peg 3.6725.</span>
+                <a href="../methodology.html" id="trust-banner-methodology">Full methodology →</a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════ GCC QUICK PRICES ═══════ -->
+      <section class="home-section" aria-labelledby="gcc-section-title">
+        <div class="home-section-inner">
+          <div class="section-intro">
+            <div>
+              <h2 id="gcc-section-title" class="home-section-title">Live Gold Prices</h2>
+              <p class="home-section-sub" id="gcc-section-sub">
+                22K per gram in local currency · freshness shown live
+              </p>
+            </div>
+            <a href="../tracker.html" class="section-link" id="gcc-see-all"></a>
+          </div>
+          <!-- Region tabs for filtering prices -->
+          <div class="gcc-region-tabs" role="tablist" aria-label="Filter gold prices by region">
+            <button
+              class="gcc-region-tab is-active"
+              data-region="gcc"
+              role="tab"
+              aria-selected="true"
+              aria-controls="gcc-quick-grid"
+              id="gcc-tab-gcc"
+              data-i18n="gccTabGccLabel"
+            >
+              GCC (6)
+            </button>
+            <button
+              class="gcc-region-tab"
+              data-region="mena"
+              role="tab"
+              aria-selected="false"
+              aria-controls="gcc-quick-grid"
+              id="gcc-tab-mena"
+              data-i18n="gccTabMenaLabel"
+            >
+              MENA (8+)
+            </button>
+            <button
+              class="gcc-region-tab"
+              data-region="global"
+              role="tab"
+              aria-selected="false"
+              aria-controls="gcc-quick-grid"
+              id="gcc-tab-global"
+              data-i18n="gccTabGlobalLabel"
+            >
+              Global (24+)
+            </button>
+          </div>
+            <div class="gcc-grid" id="gcc-quick-grid" role="tabpanel" aria-live="polite">
+            <!-- Filled by home.js -->
+            <div class="gcc-card skeleton-card">
+              <div class="skeleton-flag"></div>
+              <div class="skeleton-line"></div>
+              <div class="skeleton-value"></div>
+            </div>
+            <div class="gcc-card skeleton-card">
+              <div class="skeleton-flag"></div>
+              <div class="skeleton-line"></div>
+              <div class="skeleton-value"></div>
+            </div>
+            <div class="gcc-card skeleton-card">
+              <div class="skeleton-flag"></div>
+              <div class="skeleton-line"></div>
+              <div class="skeleton-value"></div>
+            </div>
+            <div class="gcc-card skeleton-card">
+              <div class="skeleton-flag"></div>
+              <div class="skeleton-line"></div>
+              <div class="skeleton-value"></div>
+            </div>
+            <div class="gcc-card skeleton-card">
+              <div class="skeleton-flag"></div>
+              <div class="skeleton-line"></div>
+              <div class="skeleton-value"></div>
+            </div>
+            <div class="gcc-card skeleton-card">
+              <div class="skeleton-flag"></div>
+              <div class="skeleton-line"></div>
+              <div class="skeleton-value"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════ HISTORY & DATA TEASER ═══════ -->
+      <!-- Removed: chart, archive, CSV download, and date lookup are accessible from the Live Tracker -->
+
+      <!-- ═══════ TOOLS ═══════ -->
+      <section class="home-section home-section--alt" aria-labelledby="tools-title" data-reveal>
+        <div class="home-section-inner">
+          <div class="section-intro centered">
+            <div>
+              <h2 id="tools-title" class="home-section-title">Everything You Need</h2>
+              <p class="home-section-sub" id="tools-sub">
+                Built for buyers, investors and professionals across the Gulf &amp; Arab world
+              </p>
+            </div>
+          </div>
+          <!-- Monoline section-icon sprite — gold, theme-aware via currentColor; decorative (aria-hidden) -->
+          <svg id="gtl-icon-sprite" width="0" height="0" class="ti-sprite" aria-hidden="true" focusable="false" style="position: absolute"><defs><symbol id="i-chart" viewBox="0 0 24 24"><path d="M4 5v14h15"/><path d="M7 14l3.5-4 3 2.5L19 7"/></symbol><symbol id="i-calc" viewBox="0 0 24 24"><rect x="6" y="3" width="12" height="18" rx="2"/><line x1="9" y1="7" x2="15" y2="7"/><line x1="9" y1="11" x2="9.01" y2="11"/><line x1="12" y1="11" x2="12.01" y2="11"/><line x1="15" y1="11" x2="15.01" y2="11"/><line x1="9" y1="14" x2="9.01" y2="14"/><line x1="12" y1="14" x2="12.01" y2="14"/><line x1="15" y1="14" x2="15.01" y2="14"/><line x1="9" y1="17.5" x2="12" y2="17.5"/></symbol><symbol id="i-pin" viewBox="0 0 24 24"><path d="M12 21s6-5.3 6-10A6 6 0 0 0 6 11c0 4.7 6 10 6 10Z"/><circle cx="12" cy="11" r="2.2"/></symbol><symbol id="i-shop" viewBox="0 0 24 24"><path d="M4.5 10l1.3-5h12.4l1.3 5"/><path d="M4.5 10a2 2 0 0 0 3.75 0 2 2 0 0 0 3.75 0 2 2 0 0 0 3.75 0 2 2 0 0 0 3.75 0"/><path d="M6 11.5V20h12v-8.5"/><path d="M10 20v-4.5h4V20"/></symbol><symbol id="i-map" viewBox="0 0 24 24"><path d="M9 4 4 6v14l5-2 6 2 5-2V4l-5 2-6-2Z"/><path d="M9 4v14M15 6v14"/></symbol><symbol id="i-book" viewBox="0 0 24 24"><path d="M12 6c-1.8-1.2-4-1.5-6-1.5V18c2 0 4.2.3 6 1.5 1.8-1.2 4-1.5 6-1.5V4.5c-2 0-4.2.3-6 1.5Z"/><path d="M12 6v13.5"/></symbol><symbol id="i-bars" viewBox="0 0 24 24"><path d="M4 20h16"/><rect x="6" y="11" width="3" height="6"/><rect x="10.5" y="7" width="3" height="10"/><rect x="15" y="13" width="3" height="4"/></symbol><symbol id="i-beaker" viewBox="0 0 24 24"><path d="M9 3h6M10 3v6.2L5.6 17a2 2 0 0 0 1.8 3h9.2a2 2 0 0 0 1.8-3L14 9.2V3"/><path d="M8 14.5h8"/></symbol><symbol id="i-coins" viewBox="0 0 24 24"><ellipse cx="12" cy="7" rx="6" ry="2.6"/><path d="M6 7v5c0 1.4 2.7 2.6 6 2.6s6-1.2 6-2.6V7"/><path d="M6 12v5c0 1.4 2.7 2.6 6 2.6s6-1.2 6-2.6v-5"/></symbol><symbol id="i-skyline" viewBox="0 0 24 24"><path d="M3 21h18"/><path d="M6.5 21V11l3-2v12"/><path d="M9.5 21V6l4 2.2V21"/><path d="M13.5 21V12l4 2.2V21"/><path d="M11.5 3v3"/></symbol><symbol id="i-globe" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M4 12h16"/><path d="M12 4c2.8 2.2 2.8 13.8 0 16M12 4c-2.8 2.2-2.8 13.8 0 16"/></symbol><symbol id="i-receipt" viewBox="0 0 24 24"><path d="M6 3h12v18l-2-1.3-2 1.3-2-1.3-2 1.3-2-1.3L6 21Z"/><path d="M9 8h6M9 12h6M9 15.5h4"/></symbol><symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 3 5 13h5l-1 8 8-10h-5l1-8Z"/></symbol><symbol id="i-scale" viewBox="0 0 24 24"><path d="M12 4v16M7 20h10M5 7h14M5 7l-2.6 5.5h5.2L5 7ZM19 7l-2.6 5.5h5.2L19 7Z"/><path d="M2.4 12.5a2.6 2.6 0 0 0 5.2 0M16.4 12.5a2.6 2.6 0 0 0 5.2 0"/></symbol><symbol id="i-lock" viewBox="0 0 24 24"><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></symbol><symbol id="i-lang" viewBox="0 0 24 24"><path d="M4 5h16v10H9l-4 4v-4H4Z"/><path d="M8 9h8M8 12h5"/></symbol><symbol id="i-offline" viewBox="0 0 24 24"><path d="M5 12.5a10 10 0 0 1 4-2.4M19 12.5a9.5 9.5 0 0 0-3-2M8.5 15.6a5 5 0 0 1 7 0M12 19h.01"/><path d="M3 3l18 18"/></symbol><symbol id="i-info" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 11v5M12 8h.01"/></symbol><symbol id="i-exchange" viewBox="0 0 24 24"><path d="M4 9h14l-3.2-3.2M20 15H6l3.2 3.2"/></symbol><symbol id="i-search" viewBox="0 0 24 24"><circle cx="11" cy="11" r="6.5"/><path d="M16.5 16.5 20 20"/></symbol><symbol id="i-menu" viewBox="0 0 24 24"><path d="M4 7h16M4 12h16M4 17h16"/></symbol><symbol id="i-bell" viewBox="0 0 24 24"><path d="M6.5 16V11a5.5 5.5 0 0 1 11 0v5l1.5 2H5l1.5-2Z"/><path d="M9.8 19a2.4 2.4 0 0 0 4.4 0"/></symbol><symbol id="i-download" viewBox="0 0 24 24"><path d="M12 4v10"/><path d="M8 11l4 4 4-4"/><path d="M5 19.5h14"/></symbol><symbol id="i-code" viewBox="0 0 24 24"><path d="M8.5 8 4.5 12l4 4"/><path d="M15.5 8l4 4-4 4"/></symbol><symbol id="i-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2.5v2.5M12 19v2.5M4.6 4.6l1.8 1.8M17.6 17.6l1.8 1.8M2.5 12H5M19 12h2.5M4.6 19.4l1.8-1.8M17.6 6.4l1.8-1.8"/></symbol><symbol id="i-moon" viewBox="0 0 24 24"><path d="M20 13.5A7.5 7.5 0 0 1 10.5 4 7.5 7.5 0 1 0 20 13.5Z"/></symbol><symbol id="i-theme-auto" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 4a8 8 0 0 1 0 16Z" fill="currentColor" stroke="none"/></symbol><symbol id="f-ae" viewBox="0 0 24 24"><rect width="24" height="24" fill="#ffffff"/><rect x="6" width="18" height="8" fill="#009739"/><rect x="6" y="16" width="18" height="8" fill="#000000"/><rect width="6" height="24" fill="#ce1126"/></symbol><symbol id="f-sa" viewBox="0 0 24 24"><rect width="24" height="24" fill="#006c35"/><rect x="4.5" y="14.4" width="15" height="1.6" rx="0.7" fill="#ffffff"/><rect x="6" y="8.8" width="12" height="1.2" rx="0.6" fill="#ffffff"/></symbol><symbol id="f-kw" viewBox="0 0 24 24"><rect width="24" height="24" fill="#ffffff"/><rect width="24" height="8" fill="#007a3d"/><rect y="16" width="24" height="8" fill="#ce1126"/><path d="M0 0H8L4 8v8l4 8H0Z" fill="#000000"/></symbol><symbol id="f-qa" viewBox="0 0 24 24"><rect width="24" height="24" fill="#8a1538"/><path d="M0 0H7l3 3-3 3 3 3-3 3 3 3-3 3 3 3-3 3H0Z" fill="#ffffff"/></symbol><symbol id="f-bh" viewBox="0 0 24 24"><rect width="24" height="24" fill="#ce1126"/><path d="M0 0H6l4 2.4-4 2.4 4 2.4-4 2.4 4 2.4-4 2.4 4 2.4-4 2.4 4 2.4-4 2.4H0Z" fill="#ffffff"/></symbol><symbol id="f-eg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#ffffff"/><rect width="24" height="8" fill="#ce1126"/><rect y="16" width="24" height="8" fill="#000000"/><path d="M12 9.4l3.2 2.6-3.2 2.6-3.2-2.6z" fill="#c09300"/></symbol><symbol id="f-jo" viewBox="0 0 24 24"><rect width="24" height="24" fill="#ffffff"/><rect width="24" height="8" fill="#000000"/><rect y="16" width="24" height="8" fill="#007a3d"/><path d="M0 0L11 12 0 24Z" fill="#ce1126"/><path d="M4.2 10.2l.62 1.78h1.86l-1.5 1.1.57 1.8-1.55-1.12-1.55 1.12.57-1.8-1.5-1.1h1.86z" fill="#ffffff"/></symbol><symbol id="f-ma" viewBox="0 0 24 24"><rect width="24" height="24" fill="#c1272d"/><path d="M12 7l1.45 4.46h4.69l-3.8 2.76 1.45 4.46L12 16.18l-3.79 2.5 1.45-4.46-3.8-2.76h4.69z" fill="none" stroke="#006233" stroke-width="1"/></symbol><symbol id="f-tr" viewBox="0 0 24 24"><rect width="24" height="24" fill="#e30a17"/><circle cx="10" cy="12" r="5.2" fill="#ffffff"/><circle cx="11.9" cy="12" r="4.1" fill="#e30a17"/><path d="M16.4 12l1.55.5-.96 1.32.01-1.64-1.56-.5 1.56-.5-.01-1.64z" fill="#ffffff"/></symbol></defs></svg>
+          <div class="tools-grid">
+            <a href="../tracker.html" class="tool-card tool-card--primary" id="home-tool-tracker">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-chart"/></svg></div>
+              <h3 class="tool-card-title" id="tool-tracker-title">Live Tracker</h3>
+              <p class="tool-card-desc" id="tool-tracker-desc">
+                Full price matrix — 24 countries, 7 karats, per gram &amp; per ounce. Auto-refresh
+                with a visible freshness label.
+              </p>
+              <span class="tool-card-cta" id="tool-tracker-cta">Open Tracker →</span>
+            </a>
+            <a href="../calculator.html" class="tool-card tool-card--primary">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-calc"/></svg></div>
+              <h3 class="tool-card-title" id="tool-calc-title">Gold Calculator</h3>
+              <p class="tool-card-desc" id="tool-calc-desc">
+                Gold value, scrap, Zakat, buying power and unit conversion — all in one tool.
+              </p>
+              <span class="tool-card-cta" id="tool-calc-cta">Open Calculator →</span>
+            </a>
+            <a href="../countries/uae/gold-price/" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-pin"/></svg></div>
+              <h3 class="tool-card-title" id="tool-uae-title">UAE Gold Prices</h3>
+              <p class="tool-card-desc" id="tool-uae-desc">
+                Dedicated UAE page with all karats in AED &amp; USD, plus context for Dubai buyers.
+              </p>
+              <span class="tool-card-cta" id="tool-uae-cta">UAE Prices →</span>
+            </a>
+            <a href="../shops.html" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-shop"/></svg></div>
+              <h3 class="tool-card-title" id="tool-shops-title">Find Gold Shops</h3>
+              <p class="tool-card-desc" id="tool-shops-desc">
+                Browse listed gold shops across UAE, GCC &amp; Arab world. Filter by region, city,
+                and specialty.
+              </p>
+              <span class="tool-card-cta" id="tool-shops-cta">Browse Shops →</span>
+            </a>
+            <a href="../countries/index.html" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-map"/></svg></div>
+              <h3 class="tool-card-title" id="tool-countries-title">Browse Countries</h3>
+              <p class="tool-card-desc" id="tool-countries-desc">
+                Country-specific pages with local gold prices and market context for 24+ markets.
+              </p>
+              <span class="tool-card-cta" id="tool-countries-cta">All Countries →</span>
+            </a>
+            <a href="../learn.html" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-book"/></svg></div>
+              <h3 class="tool-card-title" id="tool-learn-title">Learn &amp; Glossary</h3>
+              <p class="tool-card-desc" id="tool-learn-desc">
+                What is 22K? Why does spot differ from retail? How does the AED peg work?
+              </p>
+              <span class="tool-card-cta" id="tool-learn-cta">Read Guide →</span>
+            </a>
+            <a href="../insights.html" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-bars"/></svg></div>
+              <h3 class="tool-card-title" id="tool-insights-title">Gold Insights</h3>
+              <p class="tool-card-desc" id="tool-insights-desc">
+                Market analysis, price drivers, and context for GCC gold buyers.
+              </p>
+              <span class="tool-card-cta" id="tool-insights-cta">Read Insights →</span>
+            </a>
+            <a href="../methodology.html" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-beaker"/></svg></div>
+              <h3 class="tool-card-title" id="tool-method-title">Methodology</h3>
+              <p class="tool-card-desc" id="tool-method-desc">
+                Full transparency on data sources, AED peg, karat math, and freshness logic.
+              </p>
+              <span class="tool-card-cta" id="tool-method-cta">Read Methodology →</span>
+            </a>
+            <a href="../invest.html" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-coins"/></svg></div>
+              <h3 class="tool-card-title" id="tool-invest-title">Gold Investing Guide</h3>
+              <p class="tool-card-desc" id="tool-invest-desc">
+                Bars vs jewellery, ETFs, Zakat on investments, storage costs — everything for GCC
+                investors.
+              </p>
+              <span class="tool-card-cta" id="tool-invest-cta">Read Guide →</span>
+            </a>
+          </div>
+          <!-- Compact alert prompt -->
+          <div class="tools-alert-row">
+            <span id="tools-alert-text"
+              >Set a price alert — free, stored locally, no account needed.</span
+            >
+            <a
+              href="../tracker.html#mode=live&amp;panel=alerts"
+              class="btn btn-sm btn-outline"
+              id="tools-alert-btn"
+              >Set Alert →</a
+            >
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="home-section home-stats-section"
+        id="home-stats-section"
+        aria-labelledby="home-stats-title"
+        data-reveal
+      >
+        <div class="home-section-inner">
+          <div class="section-intro centered">
+            <div>
+              <h2 id="home-stats-title" class="home-section-title">Gold Ticker Live by the numbers</h2>
+              <p class="home-section-sub" id="home-stats-sub">
+                One bilingual command center for spot-linked gold reference prices, market context,
+                and buyer tools across the GCC and beyond.
+              </p>
+            </div>
+          </div>
+          <div class="home-stats-grid" aria-label="Gold Ticker Live stats">
+            <article class="home-stat-card">
+              <strong class="home-stat-value" id="home-stat-1-value">24+</strong>
+              <span class="home-stat-label" id="home-stat-1-label">Countries</span>
+            </article>
+            <article class="home-stat-card">
+              <strong class="home-stat-value" id="home-stat-2-value">7</strong>
+              <span class="home-stat-label" id="home-stat-2-label">Karats</span>
+            </article>
+            <article class="home-stat-card">
+              <strong class="home-stat-value" id="home-stat-3-value">EN / AR</strong>
+              <span class="home-stat-label" id="home-stat-3-label">Bilingual</span>
+            </article>
+            <article class="home-stat-card">
+              <strong class="home-stat-value" id="home-stat-4-value">Free</strong>
+              <span class="home-stat-label" id="home-stat-4-label">Forever</span>
+            </article>
+          </div>
+          <p class="source-note home-stats-disclaimer" id="home-stats-disclaimer">
+            Spot-linked reference estimates only — final retail and jewelry quotes can include
+            making charges, dealer margin, and taxes.
+          </p>
+        </div>
+      </section>
+ 
+      <section class="home-section" aria-labelledby="next-step-title" data-reveal>
+        <div class="home-section-inner">
+          <div class="section-intro centered">
+            <div>
+              <h2 id="next-step-title" class="home-section-title">What should I check next?</h2>
+              <p class="home-section-sub" id="next-step-sub">
+                Focused guides for buying, comparing, and understanding the gap between live
+                reference prices and final shop quotes.
+              </p>
+            </div>
+          </div>
+          <div class="tools-grid">
+            <a href="../content/uae-gold-buying-guide/" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-pin"/></svg></div>
+              <h3 class="tool-card-title" id="next-uae-title">UAE buying guide</h3>
+              <p class="tool-card-desc" id="next-uae-desc">
+                Start with AED reference prices, then compare making charges, VAT, and shop terms.
+              </p>
+              <span class="tool-card-cta" id="next-uae-cta">Read UAE guide →</span>
+            </a>
+            <a href="../content/dubai-gold-rate-guide/" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-skyline"/></svg></div>
+              <h3 class="tool-card-title" id="next-dubai-title">Dubai gold rate guide</h3>
+              <p class="tool-card-desc" id="next-dubai-desc">
+                Understand Dubai rates, souk context, and what to confirm before paying.
+              </p>
+              <span class="tool-card-cta" id="next-dubai-cta">Open Dubai guide →</span>
+            </a>
+            <a href="../content/gcc-gold-price-comparison/" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-globe"/></svg></div>
+              <h3 class="tool-card-title" id="next-gcc-title">GCC comparison</h3>
+              <p class="tool-card-desc" id="next-gcc-desc">
+                Compare Gulf reference prices using the same karat, unit, and freshness context.
+              </p>
+              <span class="tool-card-cta" id="next-gcc-cta">Compare GCC markets →</span>
+            </a>
+            <a href="../content/spot-vs-retail-gold-price/" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-receipt"/></svg></div>
+              <h3 class="tool-card-title" id="next-svr-title">Spot vs retail</h3>
+              <p class="tool-card-desc" id="next-svr-desc">
+                Learn why live spot-linked estimates are not final jewelry or shop prices.
+              </p>
+              <span class="tool-card-cta" id="next-svr-cta">Understand the difference →</span>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════ COUNTRY QUICK ACCESS ═══════ -->
+      <section id="countries-quick" class="home-section" aria-labelledby="countries-quick-title" data-reveal>
+        <div class="home-section-inner">
+          <div class="section-intro">
+            <div>
+              <h2 id="countries-quick-title" class="home-section-title">Browse by Country</h2>
+              <p class="home-section-sub" id="countries-quick-sub">
+                Dedicated pages with local context for every major market
+              </p>
+            </div>
+            <a href="../countries/index.html" class="section-link" id="countries-see-all"
+              >See all countries →</a
+            >
+          </div>
+          <div class="country-search-wrap">
+            <input
+              type="search"
+              class="country-search-input"
+              id="country-search"
+              placeholder="Filter countries…"
+              aria-label="Filter countries"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </div>
+          <div class="country-tiles" role="list">
+            <a href="../countries/uae/gold-price/" class="country-tile" role="listitem"
+              ><span aria-hidden="true">🇦🇪</span><span id="ct-uae">UAE</span></a
+            >
+            <a href="../countries/saudi-arabia/gold-price/" class="country-tile" role="listitem"
+              ><span aria-hidden="true">🇸🇦</span><span id="ct-sa">Saudi Arabia</span></a
+            >
+            <a href="../countries/kuwait/gold-price/" class="country-tile" role="listitem"
+              ><span aria-hidden="true">🇰🇼</span><span id="ct-kw">Kuwait</span></a
+            >
+            <a href="../countries/qatar/gold-price/" class="country-tile" role="listitem"
+              ><span aria-hidden="true">🇶🇦</span><span id="ct-qa">Qatar</span></a
+            >
+            <a href="../countries/bahrain/gold-price/" class="country-tile" role="listitem"
+              ><span aria-hidden="true">🇧🇭</span><span id="ct-bh">Bahrain</span></a
+            >
+            <a href="../countries/oman/gold-price/" class="country-tile" role="listitem"
+              ><span aria-hidden="true">🇴🇲</span><span id="ct-om">Oman</span></a
+            >
+            <a href="../countries/egypt/gold-price/" class="country-tile" role="listitem"
+              ><span aria-hidden="true">🇪🇬</span><span id="ct-eg">Egypt</span></a
+            >
+            <a href="../countries/jordan/gold-price/" class="country-tile" role="listitem"
+              ><span aria-hidden="true">🇯🇴</span><span id="ct-jo">Jordan</span></a
+            >
+            <a href="../countries/morocco/gold-price/" class="country-tile" role="listitem"
+              ><span aria-hidden="true">🇲🇦</span><span id="ct-ma">Morocco</span></a
+            >
+            <a href="../countries/india/gold-price/" class="country-tile" role="listitem"
+              ><span aria-hidden="true">🇮🇳</span><span id="ct-in">India</span></a
+            >
+            <a href="../countries/index.html" class="country-tile country-tile--more"
+              ><span aria-hidden="true">+</span><span id="ct-more">See all countries</span></a
+            >
+          </div>
+          <p class="country-search-empty" id="country-search-empty" aria-live="polite" hidden>
+            No countries match your search. Try UAE, Saudi Arabia, or Kuwait.
+          </p>
+        </div>
+      </section>
+
+      <!-- ═══════ WHY USE THIS ═══════ -->
+      <!-- Removed: trust strip above covers all six value props concisely -->
+
+      <!-- ═══════ ALERT CTA ═══════ -->
+      <!-- Removed: compact alert prompt is now inline in the Tools section above -->
+
+      <!-- ═══════ MARKETS HIGHLIGHTS ═══════ -->
+      <section class="home-section home-section--markets" aria-labelledby="markets-title" data-reveal>
+        <div class="home-section-inner">
+          <div class="section-intro">
+            <div>
+              <h2 id="markets-title" class="home-section-title">Major Gold Markets</h2>
+              <p class="home-section-sub" id="markets-sub">
+                Key trading centres in the GCC and Arab world
+              </p>
+            </div>
+            <a href="../tracker.html" class="section-link" id="markets-see-tracker"
+              >View all prices →</a
+            >
+          </div>
+          <div class="markets-grid">
+            <a href="../countries/uae/gold-price/" class="market-card hover-lift">
+              <div class="market-card-flag" aria-hidden="true">🇦🇪</div>
+              <div class="market-card-body">
+                <h3 class="market-card-name" id="mkt-dubai-name">Dubai Gold Souk</h3>
+                <p class="market-card-loc" id="mkt-dubai-loc">UAE — AED</p>
+                <p class="market-card-desc" id="mkt-dubai-desc">
+                  One of the world's largest gold trading centres, with hundreds of shops along
+                  the Dubai Creek and Deira.
+                </p>
+                <span class="market-card-cta" id="mkt-dubai-cta">View UAE prices →</span>
+              </div>
+            </a>
+            <a href="../countries/saudi-arabia/gold-price/" class="market-card hover-lift">
+              <div class="market-card-flag" aria-hidden="true">🇸🇦</div>
+              <div class="market-card-body">
+                <h3 class="market-card-name" id="mkt-riyadh-name">Riyadh Gold Market</h3>
+                <p class="market-card-loc" id="mkt-riyadh-loc">Saudi Arabia — SAR</p>
+                <p class="market-card-desc" id="mkt-riyadh-desc">
+                  Al-Dirah and Thumairy gold souqs offer traditional and modern gold jewelry for
+                  local and visiting buyers.
+                </p>
+                <span class="market-card-cta" id="mkt-riyadh-cta">View Saudi prices →</span>
+              </div>
+            </a>
+            <a href="../countries/kuwait/gold-price/" class="market-card hover-lift">
+              <div class="market-card-flag" aria-hidden="true">🇰🇼</div>
+              <div class="market-card-body">
+                <h3 class="market-card-name" id="mkt-kuwait-name">Kuwait Gold Souk</h3>
+                <p class="market-card-loc" id="mkt-kuwait-loc">Kuwait — KWD</p>
+                <p class="market-card-desc" id="mkt-kuwait-desc">
+                  Kuwait's gold district concentrates hundreds of jewelry shops in a compact
+                  trading area near the old city.
+                </p>
+                <span class="market-card-cta" id="mkt-kuwait-cta">View Kuwait prices →</span>
+              </div>
+            </a>
+            <a href="../countries/egypt/gold-price/" class="market-card hover-lift">
+              <div class="market-card-flag" aria-hidden="true">🇪🇬</div>
+              <div class="market-card-body">
+                <h3 class="market-card-name" id="mkt-cairo-name">Khan el-Khalili</h3>
+                <p class="market-card-loc" id="mkt-cairo-loc">Egypt — EGP</p>
+                <p class="market-card-desc" id="mkt-cairo-desc">
+                  Cairo's historic bazaar is one of the oldest gold markets in the Arab world,
+                  trading since the 14th century.
+                </p>
+                <span class="market-card-cta" id="mkt-cairo-cta">View Egypt prices →</span>
+              </div>
+            </a>
+          </div>
+          <p class="markets-note" id="markets-note">
+            Reference prices only — actual shop prices vary by location, making charges, and VAT.
+          </p>
+        </div>
+      </section>
+
+      <!-- ═══════ INSIGHTS BANNER ═══════ -->
+      <!-- Removed: Insights is already a card in the Tools grid above -->
+
+      <!-- ═══════ SOCIAL FOLLOW CTA ═══════ -->
+      <section class="home-section home-section--social" aria-label="Follow us on social media" data-reveal>
+        <div class="home-section-inner home-section-inner--narrow home-social-wrap">
+          <p id="social-follow-text" class="home-social-text">
+            Daily gold price updates on X &mdash; GCC &amp; Arab world
+          </p>
+          <a
+            href="https://x.com/GoldTickerLive"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="btn btn-primary home-social-btn"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path
+                d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+              />
+            </svg>
+            <span id="social-follow-cta">Follow @GoldTickerLive</span>
+          </a>
+        </div>
+      </section>
+
+      <!-- ═══════ HOW GOLD PRICES WORK ═══════ -->
+      <section id="how-it-works" class="home-explainer-strip" aria-label="How gold prices work" data-reveal>
+        <div class="home-section-inner">
+          <div class="explainer-strip-items">
+            <div class="explainer-strip-item">
+              <span class="explainer-strip-icon" aria-hidden="true"><svg aria-hidden="true" focusable="false"><use href="#i-bars"/></svg></span>
+              <div class="explainer-strip-body">
+                <strong class="explainer-strip-title" id="explainer-spot-title">Spot Price</strong>
+                <p class="explainer-strip-desc" id="explainer-spot-desc">XAU/USD is the global benchmark price for one troy ounce of pure gold, traded continuously on international markets.</p>
+              </div>
+            </div>
+            <div class="explainer-strip-item">
+              <span class="explainer-strip-icon" aria-hidden="true"><svg aria-hidden="true" focusable="false"><use href="#i-scale"/></svg></span>
+              <div class="explainer-strip-body">
+                <strong class="explainer-strip-title" id="explainer-karat-title">Karat Purity</strong>
+                <p class="explainer-strip-desc" id="explainer-karat-desc">24K is 99.9% pure gold; 22K is 91.7%; 18K is 75%. Lower karats contain other metals, reducing purity and price proportionally.</p>
+              </div>
+            </div>
+            <div class="explainer-strip-item">
+              <span class="explainer-strip-icon" aria-hidden="true"><svg aria-hidden="true" focusable="false"><use href="#i-exchange"/></svg></span>
+              <div class="explainer-strip-body">
+                <strong class="explainer-strip-title" id="explainer-local-title">Your Local Price</strong>
+                <p class="explainer-strip-desc" id="explainer-local-desc">We convert the USD spot price using live FX rates so you see the estimated gram price in your local currency instantly.</p>
+              </div>
+            </div>
+          </div>
+          <p class="explainer-strip-footer">
+            <a href="../methodology.html" class="section-link" id="explainer-methodology-link" data-i18n="explainerMethodologyLink">Full price methodology &amp; data sources →</a>
+            <br>
+            <a href="../content/spot-vs-retail-gold-price/" class="section-link" id="explainer-svr-link" data-i18n="explainerSvrLink">Spot vs retail price difference explained →</a>
+          </p>
+        </div>
+      </section>
+
+      <section id="methodology" class="home-section home-section--methodology" data-reveal>
+        <div class="home-section-inner">
+          <div class="section-intro">
+            <div>
+              <h2 class="home-section-title" id="home-methodology-title">Methodology at a glance</h2>
+              <p class="home-section-sub" id="home-methodology-sub">
+                Spot to gram to karat to local currency, with trust labels and comparison checks.
+              </p>
+            </div>
+            <a href="../methodology.html" class="section-link" id="home-methodology-page-link"
+              >Open full methodology →</a
+            >
+          </div>
+          <div id="home-methodology-mount"></div>
+        </div>
+      </section>
+
+      <section id="location-guides" class="home-section home-section--location-guides" data-reveal>
+        <div class="home-section-inner">
+          <div class="section-intro">
+            <div>
+              <h2 class="home-section-title" id="home-location-guides-title">City buying guides</h2>
+              <p class="home-section-sub" id="home-location-guides-sub">
+                Quick context for common karats, buyer habits, and quote-verification checkpoints.
+              </p>
+            </div>
+            <a href="../countries/index.html" class="section-link" id="home-location-guides-link"
+              >Browse country pages →</a
+            >
+          </div>
+          <div id="home-location-guides-mount"></div>
+        </div>
+      </section>
+
+      <!-- ═══════ FAQ ═══════ -->
+      <section id="faq" class="home-section" aria-labelledby="faq-title" data-reveal>
+        <div class="home-section-inner home-section-inner--narrow">
+          <div class="section-intro centered">
+            <h2 id="faq-title" class="home-section-title" data-i18n="faqTitle">Common Questions</h2>
+          </div>
+          <div class="faq-list" itemscope itemtype="https://schema.org/FAQPage">
+            <details
+              class="faq-item"
+              itemscope
+              itemtype="https://schema.org/Question"
+              itemprop="mainEntity"
+            >
+              <summary class="faq-q" itemprop="name" data-i18n="faq1Q">
+                What is the gold price per gram in UAE today?
+              </summary>
+              <div
+                class="faq-a"
+                itemscope
+                itemtype="https://schema.org/Answer"
+                itemprop="acceptedAnswer"
+              >
+                <div itemprop="text" id="faq-a1">
+                  The live gold price per gram in UAE (AED) is shown on the
+                  <a href="../tracker.html">Live Tracker</a> and the
+                  <a href="../countries/uae/">UAE page</a>. Spot source updates hourly during market hours;
+                  pages re-poll about every 90 seconds while open. Prices use the official AED peg of 3.6725.
+                </div>
+              </div>
+            </details>
+            <details
+              class="faq-item"
+              itemscope
+              itemtype="https://schema.org/Question"
+              itemprop="mainEntity"
+            >
+              <summary class="faq-q" itemprop="name" data-i18n="faq2Q">
+                What is the difference between 24K, 22K and 21K gold?
+              </summary>
+              <div
+                class="faq-a"
+                itemscope
+                itemtype="https://schema.org/Answer"
+                itemprop="acceptedAnswer"
+              >
+                <div itemprop="text" id="faq-a2">
+                  24K is 100% pure gold. 22K is 91.7% gold (common for Gulf jewelry). 21K is 87.5%
+                  gold (popular in Egypt and Levant). 18K is 75% gold (common for fine jewelry
+                  worldwide). The price scales with purity — see our
+                  <a href="../learn.html">Learn page</a> for the full breakdown.
+                </div>
+              </div>
+            </details>
+            <details
+              class="faq-item"
+              itemscope
+              itemtype="https://schema.org/Question"
+              itemprop="mainEntity"
+            >
+              <summary class="faq-q" itemprop="name" data-i18n="faq3Q">
+                Why is the AED price different from a live API conversion?
+              </summary>
+              <div
+                class="faq-a"
+                itemscope
+                itemtype="https://schema.org/Answer"
+                itemprop="acceptedAnswer"
+              >
+                <div itemprop="text" id="faq-a3">
+                  The UAE Dirham is officially pegged to the US Dollar at 3.6725 by the UAE Central
+                  Bank. This rate never changes. Most FX APIs show a slightly different rate due to
+                  bid/ask spreads. We hardcode the official peg to give you accurate AED gold
+                  prices.
+                </div>
+              </div>
+            </details>
+            <details
+              class="faq-item"
+              itemscope
+              itemtype="https://schema.org/Question"
+              itemprop="mainEntity"
+            >
+              <summary class="faq-q" itemprop="name" data-i18n="faq4Q">
+                Is this the actual jewelry or retail gold price?
+              </summary>
+              <div
+                class="faq-a"
+                itemscope
+                itemtype="https://schema.org/Answer"
+                itemprop="acceptedAnswer"
+              >
+                <div itemprop="text" id="faq-a4">
+                  No — these are spot-linked bullion estimates. Actual jewellery prices at retail
+                  stores are higher due to making charges, shop premiums, taxes, and markups. The
+                  Dubai Gold &amp; Jewellery Group publishes a daily retail rate. Our tracker gives
+                  you the international spot baseline.
+                </div>
+              </div>
+            </details>
+            <details
+              class="faq-item"
+              itemscope
+              itemtype="https://schema.org/Question"
+              itemprop="mainEntity"
+            >
+              <summary class="faq-q" itemprop="name" data-i18n="faq5Q">How often do prices update?</summary>
+              <div
+                class="faq-a"
+                itemscope
+                itemtype="https://schema.org/Answer"
+                itemprop="acceptedAnswer"
+              >
+                <div itemprop="text" id="faq-a5">
+                  The gold spot price auto-refreshes while you have the page open; the underlying source data
+                  updates hourly during market hours. FX rates update once per day (via open.er-api.com).
+                  A countdown timer on the tracker shows you exactly when the next refresh is due. Data is
+                  cached locally so the last known price shows even when you're offline, with a visible
+                  cached / fallback label so you can tell the difference.
+                </div>
+              </div>
+            </details>
+            <details
+              class="faq-item"
+              itemscope
+              itemtype="https://schema.org/Question"
+              itemprop="mainEntity"
+            >
+              <summary class="faq-q" itemprop="name" data-i18n="faq6Q">
+                Does the price include making charges or VAT?
+              </summary>
+              <div
+                class="faq-a"
+                itemscope
+                itemtype="https://schema.org/Answer"
+                itemprop="acceptedAnswer"
+              >
+                <div itemprop="text" id="faq-a6">
+                  No. The prices on Gold Ticker Live are spot-linked reference estimates for the gold
+                  content only. When you buy jewellery in a shop, the final price is higher because
+                  it adds making charges (fabrication fees, typically 5–25%), dealer margin, and
+                  in some countries VAT (e.g. 5% in the UAE). The tracker gives you the bullion
+                  baseline so you can understand how much of the quoted price is gold and how much
+                  is markup. See
+                  <a href="../content/spot-vs-retail-gold-price/">Spot vs retail price</a>
+                  for a detailed breakdown.
+                </div>
+              </div>
+            </details>
+            <details
+              class="faq-item"
+              itemscope
+              itemtype="https://schema.org/Question"
+              itemprop="mainEntity"
+            >
+              <summary class="faq-q" itemprop="name" data-i18n="faq7Q">
+                Can I use these prices when selling gold?
+              </summary>
+              <div
+                class="faq-a"
+                itemscope
+                itemtype="https://schema.org/Answer"
+                itemprop="acceptedAnswer"
+              >
+                <div itemprop="text" id="faq-a7">
+                  The displayed price is a useful starting point. When selling gold, dealers
+                  typically offer below the spot price — often 1–5% less — to cover their spread
+                  and processing costs. The amount you receive depends on the karat of the piece,
+                  the buyer's buy-back rate, and any applicable fees. Use our
+                  <a href="../calculator.html">Gold Calculator</a> to estimate the melt value of
+                  your piece, then compare offers from multiple dealers.
+                </div>
+              </div>
+            </details>
+          </div>
+          <div class="faq-more-row">
+            <a href="../content/faq/" class="section-link" id="faq-more-link"
+              >More gold price questions answered →</a
+            >
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- ═══════ AD: Rectangle (before footer) ═══════ -->
+    <div id="ad-bottom" class="ad-container" aria-label="Advertisement"></div>
+
+    <!-- ═══════ FOOTER (injected by home.js) ═══════ -->
+
+    <script type="module" src="../src/pages/home.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
     <link rel="canonical" href="https://goldtickerlive.com/" />
     <link rel="alternate" hreflang="x-default" href="https://goldtickerlive.com/" />
     <link rel="alternate" hreflang="en" href="https://goldtickerlive.com/" />
-    <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/?lang=ar" />
+    <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/ar/" />
     <title>Gold Ticker Live — Reference Gold Prices UAE &amp; GCC Today</title>
 
     <!-- DNS Prefetch -->

--- a/reports/seo/inventory.json
+++ b/reports/seo/inventory.json
@@ -5,12 +5,12 @@
     "totalHtmlFiles": 343,
     "withCanonical": 341,
     "withoutCanonical": 2,
-    "withOgImage": 263,
-    "withoutOgImage": 80,
-    "withJsonLd": 338,
-    "withoutJsonLd": 5,
+    "withOgImage": 264,
+    "withoutOgImage": 79,
+    "withJsonLd": 339,
+    "withoutJsonLd": 4,
     "hreflangEnArPairs": 339,
-    "noindexCount": 104
+    "noindexCount": 103
   },
   "records": [
     {
@@ -259,21 +259,21 @@
       "exempt": null,
       "lang": "ar",
       "dir": "rtl",
-      "title": "Gold Ticker Live — العربية",
-      "metaDescription": null,
-      "canonical": "https://goldtickerlive.com/",
-      "robots": "noindex,follow",
-      "ogTitle": null,
-      "ogDescription": null,
-      "ogImage": null,
-      "ogUrl": null,
-      "ogType": null,
-      "twitterCard": null,
-      "twitterImage": null,
+      "title": "أسعار الذهب اليوم في الإمارات والخليج | Gold Ticker Live",
+      "metaDescription": "سعر جرام الذهب اليوم في الإمارات بالدرهم — أسعار مرجعية لعيار 24 و22 و21 و18 لدول الخليج وأكثر من 20 دولة عربية، مع تحديث تلقائي ووسم يوضّح حداثة السعر. الأسعار مرجعية وليست أسعار تجزئة.",
+      "canonical": "https://goldtickerlive.com/ar/",
+      "robots": null,
+      "ogTitle": "Gold Ticker Live — Reference Gold Prices for GCC & the Arab World | أسعار الذهب المرجعية",
+      "ogDescription": "Track gold spot prices in 24+ countries. Seven karat grades (14K–24K) from gold-api.com spot + open.er-api.com FX. Source updates hourly; pages re-poll ~90s. Bilingual EN/AR.",
+      "ogImage": "https://goldtickerlive.com/assets/og-image.png",
+      "ogUrl": "https://goldtickerlive.com/ar/",
+      "ogType": "website",
+      "twitterCard": "summary_large_image",
+      "twitterImage": "https://goldtickerlive.com/assets/og-image.png",
       "hreflang": [
         {
           "lang": "ar",
-          "href": "https://goldtickerlive.com/?lang=ar"
+          "href": "https://goldtickerlive.com/ar/"
         },
         {
           "lang": "en",
@@ -284,8 +284,11 @@
           "href": "https://goldtickerlive.com/"
         }
       ],
-      "jsonLdTypes": [],
-      "hasStructuredData": false,
+      "jsonLdTypes": [
+        "Organization",
+        "WebSite"
+      ],
+      "hasStructuredData": true,
       "jsonLdParseFailures": null
     },
     {
@@ -12089,7 +12092,7 @@
       "hreflang": [
         {
           "lang": "ar",
-          "href": "https://goldtickerlive.com/?lang=ar"
+          "href": "https://goldtickerlive.com/ar/"
         },
         {
           "lang": "en",

--- a/scripts/node/generate-ar-homepage.mjs
+++ b/scripts/node/generate-ar-homepage.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Generate the indexable Arabic homepage at `ar/index.html` from `index.html`.
+ *
+ * The homepage app (`src/pages/home.js`) renders in Arabic when served at
+ * `/ar/` — see `getLang()` / `getDepth()` in that file. This generator keeps
+ * the Arabic homepage's structure in lock-step with the English one; only the
+ * language/SEO metadata and the relative asset depth differ. Re-run it whenever
+ * `index.html` changes (or wire it into the build).
+ *
+ * Usage:
+ *   node scripts/node/generate-ar-homepage.mjs          # write ar/index.html
+ *   node scripts/node/generate-ar-homepage.mjs --check  # fail if out of date
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SRC = path.join(ROOT, 'index.html');
+const OUT = path.join(ROOT, 'ar', 'index.html');
+
+const AR_TITLE = 'أسعار الذهب اليوم في الإمارات والخليج | Gold Ticker Live';
+const AR_DESC =
+  'سعر جرام الذهب اليوم في الإمارات بالدرهم — أسعار مرجعية لعيار 24 و22 و21 و18 لدول الخليج وأكثر من 20 دولة عربية، مع تحديث تلقائي ووسم يوضّح حداثة السعر. الأسعار مرجعية وليست أسعار تجزئة.';
+
+function build() {
+  let html = fs.readFileSync(SRC, 'utf8');
+
+  // 1. Document language + direction.
+  html = html.replace('<html lang="en" dir="ltr">', '<html lang="ar" dir="rtl">');
+
+  // 2. Self-canonical + og:url to /ar/ (this IS the canonical Arabic homepage).
+  html = html.replace(
+    'rel="canonical" href="https://goldtickerlive.com/"',
+    'rel="canonical" href="https://goldtickerlive.com/ar/"'
+  );
+  html = html.replace(
+    'property="og:url" content="https://goldtickerlive.com/"',
+    'property="og:url" content="https://goldtickerlive.com/ar/"'
+  );
+
+  // 3. Reciprocal hreflang: ar → /ar/ (x-default + en stay at the root /).
+  html = html.replace(
+    'hreflang="ar" href="https://goldtickerlive.com/?lang=ar"',
+    'hreflang="ar" href="https://goldtickerlive.com/ar/"'
+  );
+
+  // 4. Open Graph locale.
+  html = html.replace(
+    'property="og:locale" content="en_US"',
+    'property="og:locale" content="ar_AE"'
+  );
+  html = html.replace(
+    'property="og:locale:alternate" content="ar_AE"',
+    'property="og:locale:alternate" content="en_US"'
+  );
+
+  // 5. Localized title + meta description.
+  html = html.replace(/<title>[^<]*<\/title>/, `<title>${AR_TITLE}</title>`);
+  html = html.replace(/(name="description"\s+content=")[^"]*(")/, `$1${AR_DESC}$2`);
+
+  // 6. This page lives one directory deep (/ar/). Prepend ../ to every RELATIVE
+  //    href/src so assets/scripts/links still resolve. Absolute URLs (scheme:,
+  //    //, /), hashes, and the canonical/hreflang URLs above are left untouched.
+  html = html.replace(
+    /((?:href|src)=")(?![a-z][a-z0-9+.-]*:|\/\/|\/|#)([^"]*)"/gi,
+    '$1../$2"'
+  );
+
+  // 7. Provenance marker.
+  html = html.replace(
+    '<head>',
+    '<head>\n    <!-- Generated from index.html by scripts/node/generate-ar-homepage.mjs — do not edit by hand. -->'
+  );
+
+  return html;
+}
+
+const out = build();
+const check = process.argv.includes('--check');
+const existing = fs.existsSync(OUT) ? fs.readFileSync(OUT, 'utf8') : '';
+
+if (check) {
+  if (existing.trimEnd() !== out.trimEnd()) {
+    console.error('✖ ar/index.html is out of date. Run: node scripts/node/generate-ar-homepage.mjs');
+    process.exit(1);
+  }
+  console.log('✓ ar/index.html is up to date.');
+} else {
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, out);
+  console.log(`✓ Wrote ar/index.html from index.html (${out.length} bytes).`);
+}

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -115,6 +115,9 @@ let karatStripUnit = (() => {
 
 function getLang() {
   try {
+    // The /ar/ path is the canonical Arabic homepage — treat it as Arabic
+    // regardless of query/localStorage so the indexable page renders in AR.
+    if (/^\/ar(\/|$)/.test(window.location.pathname)) return 'ar';
     const urlLang = new URLSearchParams(window.location.search).get('lang');
     if (urlLang === 'ar' || urlLang === 'en') return urlLang;
     const p = JSON.parse(localStorage.getItem(LANG_KEY) || '{}');
@@ -122,6 +125,13 @@ function getLang() {
   } catch {
     return 'en';
   }
+}
+
+// Directory depth from the site root, so the shared shell builds correct
+// relative links. The homepage app serves both `/` (depth 0) and the indexable
+// Arabic homepage `/ar/` (depth 1).
+function getDepth() {
+  return /^\/ar(\/|$)/.test(window.location.pathname) ? 1 : 0;
 }
 
 function saveLang(l) {
@@ -1442,7 +1452,7 @@ async function init() {
   injectFaqSchema(document, buildMethodologyFaqSchema(lang));
 
   // Nav + footer + spot bar
-  const shell = mountSharedShell({ lang, depth: 0, withSpotBar: true });
+  const shell = mountSharedShell({ lang, depth: getDepth(), withSpotBar: true });
   initPageEnter('main');
   const navCtrl = shell.navCtrl;
   navCtrl.getLangToggleButtons().forEach((btn) => {


### PR DESCRIPTION
## P0 — Indexable Arabic homepage at `/ar/` + reciprocal hreflang

Closes the one real open P0 from the audit (live-confirmed): the **Arabic homepage wasn't indexable**.

### Before
- `/ar/` returned `200` but with `<meta robots="noindex,follow">`, `<link canonical=…/>` (the **English** homepage), and a JS `location.replace('/?lang=ar')` redirect — a stub, not a page.
- The EN homepage's `hreflang="ar"` pointed at `/?lang=ar` (a non-distinct URL Google won't treat as a separate page).
- Net effect: the entire Arabic homepage was hidden from search.

### After — `/ar/` is a real indexable Arabic homepage
Mirrors the pattern your `/ar/` **sub-pages** already use (methodology, chart, gold-price).

- **`src/pages/home.js`** — `getLang()` treats the `/ar/` path as Arabic (so the page renders in AR without `?lang=`); new `getDepth()` returns the correct directory depth so the shared shell builds valid links from `/ar/`.
- **`scripts/node/generate-ar-homepage.mjs`** (new) — derives `ar/index.html` from `index.html`: `lang="ar" dir="rtl"`, AR `<title>` + description, **self-canonical `/ar/`**, `og:locale ar_AE`, reciprocal hreflang (`ar→/ar/`, `en`/`x-default→/`), and depth-fixed `../` asset paths. Idempotent + `--check` mode so the two homepages never drift. **No noindex, no redirect.**
- **`index.html`** — `hreflang="ar"` now points to `/ar/`.
- **`reports/seo/inventory.json`** — regenerated for the new page.

### Verification (all local, all green)
- `npx vite build` → builds `dist/ar/index.html` cleanly (exit 0)
- `npm run validate` → **pass** (SEO meta, schema, shell-guard, a11y, reference-language, inventory)
- `npm test` → **0 failures**
- **Real browser render** of the built `/ar/`: full Arabic homepage — `lang=ar`, `dir=rtl`, self-canonical `/ar/`, live spot price, RTL nav. (screenshot-verified)

### Follow-ups (not in this PR)
- Optionally wire `generate-ar-homepage.mjs` into `npm run build` so `ar/index.html` regenerates automatically.
- Sweep remaining legacy `.html` pages whose `hreflang="ar"` still points at `?lang=ar` where an `/ar/` target exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large SEO and routing change for the homepage pair; wrong canonical/hreflang or stale generated HTML would affect indexing, though behavior is guarded by validate/inventory checks.
> 
> **Overview**
> Replaces the **`/ar/` stub** (noindex, wrong canonical, JS redirect to `/?lang=ar`) with a **full, indexable Arabic homepage** aligned with the English `index.html`.
> 
> **`scripts/node/generate-ar-homepage.mjs`** derives `ar/index.html` from the root homepage: `lang="ar"` / RTL, Arabic title and meta description, self-canonical and `og:url` at `/ar/`, swapped `og:locale`, reciprocal **`hreflang="ar"` → `/ar/`**, and `../`-prefixed relative asset paths. It supports **`--check`** so the generated file cannot drift from `index.html`.
> 
> **`src/pages/home.js`** treats `/ar/` as Arabic via **`getLang()`** (path wins over query/localStorage) and uses **`getDepth()`** so **`mountSharedShell`** builds correct relative nav/footer links from `/ar/`.
> 
> **`index.html`** updates Arabic **`hreflang`** from `/?lang=ar` to **`https://goldtickerlive.com/ar/`**. **`reports/seo/inventory.json`** reflects the new indexable page (no noindex, full OG/JSON-LD).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7fcec6bb60c3efb7fdfd0c6b683eedf59085899. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->