### PR TITLE
security(ci): pin remaining GitHub Actions to SHAs + document Supabase two-project topology

### DIFF
--- a/.github/workflows/generate-sitemap.yml
+++ b/.github/workflows/generate-sitemap.yml
@@ -23,8 +23,8 @@ jobs:
   sitemap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
       - run: node scripts/generate-sitemap.js

--- a/.github/workflows/record-price-history.yml
+++ b/.github/workflows/record-price-history.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/supabase/PROJECTS.md
+++ b/supabase/PROJECTS.md
@@ -1,0 +1,57 @@
+# Supabase projects — topology & RLS status
+
+> Why this file exists: the codebase talks to **two different Supabase projects**, and the rest of
+> `supabase/` (`schema.sql`, `verify.sql`, migrations `001`–`003`) describes only the first one.
+> This caused real confusion during a security audit, so the split is documented here. Project refs
+> below are already present in the repo (the committed **anon** key embeds one); they are not
+> secrets. **Anon keys are safe to commit — they are gated by RLS. Service-role keys are not and
+> must never be committed.**
+
+## Project A — the site project: `nebdpxjazlnsrfmlpgeq`
+
+- **Used by:** `src/config/supabase.js` and `admin/supabase-config.js`
+  (`SUPABASE_URL = https://nebdpxjazlnsrfmlpgeq.supabase.co` + the public anon key).
+- **How the site talks to it:** browser → PostgREST with the anon key only.
+  `src/lib/supabase-data.js` queries `shop_listings` (`status=eq.active`). That table is **not
+  currently deployed** (REST returns `404 PGRST205`), so `fetchShops()` returns `null` and the page
+  falls back to the curated local `data/shops.js` directory — never a blank page.
+- **Intended schema:** `supabase/schema.sql` (snake_case: `shops`, `shop_submissions`,
+  `shop_listings`, `market_clusters`, `price_history`, `price_alerts`, `orders`,
+  `pricing_overrides`, `user_profiles`, …).
+- **Manual SQL migrations that target THIS project:** `001_price_history.sql`,
+  `002_admin_rls_lockdown.sql`, `003_public_insert_hardening.sql` — all **staged, not applied** (see
+  each file's header). `verify.sql` also targets this project.
+- **RLS status:** **UNVERIFIED from this repo.** This project is not reachable via the Supabase MCP
+  connector wired to this workspace, so its live RLS posture was not confirmed. Owner action: run
+  `verify.sql` / the security advisor against it and apply `002`/`003` if the lints confirm the gaps
+  they describe.
+
+## Project B — the Prisma comparison DB: `lulqcytwhtjdsbzslpiw`
+
+- **Used by:** a **separate, Vercel-integrated, Prisma-managed** app (a price-comparison feature).
+  **No code in this repo reads or writes it** — the PascalCase tables are never referenced by any
+  in-repo PostgREST/SDK call.
+- **Tables (PascalCase, must stay quoted in SQL):** `Store`, `Product`, `Listing`, `PriceHistory`,
+  plus Prisma's `_prisma_migrations`.
+- **RLS status:** **VERIFIED 2026-06-30** via the Supabase security advisor + `pg_catalog`. RLS was
+  **disabled** on all 5 tables and `anon`/`authenticated` held full
+  `SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER` grants — i.e. the public anon key could
+  read, overwrite, delete, and TRUNCATE every row. All 5 tables are owned by `postgres`
+  (`rolbypassrls = true`) and `service_role` also bypasses RLS, so the Prisma server connection is
+  unaffected by enabling RLS.
+- **Fix:** `supabase/migrations/004_prisma_comparison_enable_rls.sql` — enable RLS, `REVOKE`
+  write+TRUNCATE from `anon`/`authenticated` (TRUNCATE is not governed by RLS, so the REVOKE is
+  required), add public read-only `SELECT` policies on the 4 business tables, and deny
+  `anon`/`authenticated` on `_prisma_migrations`. **Staged, not applied** — apply requires owner
+  approval, then re-run the advisor.
+
+## Quick reference
+
+| Aspect          | Project A (`nebdpxjazlnsrfmlpgeq`) | Project B (`lulqcytwhtjdsbzslpiw`)     |
+| --------------- | ---------------------------------- | -------------------------------------- |
+| Role            | Public site + admin                | Prisma price-comparison (separate app) |
+| Naming          | snake_case                         | PascalCase                             |
+| In-repo access  | Yes (anon key, PostgREST)          | None                                   |
+| Schema source   | `supabase/schema.sql`              | Prisma (external repo)                 |
+| Migrations here | `001`–`003` (staged)               | `004` (staged)                         |
+| RLS confirmed?  | No (not reachable from this repo)  | Yes (advisor + `pg_catalog`)           |


### PR DESCRIPTION
## Summary

Session 1 (security) follow-up to #476. Two small, low-risk, independent changes. **No product behavior changes.**

1. **`security(ci)`** — pin the last GitHub Actions still referenced by mutable tag to full commit SHAs (supply-chain hardening). The rest of the repo already SHA-pins; this closes the remaining gap.
2. **`docs(supabase)`** — add `supabase/PROJECTS.md` documenting the **two** Supabase projects the codebase touches (the audit surfaced that `supabase/` only described one).

## Implementation notes

**1. Action pinning — `.github/workflows/generate-sitemap.yml`, `record-price-history.yml`**
- Before: `actions/checkout@v7`, `actions/setup-node@v6`, `actions/setup-python@v6` (mutable tags). A hijacked or force-moved tag would execute attacker code with the workflow's `GITHUB_TOKEN`.
- After: pinned to the exact SHAs already standard elsewhere in the repo — `actions/checkout@9c091bb…` (`# v6`), `actions/setup-node@48b55a0…` (`# v6`), `actions/setup-python@a309ff8…` (`# v6`).
- Grep confirms **no remaining tag-pinned `uses:`** except a commented-out template example in `codeql.yml`. Both edited YAML files parse cleanly (`yaml.safe_load`); the only behavior delta is aligning the two stray `checkout@v7` refs down to the repo-standard `v6` pin. Every workflow already declares a least-privilege `permissions:` block, so no token-scope changes were needed.

**2. `supabase/PROJECTS.md`** — documents:
- **Project A `nebdpxjazlnsrfmlpgeq`** — the site/admin project the committed anon key targets (snake_case schema, migrations `001`–`003`). Its live RLS is **UNVERIFIED** from this repo (not reachable via the workspace's Supabase connector).
- **Project B `lulqcytwhtjdsbzslpiw`** — the separate Vercel/Prisma comparison DB (PascalCase `Store/Product/Listing/PriceHistory`), no in-repo access; RLS gap **verified** and fixed by staged migration `004` (#476).
- Reiterates that anon keys are safe to commit (RLS-gated) while service-role keys are not.

## Checklist
- [x] `git diff` shows only the intended ref swaps (indentation preserved)
- [x] Both edited workflows parse as valid YAML
- [x] No remaining mutable-tag `uses:` refs (except a commented example)
- [x] Markdown is Prettier-formatted (via lint-staged on commit)
- [ ] `npm test` / `npm run build` — **N/A**: changes are CI-workflow pins and a docs file; no app/runtime code touched. GitHub validates the workflow definitions on push.

_Gold-provider-bakeoff checklist omitted — no provider adapters, bakeoff scripts, or gold-price workflows touched._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2fSfXuZsrSkjB72JoQ2Yc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI supply-chain hardening and documentation only; no application or database behavior changes in this PR.
> 
> **Overview**
> Pins the last mutable-tag **GitHub Actions** references in **`generate-sitemap`** and **`record-price-history`** to the same full commit SHAs used elsewhere (`checkout`, `setup-node`, `setup-python`), including aligning stray `checkout@v7` refs to the repo-standard **v6** pin. No workflow permissions or runtime app code change.
> 
> Adds **`supabase/PROJECTS.md`** to document the **two** Supabase projects (site snake_case vs external Prisma PascalCase DB), which migrations target each, RLS verification status, and that staged migration **`004`** addresses the verified Project B gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a62109aa97f5253490218079efb1217358b7d8f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->