### PR TITLE
fix(ux): RTL mirroring + keyboard focus polish (Session 4)

### DIFF
--- a/styles/market-page.css
+++ b/styles/market-page.css
@@ -312,6 +312,10 @@
   flex-direction: row-reverse;
 }
 
+[dir='rtl'] .mkt-tips-list li::before {
+  content: '←';
+}
+
 /* ═══════════════════════════════════════════════
    Phase 50: Market Page — Premium Visual Polish
    ═══════════════════════════════════════════════ */

--- a/styles/pages/calculator.css
+++ b/styles/pages/calculator.css
@@ -801,7 +801,7 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   flex-shrink: 0;
-  margin-right: 0.25rem;
+  margin-inline-end: 0.25rem;
 }
 
 .calc-preset-chip {

--- a/styles/pages/insights.css
+++ b/styles/pages/insights.css
@@ -594,7 +594,7 @@
 }
 
 .insights-featured-body ul {
-  padding-left: 1.3rem;
+  padding-inline-start: 1.3rem;
   margin-bottom: 0.75rem;
 }
 

--- a/styles/pages/pricing.css
+++ b/styles/pages/pricing.css
@@ -96,6 +96,16 @@
   transform: translateX(24px);
 }
 
+/* RTL: thumb starts on the right and slides left so the switch reads correctly in Arabic */
+[dir='rtl'] .toggle-label input::before {
+  left: auto;
+  right: 2px;
+}
+
+[dir='rtl'] .toggle-label input:checked::before {
+  transform: translateX(-24px);
+}
+
 .toggle-badge {
   background: var(--color-live-bg);
   color: var(--color-live);

--- a/styles/pages/shops.css
+++ b/styles/pages/shops.css
@@ -223,7 +223,6 @@
   background: rgb(176 138 62 / 20%);
   border-color: rgb(176 138 62 / 50%);
   color: #ffd98c;
-  outline: none;
 }
 
 .shops-chip:active {
@@ -2322,7 +2321,7 @@
   color: var(--color-gold-dark);
   font-weight: 500;
   white-space: nowrap;
-  margin-left: 0.5rem;
+  margin-inline-start: 0.5rem;
 }
 
 .nearme-map-links {

--- a/styles/pages/shops.css
+++ b/styles/pages/shops.css
@@ -1100,7 +1100,6 @@
 .shops-clear-btn:focus-visible {
   background: rgb(176 138 62 / 10%);
   border-color: var(--color-gold);
-  outline: none;
 }
 
 .shops-empty-submit {

--- a/styles/partials/price-display.css
+++ b/styles/partials/price-display.css
@@ -139,6 +139,8 @@
   padding: 0.2rem 0.65rem;
   border-radius: var(--radius-pill);
   letter-spacing: 0.01em;
+  direction: ltr;
+  unicode-bidi: isolate;
 }
 
 .price-hero__change--up,

--- a/styles/partials/utilities.css
+++ b/styles/partials/utilities.css
@@ -1844,7 +1844,6 @@ details.nav-drawer-group[open] .nav-drawer-group-caret {
 .nav-search-recent:hover,
 .nav-search-recent:focus-visible {
   background: var(--surface-subtle, rgb(0, 0, 0, 0.04));
-  outline: none;
 }
 .nav-search-result-icon {
   font-size: 1rem;


### PR DESCRIPTION
## Summary

**Session 4 (Frontend / UX / Accessibility / Performance)** — a tight, CSS-only presentation pass. RTL/Arabic mirroring + keyboard-focus visibility. **No** price/freshness logic, SEO markup, body content, or DB/API changes.

**What** — two commits, 7 CSS files:

**Commit 1 — RTL mirroring + first focus fix** (`ba72312`)
1. **`styles/pages/pricing.css`** — RTL billing toggle: the thumb starts on the right and slides left under `[dir='rtl']` (was visually inverted in the Arabic build). *Additive.*
2. **`styles/partials/price-display.css`** — bidi-isolate the shared signed change badge (`.price-hero__change` / `.hlc-change`) with `direction: ltr; unicode-bidi: isolate` so `+` / `−` / `%` keep logical order in RTL (mirrors the `tracker-pro.css` pattern). *LTR-inert.*
3. **`styles/market-page.css`** — mirror the tips-list arrow glyph `→` → `←` under `[dir='rtl']` (the existing rule only reversed flex order). *Additive.*
4. **`styles/pages/insights.css`, `calculator.css`, `shops.css`** — physical `padding-left` / `margin-right` / `margin-left` → logical properties (`padding-inline-start`, `margin-inline-end`, `margin-inline-start`). *Byte-identical in LTR, correct in RTL.*
5. **`styles/pages/shops.css`** — restore the keyboard focus ring on `.shops-chip` (removed a stray `outline: none` that suppressed the global `base.css :focus-visible` outline).

**Commit 2 — complete the focus-ring fix** (`5efa7e9`)
6. **`styles/partials/utilities.css`** — `.nav-search-result` / `.nav-search-recent` (nav search dropdown items) and **`styles/pages/shops.css`** — `.shops-clear-btn` (empty-state clear button): same defect as #5 — `:focus-visible` bundled with `:hover` + `outline: none`, so keyboard focus was indistinguishable from hover. Removing the stray `outline: none` restores the global focus ring on keyboard focus only. Fixing all three instances makes the a11y story consistent (WCAG 2.2 SC 2.4.7).

**Why** — RTL/Arabic parity and WCAG 2.2 AA are core to the trust promise. Every item is a genuine, still-present presentation defect, verified against the **current** code (the repo's `DESIGN_AUDIT.md` is stale).

**How** — smallest correct change; reuse existing tokens/patterns; each fix is scoped to `[dir='rtl']`, a logical-property swap, a bidi property, or the removal of a focus-suppressing `outline: none`, so **LTR rendering is provably unchanged** and `:hover` (which never carried an outline) is unaffected.

## Implementation notes

Findings came from a parallel audit, then **adversarially re-verified** against current files; stale / out-of-scope / risky items were rejected. Notable non-shipped decisions:

- **Dropped — hero price "inverted responsive scale"**: disproven by **browser measurement**. A second base `.hlc-price` rule (`home.css:3471`) overrides the `@media (≤480px)` rule, so the price is already `--text-data-xl` at 390–480px, not `1.7rem`. Computed `font-size` was identical before/after → a no-op.
- **Dropped — two "dark-mode contrast" candidates**: dead/unused selectors (`.home-chart-range-btn.is-active` overridden at `home.css:3519` + dark-handled at `:3436`; `.karat-pill` / `.unit-btn` / `.tab` not rendered on any `components.css` dark page).
- **Deferred (separate perf PR)**: preload self-hosted woff2 subsets on the 21 country-leaf `<head>`s — a real LCP win, but it spans many generated pages / build-injection and sits adjacent to SEO `<head>` markup, so it belongs in its own change.
- **Deferred — kstrip unit-toggle tap target (36px → 44px)**: 36px already meets WCAG 2.2 **AA** (SC 2.5.8 = 24px min; 44px is AAA SC 2.5.5); enlarging risks DS-v4 segmented inconsistency.
- **Flagged to the tracker revamp lane** (`claude/tracker-html-revamp-bpk97i`, owns `styles/pages/tracker-pro.css` — not edited here): freshness status-badge contrast in light theme on the always-dark hero; invisible `--estimated` source-badge border; status-pill width not reserved → CLS on the 90s refresh.

**Proof (VERIFIED, re-run after each commit):**

- `npm test` → **1273 / 1273 pass**; `npm run validate` → pass; `npm run build` → pass; `npm run lint` + stylelint → clean. Baseline was identical → **zero regressions**.
- RTL toggle fix confirmed in a real browser (Chromium, forced `dir=rtl`): thumb sits at the **left** of the pill before, the **right** after.
- The dropped hero-price item was disproven by measuring computed `.hlc-price` `font-size` across 360–480px (identical before/after).

**Risks:** Minimal. Every diff is an additive `[dir='rtl']` rule, an LTR-identical logical-property swap, a bidi-isolation property, or the removal of a focus-suppressing `outline: none`. No JS, no logic, no shared-token edits.

## Checklist
- [x] Dependencies installed (`npm ci`); eslint + stylelint clean
- [x] `npm run build` passes; `npm test` (1273/1273) and `npm run validate` pass (re-run after both commits)
- [ ] Playwright smoke suite (`npm run test:playwright`) — not run: the pinned Playwright browser build isn't present in this environment; verified via direct Chromium screenshot + computed-style measurement instead

## Gold provider bakeoff checklist

N/A — CSS-only PR; does not touch gold provider adapters, bakeoff scripts, the X duplicate-post guard, or production gold-price workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLwL4QBCap1kprJar6wUB6