### PR TITLE
content(S5): trust-copy honesty + calculator EN/AR parity & dead cross-link fixes

### DIFF
--- a/methodology.html
+++ b/methodology.html
@@ -321,7 +321,7 @@
           <p id="aed-peg-p1">
             The UAE Dirham has been officially pegged to the US Dollar at a rate of
             <strong>3.6725 AED per 1 USD</strong> since November 1997. This peg is maintained by the
-            UAE Central Bank and has never changed in over 27 years of continuous operation.
+            UAE Central Bank and has remained unchanged through every market cycle since.
           </p>
 
           <div class="method-formula-block">
@@ -341,10 +341,11 @@
           </p>
 
           <p id="aed-peg-effect-p">
-            This means AED gold prices on this site are always mathematically exact relative to the
-            USD spot price — with zero exchange rate uncertainty. This is actually a feature, not a
-            limitation: because the peg has held since 1997, our hardcoded value is more accurate
-            than any API-derived figure.
+            This means the USD→AED conversion step itself carries no exchange-rate uncertainty —
+            because the peg has held since 1997, the hardcoded value is more reliable than a
+            free-tier API rate for that one step. The AED gold price is still only as fresh and
+            accurate as the XAU/USD spot input it is built on, which is why every AED figure keeps a
+            freshness label and remains a reference estimate, not a guaranteed price.
           </p>
 
           <p id="aed-peg-reference-p">
@@ -576,6 +577,7 @@
             <li><span class="badge badge--delayed">Delayed</span> Provider lag (often FX)</li>
             <li><span class="badge badge--stale">Stale</span> Older than our stale threshold</li>
             <li><span class="badge badge--fallback">Fallback</span> Last known value after failure</li>
+            <li><span class="badge badge--unavailable">Unavailable</span> Every provider failed — no price is shown, only a clear error state</li>
           </ul>
         </section>
 

--- a/methodology.html
+++ b/methodology.html
@@ -335,9 +335,9 @@
           <p id="aed-peg-approach-p">
             We <strong>never</strong> use the AED rate returned by the open.er-api.com API. Even
             though the API returns an AED rate, free-tier exchange rate APIs can occasionally return
-            rounded or slightly off values. To guarantee accuracy for AED-denominated gold prices,
-            we hardcode the official peg rate of <strong>3.6725</strong> and delete any AED value
-            from the API response before processing.
+            rounded or slightly off values. To keep the USD→AED conversion step exact, we hardcode
+            the official peg rate of <strong>3.6725</strong> and delete any AED value from the API
+            response before processing.
           </p>
 
           <p id="aed-peg-effect-p">

--- a/src/components/ShopVsReferencePanel.js
+++ b/src/components/ShopVsReferencePanel.js
@@ -5,9 +5,9 @@
 import { el, clear } from '../lib/safe-dom.js';
 import { formatPrice } from '../lib/formatter.js';
 
-/** Typical GCC jewellery making-charge range (illustrative). */
-const MAKING_LOW = 0.08;
-const MAKING_HIGH = 0.22;
+/** Typical jewellery making-charge range (illustrative; matches the 5–25% band cited in the FAQ). */
+const MAKING_LOW = 0.05;
+const MAKING_HIGH = 0.25;
 
 /**
  * @param {{
@@ -18,12 +18,7 @@ const MAKING_HIGH = 0.22;
  * }} options
  * @returns {HTMLElement}
  */
-export function renderShopVsReferencePanel({
-  referenceLocal,
-  currency,
-  decimals = 2,
-  t,
-}) {
+export function renderShopVsReferencePanel({ referenceLocal, currency, decimals = 2, t }) {
   const root = el('div', { class: 'shop-vs-reference', 'aria-labelledby': 'shop-vs-ref-heading' });
   const heading = el('h3', { class: 'shop-vs-reference__title', id: 'shop-vs-ref-heading' }, [
     t('title'),
@@ -41,10 +36,14 @@ export function renderShopVsReferencePanel({
   ]);
 
   const disclaimer = el('p', { class: 'shop-vs-reference__disclaimer' }, [t('disclaimer')]);
-  const link = el('a', {
-    class: 'shop-vs-reference__link',
-    href: 'content/spot-vs-retail-gold-price/',
-  }, [t('link')]);
+  const link = el(
+    'a',
+    {
+      class: 'shop-vs-reference__link',
+      href: 'content/spot-vs-retail-gold-price/',
+    },
+    [t('link')]
+  );
 
   root.append(heading, intro, bars, disclaimer, link);
   return root;

--- a/src/components/ShopVsReferencePanel.js
+++ b/src/components/ShopVsReferencePanel.js
@@ -40,7 +40,9 @@ export function renderShopVsReferencePanel({ referenceLocal, currency, decimals 
     'a',
     {
       class: 'shop-vs-reference__link',
-      href: 'content/spot-vs-retail-gold-price/',
+      // Leading `./` is required: safe-dom's safeHref() drops bare-relative
+      // hrefs, which would otherwise render this trust link with no href.
+      href: './content/spot-vs-retail-gold-price/',
     },
     [t('link')]
   );

--- a/src/config/translations.js
+++ b/src/config/translations.js
@@ -27,7 +27,7 @@ export const TRANSLATIONS = {
     'karat.col.usd': 'USD',
     'karat.col.aed': 'AED (Fixed Peg)',
     'karat.disclaimer':
-      'Estimated bullion-equivalent values. Retail and jewelry prices may differ.',
+      'Estimated bullion-equivalent values. Retail and jewelry prices may differ. Not financial advice.',
     'unit.gram': 'Per Gram',
     'unit.oz': 'Per Ounce',
     'countries.title': 'Global Gold Estimates',
@@ -1379,7 +1379,8 @@ export const TRANSLATIONS = {
     'karat.col.karat': 'العيار',
     'karat.col.usd': 'دولار (USD)',
     'karat.col.aed': 'درهم (AED) ربط ثابت',
-    'karat.disclaimer': 'قيم تقديرية مكافئة للسبيكة. قد تختلف أسعار التجزئة والمجوهرات.',
+    'karat.disclaimer':
+      'قيم تقديرية مكافئة للسبيكة. قد تختلف أسعار التجزئة والمجوهرات. ليست نصيحة مالية.',
     'unit.gram': 'لكل غرام',
     'unit.oz': 'لكل أوقية',
     'countries.title': 'تقديرات الذهب العالمية',

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -179,7 +179,9 @@ const T = {
     convert_title: 'Gold Weight Unit Converter',
     convert_desc: 'Convert between grams, troy ounces, tolas, mashas, and more.',
     conv_amount: 'Amount',
+    conv_amount_placeholder: 'Enter a value',
     conv_from: 'From',
+    val_making_charge_link: 'What is a making charge?',
     conv_results_title: 'Equivalent weights',
     freshness_waiting: 'Freshness: waiting for source timestamp…',
     trust_note:
@@ -312,7 +314,9 @@ const T = {
     convert_title: 'محوّل وحدات الذهب',
     convert_desc: 'حوّل بين الغرام والأوقية التروي والتولة والمثقال وغيرها.',
     conv_amount: 'الكمية',
+    conv_amount_placeholder: 'أدخل قيمة',
     conv_from: 'من',
+    val_making_charge_link: 'ما هي المصنعية؟',
     conv_results_title: 'الأوزان المكافئة',
     freshness_waiting: 'حداثة البيانات: بانتظار الطابع الزمني من المصدر…',
     trust_note:
@@ -1125,7 +1129,7 @@ function applyLang() {
     valDisclaimer.append(
       `${t('val_disclaimer')} `,
       el('a', { href: './content/gold-making-charges-guide/', class: 'calc-inline-link' }, [
-        STATE.lang === 'ar' ? 'ما هي المصنعية؟' : 'What is a making charge?',
+        t('val_making_charge_link'),
       ])
     );
   }
@@ -1159,9 +1163,7 @@ function applyLang() {
   set('calc-convert-h2', t('convert_title'));
   set('calc-convert-desc', t('convert_desc'));
   set('conv-amount-label', t('conv_amount'));
-  document
-    .getElementById('conv-amount')
-    ?.setAttribute('placeholder', STATE.lang === 'ar' ? 'أدخل قيمة' : 'Enter a value');
+  document.getElementById('conv-amount')?.setAttribute('placeholder', t('conv_amount_placeholder'));
   set('conv-from-label', t('conv_from'));
   set('conv-results-title', t('conv_results_title'));
   set('calc-freshness-note', t('freshness_waiting'));

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -137,7 +137,7 @@ const T = {
       'Spot-linked reference estimate only. Final retail prices can include making charges, dealer margins, and taxes.',
     shop_vs_ref_title: 'Reference vs typical shop range',
     shop_vs_ref_intro:
-      'Jewellery shops often quote above the raw gold reference. The range below is illustrative (8–22% making charges) — not a live shop price.',
+      'Jewellery shops often quote above the raw gold reference. The range below is illustrative (5–25% making charges) — not a live shop price.',
     shop_vs_ref_reference: 'Raw gold reference',
     shop_vs_ref_low: 'Typical shop (low making)',
     shop_vs_ref_high: 'Typical shop (higher making)',
@@ -272,7 +272,7 @@ const T = {
       'تقدير مرجعي مرتبط بالسعر الفوري فقط. قد تشمل أسعار التجزئة النهائية المصنعية وهوامش التجار والضرائب.',
     shop_vs_ref_title: 'المرجع مقابل نطاق المحلات التقريبي',
     shop_vs_ref_intro:
-      'غالباً ما تقتبس محلات المجوهرات فوق قيمة الذهب الخام. النطاق أدناه توضيحي (مصنعية 8–22٪) — وليس سعر محل مباشر.',
+      'غالباً ما تقتبس محلات المجوهرات فوق قيمة الذهب الخام. النطاق أدناه توضيحي (مصنعية 5–25٪) — وليس سعر محل مباشر.',
     shop_vs_ref_reference: 'المرجع (ذهب خام)',
     shop_vs_ref_low: 'محل نموذجي (مصنعية منخفضة)',
     shop_vs_ref_high: 'محل نموذجي (مصنعية أعلى)',
@@ -398,7 +398,10 @@ function getSelectedCountryContext(currency) {
 }
 
 function buildCountryPageHref(country) {
-  return country?.slug ? `countries/${country.slug}/` : 'countries/index.html';
+  // Keep the leading `./` — safe-dom's safeHref() strips bare-relative hrefs
+  // (only `/`, `./`, `../`, `#`, or absolute schemes survive), so an el()-built
+  // anchor would otherwise render with no href and become a dead link.
+  return country?.slug ? `./countries/${country.slug}/` : './countries/index.html';
 }
 
 let _shopsHandoffListenersBound = false;
@@ -495,14 +498,58 @@ const UNIT_TO_GRAMS = {
 };
 
 const UNIT_LABELS = {
-  gram: 'Gram (g)',
-  oz: 'Troy Ounce (ozt)',
-  kg: 'Kilogram (kg)',
-  tola: 'Tola',
-  masha: 'Masha',
-  baht: 'Baht (Thai)',
-  taels: 'Taels (Chinese)',
+  en: {
+    gram: 'Gram (g)',
+    oz: 'Troy Ounce (ozt)',
+    kg: 'Kilogram (kg)',
+    tola: 'Tola (11.66g)',
+    masha: 'Masha (0.972g)',
+    baht: 'Baht (Thai)',
+    taels: 'Taels (Chinese)',
+  },
+  ar: {
+    gram: 'جرام (g)',
+    oz: 'أونصة تروي (ozt)',
+    kg: 'كيلوغرام (kg)',
+    tola: 'تولة (11.66غ)',
+    masha: 'ماشة (0.972غ)',
+    baht: 'باهت (تايلندي)',
+    taels: 'تيل (صيني)',
+  },
 };
+
+// Units offered by each weight-unit <select> (option order preserved).
+const UNIT_SELECT_OPTIONS = {
+  'val-unit': ['gram', 'oz', 'tola', 'masha'],
+  'scrap-unit': ['gram', 'oz', 'tola'],
+  'zakat-unit': ['gram', 'oz', 'tola'],
+  'conv-from': ['gram', 'oz', 'kg', 'tola', 'masha', 'baht', 'taels'],
+};
+
+/** Localized display label for a weight unit (falls back to EN, then the raw code). */
+function unitLabel(unit) {
+  const labels = UNIT_LABELS[STATE.lang === 'ar' ? 'ar' : 'en'];
+  return labels[unit] ?? UNIT_LABELS.en[unit] ?? unit;
+}
+
+/** Rebuild every weight-unit <select> with localized labels, preserving the chosen value. */
+function populateUnitSelects() {
+  for (const [id, units] of Object.entries(UNIT_SELECT_OPTIONS)) {
+    const select = document.getElementById(id);
+    if (!select) continue;
+    const previous = select.value;
+    select.replaceChildren(
+      ...units.map((unit) => {
+        const opt = document.createElement('option');
+        opt.value = unit;
+        opt.textContent = unitLabel(unit);
+        return opt;
+      })
+    );
+    if (units.includes(previous)) select.value = previous;
+    else if (units[0]) select.value = units[0];
+  }
+}
 
 function toGrams(amount, unit) {
   return amount * (UNIT_TO_GRAMS[unit] ?? 1);
@@ -748,7 +795,7 @@ function calcScrap() {
   result.hidden = false;
   updateTrackerHandoff({ karat, currency });
   updateMobileDock({
-    title: t('scrap_label_spot'),
+    title: t('scrap_label_dealer'),
     value: document.getElementById('scrap-result-dealer').textContent,
     meta: t('dock_meta'),
     targetId: 'scrap-result',
@@ -903,7 +950,7 @@ function calcConvert() {
   for (const [unit, factor] of entries) {
     grid.appendChild(
       el('div', { class: 'conv-row' }, [
-        el('span', { class: 'conv-row-label' }, [UNIT_LABELS[unit] ?? unit]),
+        el('span', { class: 'conv-row-label' }, [unitLabel(unit)]),
         el('span', { class: 'conv-row-value' }, [
           (inGrams / factor).toLocaleString('en-US', { maximumFractionDigits: 6 }),
         ]),
@@ -914,7 +961,7 @@ function calcConvert() {
   convResults.hidden = false;
   updateMobileDock({
     title: t('conv_results_title'),
-    value: `${amount.toLocaleString('en-US', { maximumFractionDigits: 4 })} ${UNIT_LABELS[from] ?? from}`,
+    value: `${amount.toLocaleString('en-US', { maximumFractionDigits: 4 })} ${unitLabel(from)}`,
     meta: t('dock_meta'),
     targetId: 'conv-results',
   });
@@ -941,7 +988,7 @@ function refreshMobileDockForActiveTab() {
       currency: document.getElementById('scrap-currency')?.value ?? 'AED',
     });
     updateMobileDock({
-      title: t('scrap_label_spot'),
+      title: t('scrap_label_dealer'),
       value: document.getElementById('scrap-result-dealer')?.textContent || '—',
       meta: t('dock_meta'),
       targetId: 'scrap-result',
@@ -1001,9 +1048,9 @@ function applyLang() {
     clear(trustNote);
     trustNote.append(
       `${t('trust_note')} `,
-      el('a', { href: 'content/spot-vs-retail-gold-price/' }, [`${t('trust_spot_link')} →`]),
+      el('a', { href: './content/spot-vs-retail-gold-price/' }, [`${t('trust_spot_link')} →`]),
       ' · ',
-      el('a', { href: 'methodology.html' }, [`${t('trust_method_link')} →`])
+      el('a', { href: './methodology.html' }, [`${t('trust_method_link')} →`])
     );
     if (explicitCountry) {
       trustNote.append(
@@ -1070,7 +1117,18 @@ function applyLang() {
   set('val-currency-label', t('val_currency'));
   set('val-currency-hint', t('val_currency_hint'));
   set('val-result-label', t('val_result_label'));
-  set('val-disclaimer', t('val_disclaimer'));
+  // Rebuild (not textContent=) so the "What is a making charge?" cross-link
+  // survives applyLang(); a plain set() wipes the static anchor on every load.
+  const valDisclaimer = document.getElementById('val-disclaimer');
+  if (valDisclaimer) {
+    clear(valDisclaimer);
+    valDisclaimer.append(
+      `${t('val_disclaimer')} `,
+      el('a', { href: './content/gold-making-charges-guide/', class: 'calc-inline-link' }, [
+        STATE.lang === 'ar' ? 'ما هي المصنعية؟' : 'What is a making charge?',
+      ])
+    );
+  }
   updateShopsHandoff({
     currency: document.getElementById('val-currency')?.value || 'AED',
   });
@@ -1101,6 +1159,9 @@ function applyLang() {
   set('calc-convert-h2', t('convert_title'));
   set('calc-convert-desc', t('convert_desc'));
   set('conv-amount-label', t('conv_amount'));
+  document
+    .getElementById('conv-amount')
+    ?.setAttribute('placeholder', STATE.lang === 'ar' ? 'أدخل قيمة' : 'Enter a value');
   set('conv-from-label', t('conv_from'));
   set('conv-results-title', t('conv_results_title'));
   set('calc-freshness-note', t('freshness_waiting'));
@@ -1165,6 +1226,7 @@ function applyLang() {
   document.documentElement.lang = STATE.lang;
   document.documentElement.dir = STATE.lang === 'ar' ? 'rtl' : 'ltr';
   populateKaratSelects();
+  populateUnitSelects();
   refreshMobileDockForActiveTab();
   rerenderActiveCalc();
 }
@@ -1740,6 +1802,7 @@ function populateKaratSelects() {
 // ── Init ─────────────────────────────────────────────────────────────────────
 async function init() {
   populateKaratSelects();
+  populateUnitSelects();
   cache.loadState(STATE);
 
   const urlLang = new URLSearchParams(location.search).get('lang');

--- a/src/pages/methodology.js
+++ b/src/pages/methodology.js
@@ -43,6 +43,8 @@ const T = {
     'fx-rates-update-h3': 'Update Frequency',
     'aed-peg-h2': 'The AED Fixed Peg (Special Case)',
     'aed-peg-approach-h3': 'Our Approach',
+    'aed-peg-effect-p':
+      'This means the USD→AED conversion step itself carries no exchange-rate uncertainty — because the peg has held since 1997, the hardcoded value is more reliable than a free-tier API rate for that one step. The AED gold price is still only as fresh and accurate as the XAU/USD spot input it is built on, which is why every AED figure keeps a freshness label and remains a reference estimate, not a guaranteed price.',
     'karat-h2': 'Karat Conversion',
     'karat-formula-h3': 'The Price Formula',
     'not-included-h2': 'What Our Prices Are Not',
@@ -81,6 +83,8 @@ const T = {
     'fx-rates-update-h3': 'معدّل التحديث',
     'aed-peg-h2': 'ربط الدرهم الثابت (حالة خاصة)',
     'aed-peg-approach-h3': 'نهجنا',
+    'aed-peg-effect-p':
+      'هذا يعني أن خطوة التحويل من الدولار إلى الدرهم لا تحمل عدم يقين في سعر الصرف — وبما أن الربط ثابت منذ 1997، فالقيمة المُثبتة في الكود أكثر موثوقية من سعر واجهة برمجية مجانية لتلك الخطوة وحدها. ومع ذلك، يبقى سعر الذهب بالدرهم بقدر حداثة ودقة مدخل XAU/USD الذي يُبنى عليه، ولذلك يحتفظ كل رقم بالدرهم بوسم الحداثة ويبقى تقديراً مرجعياً وليس سعراً مضموناً.',
     'karat-h2': 'تحويل العيار',
     'karat-formula-h3': 'معادلة السعر',
     'not-included-h2': 'ما لا تمثّله أسعارنا',


### PR DESCRIPTION
## Summary

Session-5 (content / tools / conversion) work, split into two lane-pure commits. A read-only audit across content, calculators, charts and shops surfaced 38 in-scope findings; this PR ships the highest-value, lowest-risk subset that I independently re-verified against current code. No price math, freshness logic, SEO `<head>`/schema, or design-system changes.

**Commit A — `content(trust)`: methodology + disclaimer honesty (EN/AR)**
- **Freshness legend:** the prose names six states (`live · delayed · cached · stale · fallback · unavailable`) but the legend defined only five — added the missing **Unavailable** row so every state a user can see is explained.
- **AED peg:** replaced "never changed in **over 27 years** of continuous operation" (a self-rotting count — already ~28.6 yrs) with duration-free phrasing.
- **AED overclaim:** scoped "mathematically exact … more accurate than any API" to the USD→AED conversion step only, restating that the AED price is still a spot-derived reference estimate with a freshness label.
- **`karat.disclaimer`:** appended "Not financial advice." in **EN and AR** to match the footer disclaimer.
- **Making-charge band:** aligned the illustrative `ShopVsReferencePanel` range to **5–25%** (was 8–22%) to match the figure cited in the FAQ.

**Commit B — `content(calculator)`: EN/AR parity + restore dead trust cross-links**
- **Dead cross-links (root cause):** `safe-dom`'s `safeHref()` strips bare-relative hrefs, so anchors built with `el()` rendered with **no href**. This silently killed the calculator's trust-note links (spot-vs-retail, methodology, country), the value-tab "What is a making charge?" link (also wiped by a `textContent=` overwrite on every `applyLang()`), and the `ShopVsReferencePanel` spot-vs-retail link. Fixed by prefixing `./` and rebuilding `#val-disclaimer` instead of overwriting it.
- **Arabic parity:** weight-unit dropdowns and the unit-converter result rows/dock stayed English in Arabic. Added an EN/AR `UNIT_LABELS` map + `populateUnitSelects()` (mirroring `populateKaratSelects`), wired into `applyLang()`/`init()`, and localized the converter placeholder. **Option `value`s are unchanged**, so calculation logic and URL presets are unaffected.
- **Scrap mobile dock:** title showed "Spot Value" over the dealer-payout number — relabeled so title and value match.

## Implementation notes

- Two commits, grouped by lane: `64c7f72` (trust copy) and `d2152a7` (calculator). They are on a single branch per this environment's branch policy; happy to split into two PRs if preferred.
- EN and AR were edited in lockstep on every user-facing string.
- Out of scope / flagged for follow-up sessions (verified but not in this PR): Arabic body copy for the 6 static trust guides + FAQ Q&A + methodology exclusions (large translation effort); the standalone `/chart/` + `karat-page` calling a backend API that doesn't exist on static prod (S1/feature rewire); the dead `/order-gold/` skeleton; calculator empty-input hints (CALC-04) and localized aria-labels (CALC-08).

## Checklist
- [x] `npm test` — **1273/1273 pass**
- [x] `npm run lint` — clean
- [x] `npm run validate` — exit 0 (pre-existing non-fatal `seo-governance` staleness warning, not from this diff)
- [x] `npm run build` — exit 0
- [x] i18n leaked-key scan — 0 leaked keys
- [ ] Playwright smoke — not run this session (static checks only); recommend a live EN/AR spot-check of the calculator before merge

## Gold provider bakeoff checklist

N/A — this PR does not touch gold provider adapters, bakeoff scripts, the X duplicate-post guard, or production gold-price workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hZjwvADkxFUNiXvhSvzQg

---
_Generated by [Claude Code](https://claude.ai/code/session_016hZjwvADkxFUNiXvhSvzQg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy, i18n, and href-prefix fixes only; no pricing, provider, or auth changes. Main regression risk is broken calculator/methodology cross-links if `./` paths are wrong on deploy.
> 
> **Overview**
> Tightens **trust copy** on methodology and shared strings, and fixes **calculator UX** (dead links, EN/AR parity) without changing price math or freshness logic.
> 
> **Methodology & disclaimers:** AED peg wording drops a self-aging “27 years” claim and narrows “exact” language to the USD→AED step while stressing spot-derived limits and freshness labels. The freshness legend adds **Unavailable** so all six documented states are explained. **`karat.disclaimer`** gains “Not financial advice.” in EN and AR.
> 
> **Illustrative shop range:** `ShopVsReferencePanel` making-charge band shifts from **8–22%** to **5–25%**, aligned with calculator copy and FAQ.
> 
> **Calculator:** Trust and guide anchors built via `el()` now use **`./`-prefixed hrefs** so `safeHref()` keeps them (bare-relative URLs were stripped). The value-tab disclaimer is **rebuilt on language apply** so the “What is a making charge?” link survives. **Weight-unit selects** get EN/AR labels via `populateUnitSelects()`; scrap mobile dock title matches dealer payout (`scrap_label_dealer`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2152a76dd90f1c5505e5cc391b9a253b55665eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->