### PR TITLE
perf(fonts): preload the LCP latin font subset on country landing pages

### DIFF
--- a/countries/algeria/index.html
+++ b/countries/algeria/index.html
@@ -60,6 +60,7 @@
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/algeria.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#b08a3e" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/bahrain/index.html
+++ b/countries/bahrain/index.html
@@ -58,6 +58,7 @@
     <meta name="twitter:title" content="Gold Price in Bahrain Today — BHD Reference Rates" />
     <meta name="twitter:description" content="Spot-linked reference gold price in Bahrain today — 24K, 22K, 21K and 18K rates in BHD per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/bahrain.png" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/egypt/index.html
+++ b/countries/egypt/index.html
@@ -54,6 +54,7 @@
     <meta name="twitter:title" content="Gold Price in Egypt Today — EGP Reference Rates" />
     <meta name="twitter:description" content="Spot-linked reference gold price in Egypt today — 24K, 22K, 21K and 18K rates in EGP per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/egypt.png" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/india/index.html
+++ b/countries/india/index.html
@@ -54,6 +54,7 @@
     <meta name="twitter:title" content="Gold Price in India Today — INR Reference Rates" />
     <meta name="twitter:description" content="Spot-linked reference gold price in India today — 24K, 22K, 21K and 18K rates in INR per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/india.png" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/iraq/index.html
+++ b/countries/iraq/index.html
@@ -45,6 +45,7 @@
     <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/countries/iraq/?lang=ar" />
     <title>Gold Price in Iraq Today — IQD | Gold Ticker Live</title>
 <link rel="preconnect" href="https://open.er-api.com" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="stylesheet" href="../../styles/pages/country.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />

--- a/countries/jordan/index.html
+++ b/countries/jordan/index.html
@@ -58,6 +58,7 @@
     <meta name="twitter:title" content="Gold Price in Jordan Today — JOD Reference Rates" />
     <meta name="twitter:description" content="Spot-linked reference gold price in Jordan today — 24K, 22K, 21K and 18K rates in JOD per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/jordan.png" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/kuwait/index.html
+++ b/countries/kuwait/index.html
@@ -58,6 +58,7 @@
     <meta name="twitter:title" content="Gold Price in Kuwait Today — KWD Reference Rates" />
     <meta name="twitter:description" content="Spot-linked reference gold price in Kuwait today — 24K, 22K, 21K and 18K rates in KWD per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/kuwait.png" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/lebanon/index.html
+++ b/countries/lebanon/index.html
@@ -60,6 +60,7 @@
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/lebanon.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#b08a3e" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/libya/index.html
+++ b/countries/libya/index.html
@@ -56,6 +56,7 @@
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/libya.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#b08a3e" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/morocco/index.html
+++ b/countries/morocco/index.html
@@ -58,6 +58,7 @@
     <meta name="twitter:title" content="Gold Price in Morocco Today — MAD Reference Rates" />
     <meta name="twitter:description" content="Spot-linked reference gold price in Morocco today — 24K, 22K, 21K and 18K rates in MAD per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/morocco.png" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/oman/index.html
+++ b/countries/oman/index.html
@@ -50,6 +50,7 @@
     <meta name="twitter:title" content="Gold Price in Oman Today — OMR Reference Rates" />
     <meta name="twitter:description" content="Spot-linked reference gold price in Oman today — 24K, 22K, 21K and 18K rates in OMR per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/oman.png" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/pakistan/index.html
+++ b/countries/pakistan/index.html
@@ -45,6 +45,7 @@
     <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/countries/pakistan/?lang=ar" />
     <title>Gold Price in Pakistan Today — PKR | Gold Ticker Live</title>
 <link rel="preconnect" href="https://open.er-api.com" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="stylesheet" href="../../styles/pages/country.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />

--- a/countries/palestine/index.html
+++ b/countries/palestine/index.html
@@ -45,6 +45,7 @@
     <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/countries/palestine/?lang=ar" />
     <title>Gold Price in Palestine Today — ILS | Gold Ticker Live</title>
 <link rel="preconnect" href="https://open.er-api.com" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="stylesheet" href="../../styles/pages/country.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />

--- a/countries/qatar/index.html
+++ b/countries/qatar/index.html
@@ -54,6 +54,7 @@
     <meta name="twitter:title" content="Gold Price in Qatar Today — QAR Reference Rates" />
     <meta name="twitter:description" content="Spot-linked reference gold price in Qatar today — 24K, 22K, 21K and 18K rates in QAR per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/qatar.png" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/saudi-arabia/index.html
+++ b/countries/saudi-arabia/index.html
@@ -58,6 +58,7 @@
     <meta name="twitter:title" content="Gold Price in Saudi Arabia Today — SAR Reference Rates" />
     <meta name="twitter:description" content="Spot-linked reference gold price in Saudi Arabia today — 24K, 22K, 21K and 18K rates in SAR per gram, with freshness labels and methodology." />
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/saudi-arabia.png" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/sudan/index.html
+++ b/countries/sudan/index.html
@@ -56,6 +56,7 @@
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/sudan.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#b08a3e" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/syria/index.html
+++ b/countries/syria/index.html
@@ -45,6 +45,7 @@
     <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/countries/syria/?lang=ar" />
     <title>Gold Price in Syria Today — SYP | Gold Ticker Live</title>
 <link rel="preconnect" href="https://open.er-api.com" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="stylesheet" href="../../styles/pages/country.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />

--- a/countries/tunisia/index.html
+++ b/countries/tunisia/index.html
@@ -60,6 +60,7 @@
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/tunisia.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#b08a3e" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/turkey/index.html
+++ b/countries/turkey/index.html
@@ -45,6 +45,7 @@
     <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/countries/turkey/?lang=ar" />
     <title>Gold Price in Turkey Today — TRY | Gold Ticker Live</title>
 <link rel="preconnect" href="https://open.er-api.com" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="stylesheet" href="../../styles/pages/country.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />

--- a/countries/uae/index.html
+++ b/countries/uae/index.html
@@ -52,6 +52,7 @@
     <meta name="twitter:image" content="https://goldtickerlive.com/assets/og/countries/uae.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#b08a3e" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
 

--- a/countries/yemen/index.html
+++ b/countries/yemen/index.html
@@ -45,6 +45,7 @@
     <link rel="alternate" hreflang="ar" href="https://goldtickerlive.com/countries/yemen/?lang=ar" />
     <title>Gold Price in Yemen Today — YER | Gold Ticker Live</title>
 <link rel="preconnect" href="https://open.er-api.com" />
+<link rel="preload" href="../../assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
 <link rel="stylesheet" href="../../styles/global.css" />
     <link rel="stylesheet" href="../../styles/pages/country.css" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />

--- a/scripts/node/consolidate-country-pages.js
+++ b/scripts/node/consolidate-country-pages.js
@@ -137,6 +137,7 @@ function buildCityGoldRatePage({ country, city, depth }) {
   <link rel="alternate" hreflang="ar" href="${canonical}/?lang=ar" />
   <title>${title}</title>
   <link rel="preconnect" href="https://open.er-api.com" />
+  <link rel="preload" href="${rel}assets/fonts/source-sans-3/source-sans-3-latin.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="stylesheet" href="${rel}styles/global.css" />
   <link rel="icon" href="${rel}favicon.svg" type="image/svg+xml" />
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary

**Session 4 (Performance / CWV) follow-up** to the merged #478. Country landing pages (`/countries/<x>/`) never preloaded the woff2 subset that renders their above-the-fold hero, so the LCP text waited on a font request only discovered *after* `global.css` downloads and parses. The home page already preloads its critical fonts; the 21 country pages did not. This adds the **one measured, actually-used** subset — no cargo-culting.

**What** — 22 files, +22 lines:
- `countries/*/index.html` (21 files) — add `<link rel="preload" ... source-sans-3-latin.woff2 as="font" crossorigin>` immediately before the `global.css` stylesheet link.
- `scripts/node/consolidate-country-pages.js` — the same line in the head template (uses `${rel}`) so future regenerations keep it.

**Why (measurement-driven, not a blind mirror of home):**
Home preloads **two** subsets — `source-sans-3-latin.woff2` *and* `cairo-arabic.woff2`. I measured the real above-the-fold render on `/countries/uae/` in Chromium first:

| Element | Size | Font | Subset |
|---|---|---|---|
| Hero H1 | 28px | Source Sans 3 | latin |
| Price (LCP text) | 44px | Source Sans 3 | latin |
| **Fonts loaded above-the-fold** | | **only Source Sans 3** | **only `source-sans-3-latin.woff2`** |

Cairo is **not loaded at all** on the English static render. So preloading `cairo-arabic.woff2` here (the naive "match home" move) would download an unused font — a perf **regression** plus a "preloaded but not used" console warning. This PR therefore preloads **only** `source-sans-3-latin.woff2`, the subset that actually paints the LCP.

**How** — smallest correct change: one resource-hint line per page, `crossorigin` (required for font preloads even same-origin), `../../` relative path matching the pages' existing `global.css` link. No meta/canonical/hreflang/JSON-LD touched; no CSS/JS/logic changed.

**Proof (VERIFIED):**
- Post-change browser check on `/countries/uae/`: head preloads **only** `source-sans-3-latin.woff2`; it is the **only** woff2 requested above-the-fold; **zero** preload/font console warnings (confirms the preloaded font is used → real optimization, no waste).
- `npm test` → **1273 / 1273 pass**; `npm run validate` → pass (all 390 HTML files scanned, schemas OK); `npm run build` → pass; `eslint` → clean.

**Risks:** Minimal. Additive resource hints only. Worst case a preload is ignored by an old browser (graceful). The Arabic (`?lang=ar`) render — which swaps the hero to Cairo via client hydration after first paint — is unaffected (its font still loads via the existing `@font-face`); a follow-up could add a Cairo preload gated to the AR entry if AR LCP proves font-bound, but that needs its own measurement.

## Implementation notes

- Country leaf heads are heavily post-processed after generation (schema / OG / theme injectors), and `consolidate-country-pages.js` is a manual tool not in the `build` chain — so the committed HTML is the served source of truth. I edited both the 21 committed files (ships now) and the generator template (keeps parity on any future regen).
- Scope intentionally limited to the 21 **country** landing pages named in the audit finding; city / karat pages are a separate, larger surface.

## Checklist
- [x] `eslint` clean; `npm test` (1273/1273) and `npm run validate` pass
- [x] `npm run build` passes
- [x] Change verified in a real browser (preload honored, correct subset, no unused-preload warning)
- [ ] Playwright smoke suite (`npm run test:playwright`) — not run: pinned Playwright browser build absent in this env; verified via direct Chromium measurement instead

## Gold provider bakeoff checklist

N/A — does not touch gold provider adapters, bakeoff scripts, the X duplicate-post guard, or production gold-price workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLwL4QBCap1kprJar6wUB6

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLwL4QBCap1kprJar6wUB6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive HTML resource hints only; no application or data-path changes.
> 
> **Overview**
> Adds a **font preload** for `source-sans-3-latin.woff2` on all **21 country landing pages** (`countries/*/index.html`), placed immediately before the `global.css` link so the hero/LCP text font can start loading before CSS discovers `@font-face`.
> 
> The hint uses `as="font"`, `type="font/woff2"`, and `crossorigin`, with `../../assets/fonts/...` paths matching each page’s existing stylesheet URLs. **Only the latin subset** is preloaded (not Cairo), aligned with above-the-fold English render using Source Sans 3.
> 
> The same line is added to **`scripts/node/consolidate-country-pages.js`** head template (`${rel}assets/fonts/...`) so future regenerations keep the preload. No CSS, JS, or pricing logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 790043689f29198a7c6ae88b022d32b087145431. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->