### PR TITLE
security: RLS lockdown for Prisma comparison DB (review-only) + API/headers/deps hardening (Session 1)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -49,6 +49,13 @@ RewriteRule ^countries/algeria\.html$ /countries/algeria/ [R=301,L]
 # ═══════════════════════════════════════════════════════════════
 # Security Headers
 # ═══════════════════════════════════════════════════════════════
+# ⚠️  HOST CAVEAT: these Header directives only take effect on an Apache host
+# with mod_headers. The default production deploy (.github/workflows/deploy.yml)
+# copies this file into dist/ but publishes to GitHub Pages, which serves it as
+# a static file and does NOT process .htaccess — so NONE of the headers below
+# are emitted on the public site. To ship them, front the site with Apache /
+# Cloudflare / Netlify, or set equivalent Cloudflare Transform Rules. The
+# parity note on HSTS below refers to value parity, not to where it is applied.
 
 <IfModule mod_headers.c>
   # Prevent MIME-type sniffing

--- a/_headers
+++ b/_headers
@@ -4,6 +4,16 @@
 # defaults for a multi-page static site with a separate admin app on a
 # different host. If deploying admin/ to the same host, tighten admin-specific
 # headers below.
+#
+# ⚠️  HOST CAVEAT — this file is ONLY honored by Netlify / Cloudflare Pages.
+# The default production deploy (.github/workflows/deploy.yml) publishes dist/
+# to GitHub Pages, which does NOT read this file (nor `.htaccess`). On that
+# host the security headers below are NOT emitted. To actually ship them on the
+# public site, front it with Cloudflare/Netlify (which consume this file) or add
+# a Cloudflare Transform Rule / Worker that sets the same headers. Until then,
+# the only header-equivalents that reach GitHub Pages are the `<meta>` tags the
+# build injects (X-Content-Type-Options, referrer) — note X-Frame-Options and
+# HSTS cannot be set via <meta> and so are absent on the GitHub Pages tier.
 
 # Long-cache immutable static assets (fingerprinted by Vite).
 /assets/*
@@ -29,13 +39,15 @@
 /manifest.json
   Cache-Control: public, max-age=3600
 
-# Global security headers applied to every response.
-# Kept in parity with the Helmet header set at server.js:42–99 so the static
-# tier (Netlify / Cloudflare Pages) ships the same hardening as the dynamic
-# admin tier. Note: CSP is intentionally NOT set here — production CSP is
-# enforced by Helmet for the admin/API host and is locked by
-# tests/csp-regression.test.js. Adding a static-host CSP would require a
-# parallel regression test in the same commit (plan item A.A.2 #9).
+# Global security headers — emitted for every response ONLY on a host that reads
+# this file (Netlify / Cloudflare Pages). They mirror the Helmet header set at
+# server.js:57–121 so that, when the static tier is fronted by such a host, it
+# ships the same hardening as the dynamic admin tier. See the HOST CAVEAT at the
+# top of this file: under the default GitHub Pages deploy these are inert.
+# Note: CSP is intentionally NOT set here — production CSP is enforced by Helmet
+# for the admin/API host and is locked by tests/csp-regression.test.js. Adding a
+# static-host CSP would require a parallel regression test in the same commit
+# (plan item A.A.2 #9).
 /*
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY

--- a/package-lock.json
+++ b/package-lock.json
@@ -1099,9 +1099,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/server.js
+++ b/server.js
@@ -116,6 +116,11 @@ app.use(
     crossOriginOpenerPolicy: { policy: 'same-origin' },
     crossOriginResourcePolicy: { policy: 'same-origin' },
     referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+    // Emit X-Frame-Options: DENY so the dynamic tier matches the DENY set in the
+    // static-tier `_headers` / `.htaccess` (Helmet's default is SAMEORIGIN).
+    // CSP `frame-ancestors 'none'` above is the authoritative control for modern
+    // browsers; this keeps legacy XFO-only clients consistent across tiers.
+    xFrameOptions: { action: 'deny' },
     hsts: IS_PROD ? { maxAge: 31536000, includeSubDomains: true, preload: true } : false,
   })
 );

--- a/server/routes/alerts.js
+++ b/server/routes/alerts.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
@@ -10,6 +11,27 @@ const { getSupabaseClient } = require('../lib/supabase-client');
 const { buildUrl } = require('../lib/site-url');
 
 const router = express.Router();
+
+// ---------------------------------------------------------------------------
+// Rate limiter for the public, unauthenticated alert write surface.
+// ---------------------------------------------------------------------------
+// POST /alerts triggers a verification email to a caller-supplied address, and
+// the management/verify/unsubscribe routes mutate state — all anonymous. Without
+// a dedicated limiter these are throttled only by the broad global /api limiter
+// (120/min in prod), which is enough headroom to email-bomb arbitrary inboxes
+// and create unbounded alert rules. Mirror the tight per-route limiter every
+// sibling public-write router already uses (submissions/leads/newsletter/shops).
+// The token-gated /jobs/check-alerts route is intentionally NOT wrapped — it has
+// its own ALERT_JOB_TOKEN check. Headroom under NODE_ENV=test keeps the route
+// tests (which share one IP) from tripping the limit.
+const alertsWriteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: process.env.NODE_ENV === 'test' ? 1000 : 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: errorResponse('RATE_LIMITED', 'Too many requests. Please try again later.'),
+});
+
 const ROOT = path.resolve(__dirname, '../..');
 const GOLD_PRICE_FILE = path.join(ROOT, 'data', 'gold_price.json');
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
@@ -769,7 +791,7 @@ function updateSubscriptionByDestination(destination, channel, patch) {
   return Promise.resolve();
 }
 
-router.post('/alerts', async (req, res) => {
+router.post('/alerts', alertsWriteLimiter, async (req, res) => {
   const parsed = sanitizeAlertInput(req.body);
   if (!parsed.ok) {
     return res.status(400).json(errorResponse('VALIDATION_ERROR', parsed.message));
@@ -832,7 +854,7 @@ router.get('/alerts/:managementToken', async (req, res) => {
   );
 });
 
-router.patch('/alerts/:managementToken', async (req, res) => {
+router.patch('/alerts/:managementToken', alertsWriteLimiter, async (req, res) => {
   const existing = await findRuleByManagementToken(req.params.managementToken);
   if (!existing) {
     return res.status(404).json(errorResponse('ALERT_NOT_FOUND', 'Alert not found.'));
@@ -870,7 +892,7 @@ router.patch('/alerts/:managementToken', async (req, res) => {
   );
 });
 
-router.delete('/alerts/:managementToken', async (req, res) => {
+router.delete('/alerts/:managementToken', alertsWriteLimiter, async (req, res) => {
   const existing = await findRuleByManagementToken(req.params.managementToken);
   if (!existing) {
     return res.status(404).json(errorResponse('ALERT_NOT_FOUND', 'Alert not found.'));
@@ -893,7 +915,7 @@ router.delete('/alerts/:managementToken', async (req, res) => {
   );
 });
 
-router.post('/alerts/verify', async (req, res) => {
+router.post('/alerts/verify', alertsWriteLimiter, async (req, res) => {
   const token = safeTrimmed(req.body?.token || req.query?.token, 256);
   if (!token) {
     return res
@@ -917,7 +939,7 @@ router.post('/alerts/verify', async (req, res) => {
   );
 });
 
-router.post('/alerts/unsubscribe', async (req, res) => {
+router.post('/alerts/unsubscribe', alertsWriteLimiter, async (req, res) => {
   const token = safeTrimmed(req.body?.token || req.query?.token, 256);
   if (!token) {
     return res

--- a/supabase/migrations/004_prisma_comparison_enable_rls.sql
+++ b/supabase/migrations/004_prisma_comparison_enable_rls.sql
@@ -1,0 +1,134 @@
+-- supabase/migrations/004_prisma_comparison_enable_rls.sql
+-- ============================================================================
+-- RED ZONE — STAGED, NOT APPLIED: enable RLS + lock down public grants
+-- ============================================================================
+-- ⚠️  DIFFERENT TARGET PROJECT than migrations 001–003 in this folder.
+--     001–003 target the site project `nebdpxjazlnsrfmlpgeq` (snake_case
+--     schema: shops, shop_listings, …). THIS migration targets the SEPARATE,
+--     Vercel-integrated, Prisma-managed price-comparison project:
+--
+--         PROJECT REF : lulqcytwhtjdsbzslpiw
+--         HOST        : db.lulqcytwhtjdsbzslpiw.supabase.co
+--         TABLES      : "Store", "Product", "Listing", "PriceHistory",
+--                       "_prisma_migrations"  (PascalCase — must stay quoted)
+--
+--     Ideally this hardening is also recorded in that app's own
+--     prisma/migrations history; it lives here because GoldTickerLive is the
+--     only in-scope repo for this security lane.
+-- ============================================================================
+-- PROBLEM (verified 2026-06-30 via Supabase security advisor + pg_catalog):
+--   * RLS is DISABLED on all 5 public tables  ->  5x rls_disabled_in_public ERROR
+--     (https://supabase.com/docs/guides/database/database-linter?lint=0013_rls_disabled_in_public).
+--   * `anon` AND `authenticated` hold FULL table privileges on every table —
+--     SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER.
+--   * Net effect: anyone holding the public anon key can read, overwrite,
+--     delete, and even TRUNCATE every row — including the Prisma migration
+--     bookkeeping table. Full anonymous read + write exposure.
+--
+-- WHY THIS IS SAFE FOR THE APP (verified via pg_roles / pg_class):
+--   * All 5 tables are owned by role `postgres`, and `postgres` has
+--     rolbypassrls = true. Prisma connects as `postgres` over DATABASE_URL, so
+--     its server-side reads/writes BYPASS RLS and are unaffected.
+--   * `service_role` also has rolbypassrls = true (any server/edge writes via
+--     the service key are unaffected).
+--   * relforcerowsecurity = false on every table, so owner-bypass stays in
+--     effect (we deliberately do NOT force RLS on the owner).
+--   * Only the PostgREST roles `anon` / `authenticated` are gated by RLS —
+--     exactly the public attack surface being closed.
+--
+-- POLICY SHAPE:
+--   * Store / Product / Listing / PriceHistory  ->  PUBLIC READ-ONLY.
+--       keep the SELECT grant + add a permissive SELECT policy so any public
+--       client read of the comparison directory keeps working; REVOKE every
+--       write + TRUNCATE grant from anon/authenticated. Writes flow only
+--       through postgres / service_role (which bypass RLS).
+--   * _prisma_migrations  ->  NO public access. REVOKE ALL from anon/auth and
+--     enable RLS with no policy. Prisma's postgres connection still manages it.
+--
+-- TRUNCATE NOTE: TRUNCATE is NOT governed by RLS policies, so enabling RLS
+--   alone would still leave anon able to TRUNCATE these tables. The REVOKE
+--   statements below are what actually close that path — do not drop them.
+--
+-- ⚠️  DO NOT auto-apply (Session 1 security lane / hard safety gate).
+--     Apply only after human approval of this PR, e.g. in the Supabase SQL
+--     editor for project lulqcytwhtjdsbzslpiw, or:
+--         psql "$PRISMA_SUPABASE_DB_URL" -f supabase/migrations/004_prisma_comparison_enable_rls.sql
+--     Then re-run the Supabase security advisor on a preview branch and confirm
+--     0 rls_disabled_in_public errors AND that public SELECT still succeeds.
+-- ============================================================================
+
+begin;
+
+-- 1) Enable RLS on every exposed table. Idempotent (no-op if already enabled).
+alter table public."Store"              enable row level security;
+alter table public."Product"            enable row level security;
+alter table public."Listing"            enable row level security;
+alter table public."PriceHistory"       enable row level security;
+alter table public."_prisma_migrations" enable row level security;
+
+-- 2) Revoke the dangerous public write/admin grants. RLS does not govern
+--    TRUNCATE / REFERENCES / TRIGGER, so these REVOKEs are required, not
+--    optional. SELECT is intentionally retained on the 4 business tables.
+revoke insert, update, delete, truncate, references, trigger
+  on public."Store"        from anon, authenticated;
+revoke insert, update, delete, truncate, references, trigger
+  on public."Product"      from anon, authenticated;
+revoke insert, update, delete, truncate, references, trigger
+  on public."Listing"      from anon, authenticated;
+revoke insert, update, delete, truncate, references, trigger
+  on public."PriceHistory" from anon, authenticated;
+
+-- _prisma_migrations is internal bookkeeping — no public role should touch it.
+revoke all on public."_prisma_migrations" from anon, authenticated;
+
+-- 3) Public read-only policies for the comparison directory. DROP-then-CREATE
+--    keeps the migration re-runnable. No policy is created for
+--    _prisma_migrations, so anon/authenticated get zero access under RLS.
+drop policy if exists "Public read stores" on public."Store";
+create policy "Public read stores"
+  on public."Store" for select to anon, authenticated using (true);
+
+drop policy if exists "Public read products" on public."Product";
+create policy "Public read products"
+  on public."Product" for select to anon, authenticated using (true);
+
+drop policy if exists "Public read listings" on public."Listing";
+create policy "Public read listings"
+  on public."Listing" for select to anon, authenticated using (true);
+
+drop policy if exists "Public read price history" on public."PriceHistory";
+create policy "Public read price history"
+  on public."PriceHistory" for select to anon, authenticated using (true);
+
+commit;
+
+-- ============================================================================
+-- POST-APPLY VERIFICATION (read-only):
+--   select relname, relrowsecurity
+--     from pg_class
+--    where relnamespace = 'public'::regnamespace
+--      and relname in ('Store','Product','Listing','PriceHistory','_prisma_migrations');
+--   -- expect relrowsecurity = true for all five.
+--
+--   select tablename, policyname, cmd, roles
+--     from pg_policies
+--    where schemaname = 'public'
+--      and tablename in ('Store','Product','Listing','PriceHistory');
+--   -- expect one SELECT policy per business table; none on _prisma_migrations.
+--
+-- Then re-run the Supabase security advisor -> expect 0 rls_disabled_in_public.
+--
+-- ROLLBACK (emergency only — restores the prior fully-exposed state; avoid):
+--   begin;
+--   drop policy if exists "Public read stores"        on public."Store";
+--   drop policy if exists "Public read products"      on public."Product";
+--   drop policy if exists "Public read listings"      on public."Listing";
+--   drop policy if exists "Public read price history" on public."PriceHistory";
+--   alter table public."Store"              disable row level security;
+--   alter table public."Product"            disable row level security;
+--   alter table public."Listing"            disable row level security;
+--   alter table public."PriceHistory"       disable row level security;
+--   alter table public."_prisma_migrations" disable row level security;
+--   -- (revoked grants are NOT auto-restored; re-grant only if truly required)
+--   commit;
+-- ============================================================================


### PR DESCRIPTION
## Summary

Session 1 (security & backend integrity). Closes the top-priority RLS exposure and three lower-severity hardening gaps found by an adversarially-verified audit. **No product behavior changes.** Five focused commits:

1. **`security(rls)`** — review-only migration to enable RLS + lock down public grants on the **Vercel/Prisma price-comparison project** (`lulqcytwhtjdsbzslpiw`: `Store/Product/Listing/PriceHistory/_prisma_migrations`). **Not applied to production — apply requires approval of this PR.**
2. **`security(api)`** — per-route rate limiter on the unauthenticated `/api/v1/alerts*` write routes (email-bombing / unbounded-rule abuse).
3. **`security(headers)`** — Helmet now emits `X-Frame-Options: DENY` (was default `SAMEORIGIN`), matching the static tier.
4. **`security(deps)`** — bump `brace-expansion` 5.0.5→5.0.7 (dev-only ReDoS, GHSA-jxxr-4gwj-5jf2).
5. **`security(docs)`** — correct misleading "parity" comments in `_headers`/`.htaccess`.

> ⚠️ The `lulqcytwhtjdsbzslpiw` project is **not** the project this repo's anon key points at (`nebdpxjazlnsrfmlpgeq`); no in-repo code reads/writes the PascalCase tables. It's the separate Vercel/Prisma app. The migration lives here because this is the only in-scope repo for the security lane.

## Implementation notes

**1. RLS migration — `supabase/migrations/004_prisma_comparison_enable_rls.sql` (STAGED, not applied)**
- The 5 public tables have **RLS off** AND `anon`/`authenticated` hold **full** `SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER` grants → the public anon key can read, overwrite, delete, and even **TRUNCATE** every row (confirmed: 5× `rls_disabled_in_public` ERROR via the security advisor).
- Migration: `ENABLE ROW LEVEL SECURITY` on all 5; **`REVOKE`** write+TRUNCATE from `anon`/`authenticated` (TRUNCATE is *not* governed by RLS, so REVOKE is required, not optional); add public read-only `SELECT` policies on the 4 business tables; deny `anon`/`authenticated` on `_prisma_migrations` entirely.
- **VERIFIED safe against the live catalog (read-only):** all 5 tables are owned by `postgres` (`rolbypassrls=true`) and `service_role` also bypasses RLS, so the Prisma server connection is unaffected; `relforcerowsecurity=false`. Only `anon`/`authenticated` (which do *not* bypass RLS) are gated.
- **UNVERIFIED:** advisor re-run on a live preview branch — creating a Supabase branch incurs cost and is a prod-config action, left for the approver. SQL is idempotent and includes verification + rollback queries inline.

**2. Alerts limiter — `server/routes/alerts.js`**
- Shared 15-min limiter (10/IP prod; generous headroom under `NODE_ENV=test`) on `POST /alerts`, `PATCH`/`DELETE /alerts/:managementToken`, `POST /alerts/verify`, `POST /alerts/unsubscribe`. Token-gated `/jobs/check-alerts` untouched. Reuses `express-rate-limit` (existing dep); mirrors the sibling public-write routers.

**3. Helmet XFO — `server.js`** — `xFrameOptions: { action: 'deny' }`. **VERIFIED:** booted the prod server, `/api/health` returns `X-Frame-Options: DENY`; `frame-ancestors 'none'` remains the authoritative control.

**4. Deps — `package-lock.json`** — lockfile-only, within minimatch's `^5.0.5` range; `npm audit` → **0 vulnerabilities**.

**5. Header honesty — `_headers` / `.htaccess`** — comments only, no directive changes. The default `deploy.yml` ships `dist/` to **GitHub Pages**, which honors neither file, so the public host currently emits none of these headers. Documented the gap + the real fix (front with Cloudflare/Netlify, or a Cloudflare Transform Rule/Worker). A sitewide `<meta>` CSP was deliberately **not** added — `tests/security-meta-guard.test.js` forbids dead security `<meta>` tags, and it risks breaking live analytics/Stripe/Supabase calls.

## Checklist
- [x] `npm ci` — clean install, 0 vulnerabilities
- [x] `npm test` — **1273 pass / 0 fail** (incl. `csp-regression` and `alerts-api`)
- [x] `npm run lint` — clean
- [x] Touched files are Prettier-clean (`prettier --check` on each)
- [ ] `npm run quality` — **not green**, but only due to **157 pre-existing** `format:check` warnings in files this PR does not touch (baseline issue, out of scope)
- [ ] `npm run build` / Playwright — **N/A**: server- and config-only changes; nothing in the Vite static bundle changed
- [ ] **Owner action:** review + apply `004_prisma_comparison_enable_rls.sql` to project `lulqcytwhtjdsbzslpiw`, then re-run the security advisor

_Gold-provider-bakeoff checklist omitted — this PR touches no provider adapters, bakeoff scripts, or gold-price workflows._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2fSfXuZsrSkjB72JoQ2Yc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication-adjacent abuse surfaces (anonymous alerts/email) and stages database privilege/RLS changes for a live Supabase project; mistaken application of the migration or over-tight limits could break public reads or legitimate alert signups.
> 
> **Overview**
> Session 1 security hardening with **no intended product behavior changes** beyond tighter abuse controls on anonymous alert writes.
> 
> Adds a **review-only** Supabase migration (`004_prisma_comparison_enable_rls.sql`) for the separate Prisma price-comparison project: enable RLS, **REVOKE** write/TRUNCATE grants from `anon`/`authenticated`, keep public **SELECT** on comparison tables, and block public access to `_prisma_migrations`. **Not auto-applied** — owner must run it after approval.
> 
> **`server/routes/alerts.js`** gets a dedicated **10 requests / 15 min / IP** limiter (higher in test) on unauthenticated write routes (`POST /alerts`, management `PATCH`/`DELETE`, verify, unsubscribe); **`/jobs/check-alerts`** stays on its job token only.
> 
> **`server.js`** sets Helmet **`X-Frame-Options: DENY`** to align with static-tier config (CSP `frame-ancestors` remains primary).
> 
> **`_headers`** and **`.htaccess`** comments only: clarify that default **GitHub Pages** deploy does **not** apply these files, so advertised security headers are inert on the public static host unless fronted by Netlify/Cloudflare/Apache or equivalent rules.
> 
> **`package-lock.json`**: dev dependency **`brace-expansion`** 5.0.5 → 5.0.7.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a80395acc81d3a054dff0104753e90d0bf2dd70. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->