### PR TITLE
Repo upgrade: site config, error reporting, formatters, SEO tests, docs

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,8 +1,8 @@
 # Gold Ticker Live — Active Task Plan
 
 > This file is the persistent task tracker for AI agents and human contributors. Agents: read this
-> before starting any task. Update it after completing work. Last updated: 2026-06-09 (platform
-> upgrade program + GitHub control center)
+> before starting any task. Update it after completing work. Last updated: 2026-07-03 (repo-upgrade
+> session — docs/tooling/test hardening)
 
 **Master workbook v2 (read first):**
 [`docs/GOLD_TICKER_LIVE_MASTER_WORKBOOK.md`](docs/GOLD_TICKER_LIVE_MASTER_WORKBOOK.md) · appendices
@@ -127,6 +127,17 @@ Canonical plan:
 
 ## ✅ Recently Completed
 
+- [x] **Repo-upgrade session (2026-07-03)** — plan:
+      [`docs/plans/2026-07-03_repo-upgrade-session.md`](docs/plans/2026-07-03_repo-upgrade-session.md).
+      Central site identity `src/config/site.js` (canonical.js now derives `CANONICAL_BASE` from it;
+      drift-guard vs `inject-schema.js` in `tests/site-config.test.js`); site-wide error reporting
+      `src/lib/error-reporter.js` (window `error` + `unhandledrejection` → governed analytics
+      `error` event, deduped/capped, wired via `site-shell.js`); locale-aware formatter additions
+      (`formatNumber`, `formatCurrency`, `formatCompactNumber`, `formatRelativeTime`); first unit
+      tests for runtime SEO modules (`tests/seo-runtime-helpers.test.js`); root `SECURITY.md`
+      policy; `docs/INTEGRATIONS.md` (live/scaffolded/inert map + MCP rules);
+      `docs/environment-variables.md` rewritten (~35 missing vars added; client-side constants
+      correctly reclassified). Verified full green gate: tests 1282+new, lint, validate, build.
 - [x] **X follow banner + brand favicon refresh (2026-07-01)** — Higgsfield-generated homepage
       banner linking to [x.com/GoldTickerLive](https://x.com/GoldTickerLive) at the top of
       `index.html` (EN/AR parity, `assets/social/x-follow-banner-{960,1920}.webp`); site-wide
@@ -246,10 +257,13 @@ Canonical plan:
 
 ### ⚠️ Pre-existing (Not Fixed)
 
-- 44 content pages missing webpage-schema (pre-existing test failures)
-- 3 pre-existing test failures (provider-failover, cache-revalidation, audit-content-pages)
+- 44 content pages missing webpage-schema — **since resolved**: `inject-schema.js --check` passes
+  clean in `npm run validate` (re-verified 2026-07-03)
+- 3 pre-existing test failures (provider-failover, cache-revalidation, audit-content-pages) —
+  **since resolved**: full suite green 1282/1282 (re-verified 2026-07-03)
 - 565 hardcoded hex colors in CSS (large effort — tracked in backlog)
-- `window.confirm()` used in developer.js for destructive actions (acceptable UX)
+- `window.confirm()` used in developer.js for destructive actions — **since resolved** via
+  `<dialog>` modal (see Up Next, 2026-06-30)
 
 ## 🏆 Big Build Catalog Status
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -20,7 +20,9 @@ computation + `getByRole` landmark probe) against the built `dist/` and raw sour
 
 Discovered (out of D1 scope, not a live 404): 69 city pages link `../../../../styles/global.css`
 (one `../` too many); browsers clamp `../` at root so it resolves to `/styles/global.css` in
-production — latent, fix as a follow-up.
+production — latent, fix as a follow-up. **Reconciliation 2026-07-03: fixed** — the depth fix landed
+2026-06-30 (see `PLAN.md` "Multi-task session 2026-06-30"); a fresh sweep of all 336 HTML files
+referencing `global.css` found zero unresolvable stylesheet paths.
 
 - **Branch:** `claude/elegant-cori-lyo379` · **PR:** vctb12/GoldTickerLive#443
 - **Baseline:** 1081 tests passing, 0 failing — held green on every committed phase.

--- a/README.md
+++ b/README.md
@@ -710,6 +710,8 @@ GoldTickerLive/
 | [`docs/LIMITATIONS.md`](docs/LIMITATIONS.md)                     | Technical limitations, bottlenecks, UX/SEO weaknesses                                     |
 | [`docs/ERROR_REPORT.md`](docs/ERROR_REPORT.md)                   | Error audit findings, root causes, and fixes                                              |
 | [`docs/environment-variables.md`](docs/environment-variables.md) | Environment variable reference                                                            |
+| [`docs/INTEGRATIONS.md`](docs/INTEGRATIONS.md)                   | Integrations / connectors / MCP map — live vs scaffolded vs inert                         |
+| [`SECURITY.md`](SECURITY.md)                                     | Security policy — how to report a vulnerability                                           |
 | [`docs/SUPABASE_SETUP.md`](docs/SUPABASE_SETUP.md)               | Supabase migration guide                                                                  |
 | [`docs/SEO_CHECKLIST.md`](docs/SEO_CHECKLIST.md)                 | SEO optimization checklist                                                                |
 | [`docs/AUTOMATIONS.md`](docs/AUTOMATIONS.md)                     | CI/CD workflow documentation                                                              |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+Gold Ticker Live is a bilingual gold-price reference platform. User trust is the product promise —
+security reports are taken seriously.
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for security problems.
+
+- Preferred: use GitHub's private vulnerability reporting — **Security → Report a vulnerability** on
+  the [repository security page](https://github.com/vctb12/GoldTickerLive/security).
+- Include reproduction steps, affected URLs/files, and impact. Reports on the public site
+  (https://goldtickerlive.com/), the Express admin backend, the Supabase integration, or the GitHub
+  Actions automation are all in scope.
+
+You should receive an acknowledgement within a few days. Please allow reasonable time for a fix
+before any public disclosure.
+
+## Scope notes
+
+- The deployed site is static (GitHub Pages); the Supabase **anon** key visible in client code is
+  public by design and gated by Row Level Security. A working RLS bypass, however, **is** a valid
+  finding.
+- Secrets are never committed — production credentials live in GitHub Actions Secrets. Any secret
+  found in the repository history should be reported.
+- The hourly price-fetch and X-posting workflows are production-critical; vulnerabilities in those
+  pipelines are high priority.
+
+## Supporting documentation
+
+| Doc                                                                | Contents                                                                  |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| [`docs/SECURITY.md`](./docs/SECURITY.md)                           | Secret-scanning + push-protection runbook, secrets inventory (names only) |
+| [`docs/SECURITY_NOTES.md`](./docs/SECURITY_NOTES.md)               | CodeQL and DOM-safety notes                                               |
+| [`docs/environment-variables.md`](./docs/environment-variables.md) | Full env-var and secrets registry                                         |
+
+Only the latest deployed version of the site is supported with security fixes.

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -1,0 +1,74 @@
+# Integrations, Connectors & MCP
+
+One map of every external service the platform talks to — what is **live in production**, what is
+**scaffolded** (code exists, surface incomplete), and what is **inert until the owner adds
+credentials**. Status honesty follows the same rules as pricing copy: nothing below claims to be
+live unless it actually is.
+
+Deep audit snapshot (per-feature FE/BE/DB matrix):
+[`audits/INTEGRATION_REALITY_CHECK.md`](./audits/INTEGRATION_REALITY_CHECK.md). Env-var registry:
+[`environment-variables.md`](./environment-variables.md).
+
+## Live in production
+
+| Integration                   | What it does                                                                                                               | Key files / docs                                                                                                                                          |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Gold price providers**      | Hourly XAU/USD fetch through the multi-provider adapter chain (`GOLD_PROVIDER_ORDER`), committed to `data/gold_price.json` | `scripts/python/gold_providers/`, `.github/workflows/gold-price-fetch.yml`, [`gold-price-provider-bakeoff.md`](./gold-price-provider-bakeoff.md)          |
+| **X / Twitter automation**    | Hourly `@GoldTickerLive` posts with duplicate/staleness guards and observability logs                                      | `.github/workflows/post_gold.yml`, [`TWITTER_AUTOMATION.md`](./TWITTER_AUTOMATION.md), [`X_AUTOMATION_OBSERVABILITY.md`](./X_AUTOMATION_OBSERVABILITY.md) |
+| **Supabase (browser)**        | Public reads (anon key + RLS) for prices, shops, settings; admin panel auth                                                | `src/config/supabase.js`, `admin/supabase-config.js`, [`SUPABASE_SETUP.md`](./SUPABASE_SETUP.md), [`SUPABASE_SCHEMA.md`](./SUPABASE_SCHEMA.md)            |
+| **GA4 analytics**             | Governed, PII-stripped event catalog via `gtag` (38 registered events; opt-out + DNT respected)                            | `src/lib/analytics.js`, [`ANALYTICS_EVENTS.md`](./ANALYTICS_EVENTS.md), `npm run analytics:inventory`                                                     |
+| **GitHub Actions**            | CI merge gate, deploy, sitemap, Lighthouse, link check, uptime, spike alerts, newsletters                                  | `.github/workflows/`, [`AUTOMATIONS.md`](./AUTOMATIONS.md), [`workbook/APPENDIX_B_WORKFLOWS_AND_CI.md`](./workbook/APPENDIX_B_WORKFLOWS_AND_CI.md)        |
+| **Telegram / Discord notify** | Optional channel posts from workflows (secrets-gated)                                                                      | `scripts/node/notify-telegram.js`, `scripts/node/notify-discord.js`                                                                                       |
+
+## Scaffolded (code exists, surface incomplete)
+
+| Integration                   | State                                                                                                                                                | Where                                                                          |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| **Supabase analytics mirror** | `track()` can persist events to `analytics_events`, but it is **off** until an anon-insert RLS policy ships (`CONSTANTS.ANALYTICS_SUPABASE_ENABLED`) | `src/lib/analytics.js`, [`ANALYTICS_EVENTS.md`](./ANALYTICS_EVENTS.md)         |
+| **Alerts v1**                 | Backend + email templates done; runs dry-run without Resend creds; UI surface minimal                                                                | [`ALERTS_AND_NOTIFICATIONS.md`](./ALERTS_AND_NOTIFICATIONS.md)                 |
+| **AI content drafts**         | Admin pipeline with human-review gate; editorial UI lightly exercised                                                                                | [`AI_CONTENT_AUTOMATION.md`](./AI_CONTENT_AUTOMATION.md)                       |
+| **Vendor self-serve portal**  | DB + partial API only; no vendor UI or role yet                                                                                                      | [`audits/INTEGRATION_REALITY_CHECK.md`](./audits/INTEGRATION_REALITY_CHECK.md) |
+
+## Inert until owner configures credentials
+
+| Integration                            | Unlock condition                                                                                              | Docs                                                           |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| **Stripe billing**                     | Set `STRIPE_SECRET_KEY` + `STRIPE_PUBLISHABLE_KEY` + `STRIPE_WEBHOOK_SECRET` + price IDs                      | [`BILLING_AND_ENTITLEMENTS.md`](./BILLING_AND_ENTITLEMENTS.md) |
+| **Resend email** (newsletter + alerts) | Set `RESEND_API_KEY` + `RESEND_FROM_EMAIL`; until then everything is dry-run/log-only                         | [`NEWSLETTER_AND_LEADS.md`](./NEWSLETTER_AND_LEADS.md)         |
+| **Supabase persistence (server)**      | Set `SUPABASE_SERVICE_ROLE_KEY` + `STORAGE_BACKEND=supabase`; falls back to JSON files otherwise              | [`SUPABASE_SETUP.md`](./SUPABASE_SETUP.md)                     |
+| **AdSense**                            | Set `AD_CONFIG.ADSENSE_PUBLISHER_ID` in `src/config/constants.js` (currently empty — no ad requests are made) | `src/config/constants.js`                                      |
+
+## MCP (Model Context Protocol)
+
+MCP lets agent tooling (Cursor, VS Code Copilot, Claude Code) reach services like Supabase and
+GitHub through configured servers.
+
+| File                       | Purpose                                                                                                                                | Committed?                        |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `.cursor/mcp.json`         | Cursor MCP config — Supabase http (read-only, `<SUPABASE_PROJECT_REF>` placeholder) + stdio (`${SUPABASE_ACCESS_TOKEN}` env reference) | Yes (placeholders only)           |
+| `.vscode/mcp.example.json` | Template for a local `.vscode/mcp.json`                                                                                                | Yes                               |
+| `.vscode/mcp.json`         | Your real local config                                                                                                                 | **No — gitignored, never commit** |
+
+Rules (also in [`SECURITY.md`](./SECURITY.md) at the repo root and
+[`environment-variables.md`](./environment-variables.md)):
+
+1. Never hardcode PATs, service-role keys, or project refs with embedded credentials in MCP config.
+2. Use env-var references (`${SUPABASE_ACCESS_TOKEN}`) or OAuth flows.
+3. Prefer read-only MCP endpoints for exploration; write access only when a task requires it.
+4. Claude Code sessions in this repo additionally get GitHub access through the built-in GitHub MCP
+   server — no repo config needed.
+
+## Adding a new integration — checklist
+
+1. **Advisory check first** — no new dependency without an explicit ask + a GitHub advisory-database
+   check (see `AGENTS.md` operational guardrails).
+2. **Secrets**: names go in `.env.example` (placeholder only) and the tables in
+   [`environment-variables.md`](./environment-variables.md); values go in GitHub Secrets.
+3. **Fail safe**: default to dry-run/disabled when credentials are missing (pattern: Resend, Stripe,
+   analytics mirror). Never let a missing key break a page or a workflow.
+4. **Label honestly**: any data surfaced to users must carry source + freshness labels per
+   [`freshness-contract.md`](./freshness-contract.md).
+5. **Document**: add a row to the appropriate table above and, for provider/data integrations, an
+   adapter entry in `scripts/python/gold_providers/registry.py` rather than a one-off fetcher.
+6. **Server boundaries**: browser code must never import `server/**` (ESLint enforces this), and
+   service-role keys never ship client-side.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,63 +7,67 @@ holds the master plan plus human-facing reference docs.
 
 **Session routing (read first):**
 [`plans/2026-06-01_master-operations-hub.md`](./plans/2026-06-01_master-operations-hub.md) ·
-[`PLAN.md`](../PLAN.md) · [`plans/ARCHIVE_AND_SUPERSESSION_INDEX.md`](./plans/ARCHIVE_AND_SUPERSESSION_INDEX.md)
+[`PLAN.md`](../PLAN.md) ·
+[`plans/ARCHIVE_AND_SUPERSESSION_INDEX.md`](./plans/ARCHIVE_AND_SUPERSESSION_INDEX.md)
 
-| File                                               | Role                                                                              |
-| -------------------------------------------------- | --------------------------------------------------------------------------------- |
-| [`GOLD_TICKER_LIVE_MASTER_WORKBOOK.md`](./GOLD_TICKER_LIVE_MASTER_WORKBOOK.md) | **Start here** — workbook v2: vision, 25 gaps, 50+ sessions, 16 scanners, 90-day map. |
-| [`workbook/`](./workbook/) | **Deep appendices** A–G: surfaces, CI, API map, execution guides, tests, secrets, SEO. |
-| [`workbook/WORKBOOK_SESSION_REGISTRY.md`](./workbook/WORKBOOK_SESSION_REGISTRY.md) | Workbook session branch ↔ PR tracker + priority queue. |
-| [`plans/2026-06-01_master-operations-hub.md`](./plans/2026-06-01_master-operations-hub.md) | **One-screen routing** — priority queue, what shipped, endless prompts index. |
-| [`REVAMP_PLAN.md`](./REVAMP_PLAN.md)               | Master plan — tracks in progress, decisions, production tracks, issues, backlog.  |
-| [`plans/README.md`](./plans/README.md)             | Proposal intake + priority matrix. New plans follow `plans/YYYY-MM-DD_<slug>.md`. |
-| [`plans/ARCHIVE_AND_SUPERSESSION_INDEX.md`](./plans/ARCHIVE_AND_SUPERSESSION_INDEX.md) | Which docs are authoritative vs archived. |
-| [`plans/`](./plans/)                               | Active proposal captures (landed sessions → stubs pointing to archive).           |
-| [`archive/2026-06/`](./archive/2026-06/)           | Landed May 2026 session plans (C1a, 2026-06-01).                                  |
-| [`AGENT_REFRESH_PLAN.md`](./AGENT_REFRESH_PLAN.md) | Historical record of the 2026-04 agent-instruction refresh.                       |
+| File                                                                                       | Role                                                                                   |
+| ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| [`GOLD_TICKER_LIVE_MASTER_WORKBOOK.md`](./GOLD_TICKER_LIVE_MASTER_WORKBOOK.md)             | **Start here** — workbook v2: vision, 25 gaps, 50+ sessions, 16 scanners, 90-day map.  |
+| [`workbook/`](./workbook/)                                                                 | **Deep appendices** A–G: surfaces, CI, API map, execution guides, tests, secrets, SEO. |
+| [`workbook/WORKBOOK_SESSION_REGISTRY.md`](./workbook/WORKBOOK_SESSION_REGISTRY.md)         | Workbook session branch ↔ PR tracker + priority queue.                                 |
+| [`plans/2026-06-01_master-operations-hub.md`](./plans/2026-06-01_master-operations-hub.md) | **One-screen routing** — priority queue, what shipped, endless prompts index.          |
+| [`REVAMP_PLAN.md`](./REVAMP_PLAN.md)                                                       | Master plan — tracks in progress, decisions, production tracks, issues, backlog.       |
+| [`plans/README.md`](./plans/README.md)                                                     | Proposal intake + priority matrix. New plans follow `plans/YYYY-MM-DD_<slug>.md`.      |
+| [`plans/ARCHIVE_AND_SUPERSESSION_INDEX.md`](./plans/ARCHIVE_AND_SUPERSESSION_INDEX.md)     | Which docs are authoritative vs archived.                                              |
+| [`plans/`](./plans/)                                                                       | Active proposal captures (landed sessions → stubs pointing to archive).                |
+| [`archive/2026-06/`](./archive/2026-06/)                                                   | Landed May 2026 session plans (C1a, 2026-06-01).                                       |
+| [`AGENT_REFRESH_PLAN.md`](./AGENT_REFRESH_PLAN.md)                                         | Historical record of the 2026-04 agent-instruction refresh.                            |
 
 ## Reference docs
 
 Stable knowledge base. These are referenced from the master plan but have their own lifecycle.
 
-| File                                                           | Role                                                     |
-| -------------------------------------------------------------- | -------------------------------------------------------- |
-| [`ARCHITECTURE.md`](./ARCHITECTURE.md)                         | System / data-flow overview.                             |
-| [`DESIGN_TOKENS.md`](./DESIGN_TOKENS.md)                       | Canonical CSS custom-property catalog.                   |
-| [`ACCESSIBILITY.md`](./ACCESSIBILITY.md)                       | WCAG 2.1 AA patterns used in the codebase.               |
-| [`PERFORMANCE.md`](./PERFORMANCE.md)                           | Perf budgets, critical-CSS strategy, image / font rules. |
-| [`SEO_STRATEGY.md`](./SEO_STRATEGY.md)                         | Long-form SEO strategy.                                  |
-| [`SEO_CHECKLIST.md`](./SEO_CHECKLIST.md)                       | Per-release SEO checklist.                               |
-| [`SEO_SITEMAP_GUIDE.md`](./SEO_SITEMAP_GUIDE.md)               | Sitemap authoring guide.                                 |
-| [`DEPENDENCIES.md`](./DEPENDENCIES.md)                         | Runtime + devDep version matrix.                         |
-| [`FILES_GUIDE.md`](./FILES_GUIDE.md)                           | Repository file tour.                                    |
-| [`EDIT_GUIDE.md`](./EDIT_GUIDE.md)                             | How to add a country / city / shop / page.               |
-| [`CONTRIBUTING.md`](./CONTRIBUTING.md)                         | Branching, PR discipline, conventions.                   |
-| [`ADMIN_GUIDE.md`](./ADMIN_GUIDE.md)                           | Admin panel usage.                                       |
-| [`ADMIN_SETUP.md`](./ADMIN_SETUP.md)                           | Admin Supabase setup.                                    |
-| [`SUPABASE_SETUP.md`](./SUPABASE_SETUP.md)                     | Supabase project setup.                                  |
-| [`SUPABASE_SCHEMA.md`](./SUPABASE_SCHEMA.md)                   | Database schema reference.                               |
-| [`ALERTS_AND_NOTIFICATIONS.md`](./ALERTS_AND_NOTIFICATIONS.md) | Alerts lifecycle, channels, and operations guide.        |
-| [`AUTOMATIONS.md`](./AUTOMATIONS.md)                           | GitHub Actions & scheduled bots.                         |
-| [`MASTER_IMPROVEMENT_PROGRAM.md`](./MASTER_IMPROVEMENT_PROGRAM.md) | **Phased improvements** — UI/UX, automations, SEO, prompts. |
-| [`CURSOR_AUTOMATIONS_PLAYBOOK.md`](./CURSOR_AUTOMATIONS_PLAYBOOK.md) | Cursor Cloud Automations — setup guide.                  |
-| [`CURSOR_AUTOMATIONS_REGISTRY.md`](./CURSOR_AUTOMATIONS_REGISTRY.md) | Live automation config + tuning log (owner-maintained).  |
-| [`AI_CONTENT_AUTOMATION.md`](./AI_CONTENT_AUTOMATION.md)       | Admin AI draft pipeline (human review required).         |
-| [`AI_AGENT_OPERATING_SYSTEM.md`](./AI_AGENT_OPERATING_SYSTEM.md) | AI-agent index (skills, prompts, agents).              |
-| [`CURSOR_HANDOVER.md`](./CURSOR_HANDOVER.md)                   | Cursor onboarding reference.                             |
-| [`TWITTER_AUTOMATION.md`](./TWITTER_AUTOMATION.md)             | Social-posting architecture.                             |
-| [`twitter_bot_architecture.md`](./twitter_bot_architecture.md) | Twitter bot runtime architecture.                        |
-| [`twitter_bot_schema.md`](./twitter_bot_schema.md)             | Twitter bot DB schema.                                   |
-| [`twitter_bot_secrets.md`](./twitter_bot_secrets.md)           | Twitter bot secrets inventory.                           |
-| [`MANUAL_INPUTS.md`](./MANUAL_INPUTS.md)                       | Human inputs required per release.                       |
-| [`TEARDOWN.md`](./TEARDOWN.md)                                 | Full-site teardown / decommission playbook.              |
-| [`environment-variables.md`](./environment-variables.md)       | Env-var inventory (server + CI + workflows).             |
-| [`tracker-state.md`](./tracker-state.md)                       | Tracker URL-hash schema.                                 |
-| [`performance-baseline.json`](./performance-baseline.json)     | Perf baseline snapshot.                                  |
-| [`replit.md`](./replit.md)                                     | Replit setup (legacy).                                   |
-| [`ERROR_REPORT.md`](./ERROR_REPORT.md)                         | Known-error inventory (historical).                      |
-| [`LIMITATIONS.md`](./LIMITATIONS.md)                           | Current technical limitations.                           |
-| [`CHANGELOG.md`](./CHANGELOG.md)                               | Changelog.                                               |
+| File                                                                 | Role                                                                                       |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [`ARCHITECTURE.md`](./ARCHITECTURE.md)                               | System / data-flow overview.                                                               |
+| [`DESIGN_TOKENS.md`](./DESIGN_TOKENS.md)                             | Canonical CSS custom-property catalog.                                                     |
+| [`ACCESSIBILITY.md`](./ACCESSIBILITY.md)                             | WCAG 2.1 AA patterns used in the codebase.                                                 |
+| [`PERFORMANCE.md`](./PERFORMANCE.md)                                 | Perf budgets, critical-CSS strategy, image / font rules.                                   |
+| [`SEO_STRATEGY.md`](./SEO_STRATEGY.md)                               | Long-form SEO strategy.                                                                    |
+| [`SEO_CHECKLIST.md`](./SEO_CHECKLIST.md)                             | Per-release SEO checklist.                                                                 |
+| [`SEO_SITEMAP_GUIDE.md`](./SEO_SITEMAP_GUIDE.md)                     | Sitemap authoring guide.                                                                   |
+| [`DEPENDENCIES.md`](./DEPENDENCIES.md)                               | Runtime + devDep version matrix.                                                           |
+| [`FILES_GUIDE.md`](./FILES_GUIDE.md)                                 | Repository file tour.                                                                      |
+| [`EDIT_GUIDE.md`](./EDIT_GUIDE.md)                                   | How to add a country / city / shop / page.                                                 |
+| [`CONTRIBUTING.md`](./CONTRIBUTING.md)                               | Branching, PR discipline, conventions.                                                     |
+| [`ADMIN_GUIDE.md`](./ADMIN_GUIDE.md)                                 | Admin panel usage.                                                                         |
+| [`ADMIN_SETUP.md`](./ADMIN_SETUP.md)                                 | Admin Supabase setup.                                                                      |
+| [`SUPABASE_SETUP.md`](./SUPABASE_SETUP.md)                           | Supabase project setup.                                                                    |
+| [`SUPABASE_SCHEMA.md`](./SUPABASE_SCHEMA.md)                         | Database schema reference.                                                                 |
+| [`ALERTS_AND_NOTIFICATIONS.md`](./ALERTS_AND_NOTIFICATIONS.md)       | Alerts lifecycle, channels, and operations guide.                                          |
+| [`AUTOMATIONS.md`](./AUTOMATIONS.md)                                 | GitHub Actions & scheduled bots.                                                           |
+| [`MASTER_IMPROVEMENT_PROGRAM.md`](./MASTER_IMPROVEMENT_PROGRAM.md)   | **Phased improvements** — UI/UX, automations, SEO, prompts.                                |
+| [`CURSOR_AUTOMATIONS_PLAYBOOK.md`](./CURSOR_AUTOMATIONS_PLAYBOOK.md) | Cursor Cloud Automations — setup guide.                                                    |
+| [`CURSOR_AUTOMATIONS_REGISTRY.md`](./CURSOR_AUTOMATIONS_REGISTRY.md) | Live automation config + tuning log (owner-maintained).                                    |
+| [`AI_CONTENT_AUTOMATION.md`](./AI_CONTENT_AUTOMATION.md)             | Admin AI draft pipeline (human review required).                                           |
+| [`AI_AGENT_OPERATING_SYSTEM.md`](./AI_AGENT_OPERATING_SYSTEM.md)     | AI-agent index (skills, prompts, agents).                                                  |
+| [`CURSOR_HANDOVER.md`](./CURSOR_HANDOVER.md)                         | Cursor onboarding reference.                                                               |
+| [`TWITTER_AUTOMATION.md`](./TWITTER_AUTOMATION.md)                   | Social-posting architecture.                                                               |
+| [`twitter_bot_architecture.md`](./twitter_bot_architecture.md)       | Twitter bot runtime architecture.                                                          |
+| [`twitter_bot_schema.md`](./twitter_bot_schema.md)                   | Twitter bot DB schema.                                                                     |
+| [`twitter_bot_secrets.md`](./twitter_bot_secrets.md)                 | Twitter bot secrets inventory.                                                             |
+| [`MANUAL_INPUTS.md`](./MANUAL_INPUTS.md)                             | Human inputs required per release.                                                         |
+| [`TEARDOWN.md`](./TEARDOWN.md)                                       | Full-site teardown / decommission playbook.                                                |
+| [`environment-variables.md`](./environment-variables.md)             | Env-var inventory (server + pipeline + CI + workflows).                                    |
+| [`INTEGRATIONS.md`](./INTEGRATIONS.md)                               | Integrations / connectors / MCP map — live vs scaffolded vs inert.                         |
+| [`SECURITY.md`](./SECURITY.md)                                       | Secret-scanning + push-protection runbook (report vulnerabilities via root `SECURITY.md`). |
+| [`SECURITY_NOTES.md`](./SECURITY_NOTES.md)                           | CodeQL and DOM-safety notes.                                                               |
+| [`tracker-state.md`](./tracker-state.md)                             | Tracker URL-hash schema.                                                                   |
+| [`performance-baseline.json`](./performance-baseline.json)           | Perf baseline snapshot.                                                                    |
+| [`replit.md`](./replit.md)                                           | Replit setup (legacy).                                                                     |
+| [`ERROR_REPORT.md`](./ERROR_REPORT.md)                               | Known-error inventory (historical).                                                        |
+| [`LIMITATIONS.md`](./LIMITATIONS.md)                                 | Current technical limitations.                                                             |
+| [`CHANGELOG.md`](./CHANGELOG.md)                                     | Changelog.                                                                                 |
 
 ## Note on consolidation
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,36 +1,31 @@
 # Environment Variables
 
-## Required Variables
+Complete inventory of environment variables across the Express server, the Python data/automation
+pipeline, build/QA scripts, and GitHub Actions. The committed template is
+[`.env.example`](../.env.example); copy it to `.env` (gitignored) for local work. Production values
+live in GitHub Secrets only.
 
-| Variable             | Required | Description                                       | Example                         |
-| -------------------- | -------- | ------------------------------------------------- | ------------------------------- |
-| `SUPABASE_URL`       | Yes      | Supabase project URL                              | `https://xxxxx.supabase.co`     |
-| `SUPABASE_ANON_KEY`  | Yes      | Supabase anonymous/public API key                 | `eyJhbGciOi...`                 |
-| `ALLOWED_EMAIL`      | Yes      | Admin email whitelist for GitHub OAuth            | `admin@example.com`             |
-| `GOLD_API_COM_KEY`   | Yes (CI) | gold-api.com API key for live XAU/USD spot prices | `[from gold-api.com dashboard]` |
-| `GOLDPRICEZ_API_KEY` | No       | Legacy goldpricez.com adapter key (optional)      | `[legacy fallback only]`        |
+> **Client-side code never reads env vars.** The deployed site is static (GitHub Pages); browser
+> config lives in committed constants — see
+> [Client-side config constants](#client-side-config-constants-not-env-vars) below.
 
-## Optional Variables (Express Server / Self-Hosted)
+## Express server / self-hosted
 
-| Variable                    | Required    | Description                                        | Example                       |
-| --------------------------- | ----------- | -------------------------------------------------- | ----------------------------- |
-| `JWT_SECRET`                | Server/test | Secret for signing JWT admin tokens (32+ chars)    | `[random 64-char hex string]` |
-| `ADMIN_PASSWORD`            | Server/test | Admin panel password (bcrypt-hashed at startup)    | `[strong password]`           |
-| `ADMIN_ACCESS_PIN`          | Server/test | 6+ digit numeric PIN gating the admin login        | `123456`                      |
-| `API_KEY_HASH_SALT`         | API/server  | Dedicated salt for PBKDF2 API key hashing          | `[random long string]`        |
-| `API_KEY_HASH_ITERATIONS`   | API/server  | PBKDF2 iteration count for API key hashing         | `210000`                      |
-| `SUPABASE_SERVICE_ROLE_KEY` | Server/CI   | Supabase service-role key (bypasses RLS)           | `eyJhbGciOi...`               |
-| `STORAGE_BACKEND`           | No          | `file` (default) or `supabase`                     | `supabase`                    |
-| `GA4_MEASUREMENT_ID`        | No          | Google Analytics 4 measurement ID                  | `G-XXXXXXXXXX`                |
-| `ADSENSE_CLIENT_ID`         | No          | Google AdSense publisher ID                        | `ca-pub-1234567890`           |
-| `CORS_ORIGINS`              | No          | Allowed CORS origins (comma-separated)             | `https://example.com`         |
-| `NODE_ENV`                  | No          | Environment mode                                   | `production`                  |
-| `PORT`                      | No          | Server port (default: 3000)                        | `3000`                        |
-| `ALERT_EMAIL_DRY_RUN`       | No          | Force alert emails into log-only dry-run mode      | `true`                        |
-| `ALERTS_EXPOSE_DEV_TOKENS`  | No          | Expose dev verification token in non-prod only     | `true`                        |
-| `ALERT_JOB_TOKEN`           | No          | Shared secret for `POST /api/v1/jobs/check-alerts` | `[random long token]`         |
-| `ALERTS_DATA_FILE`          | No          | Override alert file-storage path (dev/test)        | `/tmp/alerts-v1.json`         |
-| `ALERTS_PRICE_FILE`         | No          | Override snapshot JSON used by alert checks        | `/tmp/gold_price.json`        |
+| Variable                    | Required    | Description                                                              | Example                       |
+| --------------------------- | ----------- | ------------------------------------------------------------------------ | ----------------------------- |
+| `JWT_SECRET`                | Server/test | Secret for signing JWT admin tokens (32+ chars)                          | `[random 64-char hex string]` |
+| `ADMIN_PASSWORD`            | Server/test | Admin panel password (bcrypt-hashed at startup)                          | `[strong password]`           |
+| `ADMIN_ACCESS_PIN`          | Server/test | 6+ digit numeric PIN gating the admin login                              | `123456`                      |
+| `API_KEY_HASH_SALT`         | API/server  | Dedicated salt for PBKDF2 API key hashing                                | `[random long string]`        |
+| `API_KEY_HASH_ITERATIONS`   | API/server  | PBKDF2 iteration count for API key hashing                               | `210000`                      |
+| `SUPABASE_URL`              | Supabase    | Supabase project URL                                                     | `https://xxxxx.supabase.co`   |
+| `SUPABASE_ANON_KEY`         | Supabase    | Supabase anonymous/public API key                                        | `eyJhbGciOi...`               |
+| `SUPABASE_SERVICE_ROLE_KEY` | Server/CI   | Supabase service-role key (bypasses RLS)                                 | `eyJhbGciOi...`               |
+| `STORAGE_BACKEND`           | No          | `file` (default) or `supabase`                                           | `supabase`                    |
+| `SITE_URL`                  | No          | Public origin used for Stripe redirects, newsletter links, uptime checks | `https://goldtickerlive.com`  |
+| `CORS_ORIGINS`              | No          | Allowed CORS origins (comma-separated)                                   | `https://example.com`         |
+| `NODE_ENV`                  | No          | Environment mode                                                         | `production`                  |
+| `PORT`                      | No          | Server port (default: 3000)                                              | `3000`                        |
 
 > **Note.** `JWT_SECRET`, `ADMIN_PASSWORD`, and `ADMIN_ACCESS_PIN` are **required at module load**
 > by `server/lib/auth.js` — without them the server throws at startup and `npm test` fails
@@ -39,6 +34,81 @@
 >
 > `API_KEY_HASH_SALT` is a separate required secret for API key create/resolve flows and should not
 > reuse `JWT_SECRET`.
+
+### Newsletter, leads & alerts (Express)
+
+| Variable                   | Required | Description                                                                  | Example                 |
+| -------------------------- | -------- | ---------------------------------------------------------------------------- | ----------------------- |
+| `RESEND_API_KEY`           | No       | Resend API key — enables real email sending                                  | `re_...`                |
+| `RESEND_FROM_EMAIL`        | No       | Verified sender address (configure with the key)                             | `alerts@example.com`    |
+| `NEWSLETTER_DRY_RUN`       | No       | `true` logs emails instead of sending (default when Resend vars are missing) | `true`                  |
+| `NEWSLETTER_DATA_FILE`     | No       | Override newsletter subscriber storage path                                  | `/tmp/subscribers.json` |
+| `LEADS_DATA_FILE`          | No       | Override leads storage path                                                  | `/tmp/leads.json`       |
+| `ALERT_EMAIL_DRY_RUN`      | No       | Force alert emails into log-only dry-run mode                                | `true`                  |
+| `ALERTS_EXPOSE_DEV_TOKENS` | No       | Expose dev verification token in non-prod only                               | `true`                  |
+| `ALERT_JOB_TOKEN`          | No       | Shared secret for `POST /api/v1/jobs/check-alerts`                           | `[random long token]`   |
+| `ALERTS_DATA_FILE`         | No       | Override alert file-storage path (dev/test)                                  | `/tmp/alerts-v1.json`   |
+| `ALERTS_PRICE_FILE`        | No       | Override snapshot JSON used by alert checks                                  | `/tmp/gold_price.json`  |
+
+### Stripe billing (Express — inert until configured)
+
+Configure the first three together; billing endpoints stay disabled while any are missing. Use test
+keys from the Stripe dashboard during development.
+
+| Variable                   | Description                                            |
+| -------------------------- | ------------------------------------------------------ |
+| `STRIPE_PUBLISHABLE_KEY`   | Publishable key (`pk_test_…` / `pk_live_…`)            |
+| `STRIPE_SECRET_KEY`        | Secret key (`sk_test_…` / `sk_live_…`)                 |
+| `STRIPE_WEBHOOK_SECRET`    | Webhook signing secret (`whsec_…`)                     |
+| `STRIPE_PRICE_PRO_MONTHLY` | Price ID for the Pro monthly plan                      |
+| `STRIPE_PRICE_API_MONTHLY` | Price ID for the API monthly plan                      |
+| `STRIPE_PRICE_PRO_YEARLY`  | Price ID for Pro yearly (legacy alias: `…_PRO_ANNUAL`) |
+| `STRIPE_PRICE_API_YEARLY`  | Price ID for API yearly (legacy alias: `…_API_ANNUAL`) |
+| `STRIPE_TRIAL_DAYS`        | Free-trial days (default `7`; `0` disables trials)     |
+
+## Python data pipeline / provider adapters
+
+Used by `scripts/python/` fetchers, the provider bakeoff, and the X-post workflow. Provider names
+for `GOLD_PROVIDER_ORDER` come from `scripts/python/gold_providers/registry.py`.
+
+| Variable                      | Description                                                       | Default            |
+| ----------------------------- | ----------------------------------------------------------------- | ------------------ |
+| `GOLD_PROVIDER_ORDER`         | Comma-separated provider names tried in order                     | see `.env.example` |
+| `AED_PEG`                     | USD→AED peg used for conversions                                  | `3.6725`           |
+| `MAX_GOLD_FRESHNESS_SECONDS`  | Max quote age before it counts as stale                           | `900`              |
+| `MIN_VALID_XAU_USD`           | Sanity floor for XAU/USD quotes                                   | `500`              |
+| `MAX_VALID_XAU_USD`           | Sanity ceiling for XAU/USD quotes                                 | `10000`            |
+| `HTTP_TIMEOUT_SECONDS`        | Per-request provider timeout                                      | `10`               |
+| `HTTP_RETRIES`                | Retries per provider request                                      | `1`                |
+| `SOFT_FAIL_ON_NO_FRESH_PRICE` | Exit 0 (skip) instead of failing when no fresh price is available | `true`             |
+| `ALLOW_STALE_PRICE`           | Permit stale price to pass through (use with care)                | `false`            |
+| `BAKEOFF_LOG_RAW`             | Capture full raw provider responses (verbose; never in prod)      | `false`            |
+
+### Per-provider adapter credentials
+
+Each adapter has an `…_ENABLED` toggle plus its key/host settings:
+
+| Provider                | Variables                                                                                                                              |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Metal Sentinel          | `METAL_SENTINEL_ENABLED`, `METAL_SENTINEL_API_KEY`, `METAL_SENTINEL_API_HOST`, `METAL_SENTINEL_AUTH_HEADER`, `METAL_SENTINEL_ENDPOINT` |
+| Finnhub (OANDA XAU/USD) | `FINNHUB_ENABLED`, `FINNHUB_API_KEY`, `FINNHUB_SYMBOL`                                                                                 |
+| Financial Modeling Prep | `FMP_ENABLED`, `FMP_API_KEY`, `FMP_SYMBOL`                                                                                             |
+| GoldAPI.io              | `GOLDAPI_IO_ENABLED`, `GOLDAPI_IO_KEY`                                                                                                 |
+| Twelve Data             | `TWELVEDATA_ENABLED`, `TWELVEDATA_API_KEY`, `TWELVEDATA_SYMBOL`                                                                        |
+| GoldPriceZ (legacy)     | `GOLDPRICEZ_ENABLED`, `GOLDPRICEZ_API_KEY`                                                                                             |
+| gold-api.com (legacy)   | `GOLD_API_COM_ENABLED`, `GOLD_API_COM_KEY`                                                                                             |
+
+### X / Twitter posting knobs
+
+| Variable                                                                                          | Description                                                                      | Default |
+| ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------- |
+| `TWITTER_API_KEY` / `TWITTER_API_SECRET` / `TWITTER_ACCESS_TOKEN` / `TWITTER_ACCESS_TOKEN_SECRET` | OAuth 1.0a credentials (local names; see the secrets table for the GitHub names) | —       |
+| `SKIP_DUPLICATE_TWEETS`                                                                           | Skip posting when content matches the last tweet                                 | `true`  |
+| `ALLOW_STALE_TWEET`                                                                               | Permit posting from a stale snapshot                                             | `false` |
+| `DRY_RUN_TWEET`                                                                                   | Compose but do not post                                                          | `false` |
+| `MIN_TWEET_MOVE_USD`                                                                              | Minimum absolute move to justify a price tweet                                   | `1.00`  |
+| `MIN_TWEET_MOVE_PCT`                                                                              | Minimum percentage move to justify a price tweet                                 | `0.03`  |
+| `FORCE_SUMMARY_AFTER_MINUTES`                                                                     | Post a summary anyway after this many quiet minutes                              | `60`    |
 
 ### Reverse-proxy / `trust proxy`
 
@@ -76,9 +146,22 @@ These are configured as repository secrets in GitHub (Settings → Secrets → A
 > **Note**: Twitter workflow files map these secrets to `TWITTER_API_KEY`, `TWITTER_API_SECRET`,
 > etc. env vars internally. The GitHub secret names do NOT have a `TWITTER_` prefix.
 
+## Client-side config constants (not env vars)
+
+Earlier revisions of this doc listed some of these as env vars — they are **committed constants**
+read by the browser, because GitHub Pages serves static files with no env at runtime:
+
+| Constant                             | Where it lives                                       | Notes                                                          |
+| ------------------------------------ | ---------------------------------------------------- | -------------------------------------------------------------- |
+| `SUPABASE_URL` / `SUPABASE_ANON_KEY` | `src/config/supabase.js`, `admin/supabase-config.js` | Anon key is designed to be public; RLS protects the data.      |
+| `ALLOWED_EMAIL`                      | `admin/supabase-config.js`                           | Client-side hint only — real authorization is Supabase RLS.    |
+| `ADSENSE_PUBLISHER_ID`               | `src/config/constants.js` (`AD_CONFIG`)              | Empty until AdSense is activated.                              |
+| GA4 measurement ID                   | gtag snippet in page shells                          | Public by nature.                                              |
+| Site identity (name/URL/description) | `src/config/site.js`                                 | Single source for runtime SEO helpers; drift-guarded in tests. |
+
 ## .env.example
 
-See [`.env.example`](../.env.example) in the repo root for a complete template.
+See [`.env.example`](../.env.example) in the repo root for the committed template.
 
 ## Local MCP config (`.vscode/mcp.json`)
 
@@ -92,6 +175,7 @@ See [`.env.example`](../.env.example) in the repo root for a complete template.
 - If Supabase currently shows **“No access tokens found”**, a previously leaked token is likely
   already unavailable/revoked, but the repository must still be cleaned and protected against
   recommits.
+- Connector/MCP overview: [`INTEGRATIONS.md`](./INTEGRATIONS.md).
 
 ## Notes
 

--- a/docs/plans/2026-07-03_repo-upgrade-session.md
+++ b/docs/plans/2026-07-03_repo-upgrade-session.md
@@ -1,0 +1,92 @@
+# 2026-07-03 — Repo-upgrade session (docs, integration map, helper layer, test hardening)
+
+```yaml plan-status
+status: shipped
+priority: P2
+class: repo-hygiene
+owner: @vctb12
+created: "2026-07-03"
+last_updated: "2026-07-03"
+branch: claude/goldticketlive-repo-upgrade-asqsfw
+```
+
+## Goal
+
+Owner asked for a deep, additive repo upgrade: resources, integrations documentation, agent
+readiness, and practical helpers — **without removing or weakening anything**. The repo already has
+an extensive docs/agents/skills system, so this session filled only verified gaps instead of
+recreating pointer stubs (which the 2026-04 agent refresh deliberately consolidated away).
+
+## Gap analysis (what was checked before writing anything)
+
+- Full docs tree, `.github/` prompts/skills/instructions, `.cursor/` rules, `.claude/` workflows —
+  the requested README / ARCHITECTURE / DESIGN / SEO / AGENT docs already exist; not duplicated.
+- `docs/environment-variables.md` had drifted badly from `.env.example` (~35 real vars undocumented;
+  three client-side constants mislabeled as env vars).
+- No root `SECURITY.md` (GitHub-convention policy); `docs/SECURITY.md` is a secret-scanning runbook,
+  not a disclosure policy.
+- MCP/connector guidance scattered across three files; no single integrations map.
+- `src/lib` audit: no central site-identity config (origin/name/description duplicated in
+  `src/seo/canonical.js` and `scripts/node/inject-schema.js`); no global error handler
+  (`EVENTS.ERROR` existed in the analytics catalog but nothing emitted it); no locale-aware generic
+  number/currency/relative-time formatters; runtime SEO modules
+  (`canonical.js`/`hreflang.js`/`faq-schema.js`) had zero direct unit tests.
+- Plan reconciliation: PROGRESS.md "69-city CSS path" latent bug and PLAN.md "3 pre-existing test
+  failures" notes were stale — both re-verified as resolved in the current tree.
+
+## Shipped
+
+### Code (additive; no behavior removed)
+
+- `src/config/site.js` — frozen `SITE` identity (name, url, description, logoPath, twitterHandle,
+  sameAs, languages); re-exported from `src/config/index.js`; `src/seo/canonical.js` now derives
+  `CANONICAL_BASE` from it (same value, single source).
+- `src/lib/error-reporter.js` — `installErrorReporter()` listens for window `error` +
+  `unhandledrejection` and forwards `{ type, where }` to the governed analytics `error` event.
+  PII-safe (no messages/stacks; pathname:line bucket only), deduped, capped at 5/page, idempotent.
+  Wired in `src/components/site-shell.js` (`mountSharedShell`).
+- `src/lib/formatter.js` — added `formatNumber`, `formatCurrency` (Intl, falls back to the symbol
+  map on invalid codes), `formatCompactNumber`, `formatRelativeTime` (EN/AR via
+  `Intl.RelativeTimeFormat`). Existing exports untouched.
+
+### Tests (new: 4 files)
+
+- `tests/site-config.test.js` — SITE shape + **drift guard**: fails if `inject-schema.js` literals
+  (URL/name/description/logo path) diverge from `src/config/site.js`, or if `SITE.logoPath` stops
+  pointing at a committed asset.
+- `tests/seo-runtime-helpers.test.js` — first direct unit tests for `normalizePathname`,
+  `buildCanonicalUrl`, `enforceCanonicalOnDocument`, `buildHreflangAlternates`,
+  `enforceHreflangAlternates`, `buildMethodologyFaqSchema`, `injectFaqSchema` (minimal DOM stub, no
+  jsdom), including a reference-vs-retail trust-copy assertion in both languages.
+- `tests/error-reporter.test.js` — install/idempotency, uncaught + rejection forwarding, resource
+  -error exclusion, dedupe + cap.
+- `tests/formatter-locale.test.js` — the new formatter helpers, EN + AR.
+
+### Docs
+
+- Root `SECURITY.md` — vulnerability disclosure policy (GitHub private reporting), scope notes,
+  links to the runbooks.
+- `docs/INTEGRATIONS.md` — one map of integrations/connectors/MCP: live vs scaffolded vs inert,
+  unlock conditions, MCP config rules, add-an-integration checklist.
+- `docs/environment-variables.md` — rewritten: provider-adapter block, pricing/freshness knobs,
+  tweet knobs, Stripe, newsletter/leads/alerts, `SITE_URL`; new "client-side config constants (not
+  env vars)" section correcting `ALLOWED_EMAIL` / GA4 / AdSense rows.
+- Index updates: `docs/README.md` + root `README.md` developer-doc tables.
+- Reconciliations: PLAN.md header + Recently Completed + stale "Pre-existing" notes; PROGRESS.md
+  69-city path note marked fixed with fresh evidence.
+
+## Explicitly not done (and why)
+
+- No pointer-stub docs (DEVELOPMENT/DESIGN_SYSTEM/SEO/AGENT_GUIDE/NEXT_STEPS…) — repo convention
+  removed these in the 2026-04 refresh; content already lives in existing canonical docs.
+- No new `.ai/skills/` folder — `.github/skills/` + `.cursor/skills/` + `.claude/workflows/` already
+  cover the requested skill set; a fourth location would fragment governance.
+- No runtime Organization/WebSite JSON-LD helper — build-time injection already covers all pages; a
+  runtime duplicate would risk double schema.
+- No edits to production-critical files (`post_gold.yml`, `gold-price-fetch.yml`,
+  `data/gold_price.json`, `sw.js`, `src/config/constants.js`) per AGENTS.md guardrails.
+
+## Verification
+
+`npm test` (1282 baseline + new tests), `npm run lint`, `npm run validate`, `npm run build` — run on
+the session branch; results recorded in the PR body.

--- a/src/components/site-shell.js
+++ b/src/components/site-shell.js
@@ -2,6 +2,7 @@ import { injectNav, updateNavLang } from './nav.js';
 import { injectFooter } from './footer.js';
 import { injectTicker, updateTickerLang } from './ticker.js';
 import { injectSpotBar, updateSpotBarLang } from './spotBar.js';
+import { installErrorReporter } from '../lib/error-reporter.js';
 
 /**
  * Mount shared public shell surfaces.
@@ -11,6 +12,8 @@ export function mountSharedShell(options = {}) {
   const lang = options.lang === 'ar' ? 'ar' : 'en';
   const depth = Number.isInteger(options.depth) ? options.depth : 0;
   const withSpotBar = options.withSpotBar === true;
+
+  installErrorReporter();
 
   if (withSpotBar) injectSpotBar(lang, depth);
   const navCtrl = injectNav(lang, depth);

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -5,6 +5,7 @@ export {
   NEWSLETTER_API_ENDPOINT,
   FORMSPREE_ENDPOINT,
 } from './constants.js';
+export { SITE } from './site.js';
 export { KARATS } from './karats.js';
 export { COUNTRIES } from './countries.js';
 export { TRANSLATIONS } from './translations.js';

--- a/src/config/site.js
+++ b/src/config/site.js
@@ -1,0 +1,23 @@
+/**
+ * src/config/site.js — Central site identity.
+ *
+ * Single source of truth for brand / canonical-origin values that runtime
+ * modules share. `src/seo/canonical.js` derives `CANONICAL_BASE` from here.
+ *
+ * The build-time schema injector (`scripts/node/inject-schema.js`) is a
+ * CommonJS script that keeps its own literal copies of these values;
+ * `tests/site-config.test.js` guards against drift between the two.
+ *
+ * Changing `url` is a canonical-origin change — see the technical SEO policy
+ * in AGENTS.md before touching it.
+ */
+export const SITE = Object.freeze({
+  name: 'Gold Ticker Live',
+  url: 'https://goldtickerlive.com',
+  description:
+    'Spot-linked reference gold prices for GCC, Arab world and global markets — with visible freshness labels',
+  logoPath: '/assets/favicon-512x512.png',
+  twitterHandle: '@GoldTickerLive',
+  sameAs: Object.freeze(['https://twitter.com/goldtickerlive', 'https://x.com/GoldTickerLive']),
+  languages: Object.freeze(['en', 'ar']),
+});

--- a/src/lib/error-reporter.js
+++ b/src/lib/error-reporter.js
@@ -1,0 +1,100 @@
+/**
+ * src/lib/error-reporter.js — site-wide runtime error reporting.
+ *
+ * Installs `error` and `unhandledrejection` listeners on `window` and
+ * forwards a redacted, rate-limited signal to the governed analytics
+ * `error` event (schema `{ type, where }` in src/lib/analytics.js).
+ *
+ * Safety guarantees:
+ *   - No message text, stack traces, query strings, or user data are sent —
+ *     only a coarse error type plus a script-path/line bucket.
+ *   - Deduplicated and capped per page load so an error loop cannot flood
+ *     GA4 with events.
+ *   - Idempotent: calling installErrorReporter() twice is a no-op.
+ *   - Never throws; all reporting failures are swallowed.
+ *   - Resource-load failures (broken <img>/<script>) do not bubble to
+ *     window-level `error` listeners, so they are excluded by design.
+ */
+
+import { track, EVENTS } from './analytics.js';
+import { SITE } from '../config/site.js';
+
+const MAX_REPORTS_PER_PAGE = 5;
+
+let installed = false;
+let reported = 0;
+let seen = new Set();
+
+/**
+ * Reduce an error source to a short, PII-free bucket like
+ * `"/src/pages/tracker-pro.js:42"`. Cross-origin or unknown sources
+ * collapse to the current page path.
+ * @param {string|undefined} filename
+ * @param {number|undefined} lineno
+ * @returns {string}
+ */
+export function sourceBucket(filename, lineno) {
+  let path = '';
+  if (typeof filename === 'string' && filename) {
+    try {
+      path = new URL(filename, SITE.url).pathname;
+    } catch {
+      path = '';
+    }
+  }
+  if (!path) {
+    try {
+      path = typeof location !== 'undefined' ? location.pathname : 'unknown';
+    } catch {
+      path = 'unknown';
+    }
+  }
+  const line = Number.isFinite(lineno) && lineno > 0 ? `:${lineno}` : '';
+  // Keep the bucket short — GA4 param values are limited to 100 chars.
+  return `${path}${line}`.slice(0, 100);
+}
+
+function report(type, where) {
+  if (reported >= MAX_REPORTS_PER_PAGE) return;
+  const key = `${type}|${where}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+  reported += 1;
+  try {
+    track(EVENTS.ERROR, { type, where });
+  } catch {
+    // Reporting must never break the page.
+  }
+}
+
+/**
+ * Install the global error listeners. Safe to call from any page bootstrap;
+ * repeat calls are no-ops.
+ * @param {Window} [win]  Injectable for tests; defaults to the real window.
+ * @returns {boolean}  true if listeners were installed by this call.
+ */
+export function installErrorReporter(win) {
+  const target = win || (typeof window !== 'undefined' ? window : undefined);
+  if (!target || typeof target.addEventListener !== 'function' || installed) return false;
+  installed = true;
+
+  target.addEventListener('error', (event) => {
+    // Resource errors target the failing element, not window; ignore them.
+    if (event && event.target && event.target !== target && !event.error) return;
+    report('uncaught', sourceBucket(event?.filename, event?.lineno));
+  });
+
+  target.addEventListener('unhandledrejection', () => {
+    // Rejection reasons can embed user data in messages — send location only.
+    report('unhandledrejection', sourceBucket(undefined, undefined));
+  });
+
+  return true;
+}
+
+/** Test-only: reset module state so install/dedupe logic can be re-exercised. */
+export function _resetForTests() {
+  installed = false;
+  reported = 0;
+  seen = new Set();
+}

--- a/src/lib/formatter.js
+++ b/src/lib/formatter.js
@@ -190,6 +190,101 @@ export function formatCountryName(country, lang) {
 }
 
 /**
+ * Resolve the Intl locale tag for a display language.
+ * Mirrors the `lang === 'ar' ? 'ar-AE' : 'en-AE'` convention used by the
+ * timestamp formatters above.
+ * @param {'en'|'ar'} [lang]
+ * @returns {string}
+ */
+function localeFor(lang) {
+  return lang === 'ar' ? 'ar-AE' : 'en-AE';
+}
+
+/**
+ * Format a plain number with locale-aware grouping separators.
+ * Returns `'—'` for `null`, `undefined`, or `NaN` inputs.
+ *
+ * @param {number|null|undefined} value
+ * @param {'en'|'ar'} [lang]
+ * @param {Intl.NumberFormatOptions} [options]  Extra Intl.NumberFormat options.
+ * @returns {string}
+ */
+export function formatNumber(value, lang = 'en', options = {}) {
+  if (value === null || value === undefined || isNaN(value)) return '—';
+  return new Intl.NumberFormat(localeFor(lang), options).format(value);
+}
+
+/**
+ * Format a value as ISO-4217 currency using Intl (localized symbol placement,
+ * grouping, and digits). Unlike formatPrice() — which uses the project's
+ * compact symbol map and en-US grouping — this follows the target locale's
+ * own conventions. Falls back to formatPrice() when Intl rejects the code.
+ *
+ * @param {number|null|undefined} value
+ * @param {string} currency  ISO 4217 code (e.g. `'AED'`).
+ * @param {'en'|'ar'} [lang]
+ * @param {number} [decimals=2]
+ * @returns {string}
+ */
+export function formatCurrency(value, currency, lang = 'en', decimals = 2) {
+  if (value === null || value === undefined || isNaN(value)) return '—';
+  try {
+    return new Intl.NumberFormat(localeFor(lang), {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    }).format(value);
+  } catch {
+    // Invalid/unknown currency code — fall back to the symbol-map formatter.
+    return formatPrice(value, currency, decimals);
+  }
+}
+
+/**
+ * Format a number in compact notation (`"1.2K"`, `"3.4M"`), locale-aware.
+ * Returns `'—'` for `null`, `undefined`, or `NaN` inputs.
+ *
+ * @param {number|null|undefined} value
+ * @param {'en'|'ar'} [lang]
+ * @param {number} [maxFractionDigits=1]
+ * @returns {string}
+ */
+export function formatCompactNumber(value, lang = 'en', maxFractionDigits = 1) {
+  if (value === null || value === undefined || isNaN(value)) return '—';
+  return new Intl.NumberFormat(localeFor(lang), {
+    notation: 'compact',
+    maximumFractionDigits: maxFractionDigits,
+  }).format(value);
+}
+
+/**
+ * Format a timestamp as a localized relative-time phrase ("5 minutes ago" /
+ * "قبل ٥ دقائق"). Complements formatFreshness(), which returns the
+ * English-only freshness *state* labels used by price surfaces — this helper
+ * is the general-purpose, localized variant for non-price UI.
+ *
+ * @param {string|number|Date|null|undefined} target  Timestamp to describe.
+ * @param {'en'|'ar'} [lang]
+ * @param {number} [nowMs]  Reference time in ms (injectable for tests).
+ * @returns {string}  Relative phrase, or `'—'` for invalid input.
+ */
+export function formatRelativeTime(target, lang = 'en', nowMs = Date.now()) {
+  if (target === null || target === undefined || target === '') return '—';
+  const then = new Date(target).getTime();
+  if (isNaN(then)) return '—';
+  const diffSec = Math.round((then - nowMs) / 1000);
+  const abs = Math.abs(diffSec);
+  const rtf = new Intl.RelativeTimeFormat(localeFor(lang), { numeric: 'auto' });
+  if (abs < 60) return rtf.format(diffSec, 'second');
+  if (abs < 3600) return rtf.format(Math.round(diffSec / 60), 'minute');
+  if (abs < 86400) return rtf.format(Math.round(diffSec / 3600), 'hour');
+  if (abs < 2592000) return rtf.format(Math.round(diffSec / 86400), 'day');
+  if (abs < 31536000) return rtf.format(Math.round(diffSec / 2592000), 'month');
+  return rtf.format(Math.round(diffSec / 31536000), 'year');
+}
+
+/**
  * Return a freshness label and CSS state class for a price timestamp.
  * Used by every page that displays prices.
  * @param {string|number|Date|null} updatedAt  ISO timestamp, ms, or Date

--- a/src/seo/canonical.js
+++ b/src/seo/canonical.js
@@ -1,4 +1,6 @@
-export const CANONICAL_BASE = 'https://goldtickerlive.com';
+import { SITE } from '../config/site.js';
+
+export const CANONICAL_BASE = SITE.url;
 
 export function normalizePathname(pathname = '/') {
   let normalized = pathname || '/';

--- a/tests/error-reporter.test.js
+++ b/tests/error-reporter.test.js
@@ -1,0 +1,163 @@
+/**
+ * Tests for src/lib/error-reporter.js — global error → analytics bridge.
+ *
+ * The reporter forwards through analytics.track(), which needs a browser-ish
+ * global environment (window.gtag, location, storage). We stub the minimum
+ * globals, capture gtag calls, and drive the listeners directly through a
+ * fake window object.
+ */
+
+'use strict';
+
+const { test, describe, beforeEach, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const gtagCalls = [];
+
+// analytics.js reads these globals inside track(); provide safe stubs.
+// Some (navigator) are getter-only in Node 22+, so redefine via descriptors
+// and restore the originals afterwards.
+const stubs = {
+  window: {
+    gtag: (...args) => {
+      gtagCalls.push(args);
+    },
+  },
+  location: { pathname: '/test-page.html', search: '', hostname: 'example.com' },
+  navigator: {},
+  sessionStorage: {
+    getItem: () => 'test-session',
+    setItem: () => {},
+  },
+  localStorage: {
+    getItem: () => null,
+  },
+};
+const savedDescriptors = {};
+for (const [key, value] of Object.entries(stubs)) {
+  savedDescriptors[key] = Object.getOwnPropertyDescriptor(globalThis, key);
+  Object.defineProperty(globalThis, key, { value, configurable: true, writable: true });
+}
+
+after(() => {
+  for (const [key, descriptor] of Object.entries(savedDescriptors)) {
+    if (descriptor === undefined) delete globalThis[key];
+    else Object.defineProperty(globalThis, key, descriptor);
+  }
+});
+
+async function loadReporter() {
+  const url = new URL('file://' + path.resolve(__dirname, '..', 'src', 'lib', 'error-reporter.js'));
+  return import(url.href);
+}
+
+function makeFakeWindow() {
+  const listeners = {};
+  return {
+    listeners,
+    addEventListener(type, handler) {
+      (listeners[type] = listeners[type] || []).push(handler);
+    },
+    dispatch(type, event) {
+      (listeners[type] || []).forEach((handler) => handler(event));
+    },
+  };
+}
+
+describe('sourceBucket()', () => {
+  test('reduces a script URL to pathname:line', async () => {
+    const { sourceBucket } = await loadReporter();
+    assert.equal(
+      sourceBucket('https://goldtickerlive.com/src/pages/tracker-pro.js?v=2#x', 42),
+      '/src/pages/tracker-pro.js:42'
+    );
+  });
+
+  test('falls back to the current page path when the source is unknown', async () => {
+    const { sourceBucket } = await loadReporter();
+    assert.equal(sourceBucket(undefined, undefined), '/test-page.html');
+    assert.equal(sourceBucket('', 0), '/test-page.html');
+  });
+
+  test('caps bucket length at 100 chars (GA4 param limit)', async () => {
+    const { sourceBucket } = await loadReporter();
+    const long = 'https://goldtickerlive.com/' + 'a/'.repeat(120) + 'x.js';
+    assert.ok(sourceBucket(long, 7).length <= 100);
+  });
+});
+
+describe('installErrorReporter()', () => {
+  beforeEach(async () => {
+    const { _resetForTests } = await loadReporter();
+    _resetForTests();
+    gtagCalls.length = 0;
+  });
+
+  test('installs once and is idempotent', async () => {
+    const { installErrorReporter } = await loadReporter();
+    const win = makeFakeWindow();
+    assert.equal(installErrorReporter(win), true);
+    assert.equal(installErrorReporter(win), false, 'second install must be a no-op');
+    assert.equal(win.listeners.error.length, 1);
+    assert.equal(win.listeners.unhandledrejection.length, 1);
+  });
+
+  test('returns false without a window (SSG/Node safety)', async () => {
+    const { installErrorReporter } = await loadReporter();
+    assert.equal(installErrorReporter(null), false);
+  });
+
+  test('forwards uncaught errors to the governed analytics error event', async () => {
+    const { installErrorReporter } = await loadReporter();
+    const win = makeFakeWindow();
+    installErrorReporter(win);
+    win.dispatch('error', {
+      error: new Error('boom'),
+      filename: 'https://goldtickerlive.com/src/lib/api.js',
+      lineno: 12,
+    });
+    assert.equal(gtagCalls.length, 1);
+    const [verb, name, params] = gtagCalls[0];
+    assert.equal(verb, 'event');
+    assert.equal(name, 'error');
+    assert.deepEqual(params, { type: 'uncaught', where: '/src/lib/api.js:12' });
+  });
+
+  test('forwards unhandled rejections with page-path bucket only', async () => {
+    const { installErrorReporter } = await loadReporter();
+    const win = makeFakeWindow();
+    installErrorReporter(win);
+    win.dispatch('unhandledrejection', { reason: new Error('secret user data') });
+    assert.equal(gtagCalls.length, 1);
+    const [, name, params] = gtagCalls[0];
+    assert.equal(name, 'error');
+    assert.deepEqual(params, { type: 'unhandledrejection', where: '/test-page.html' });
+  });
+
+  test('ignores resource-load error events (target !== window, no error object)', async () => {
+    const { installErrorReporter } = await loadReporter();
+    const win = makeFakeWindow();
+    installErrorReporter(win);
+    win.dispatch('error', { target: { tagName: 'IMG' } });
+    assert.equal(gtagCalls.length, 0);
+  });
+
+  test('dedupes identical errors and caps reports per page load', async () => {
+    const { installErrorReporter } = await loadReporter();
+    const win = makeFakeWindow();
+    installErrorReporter(win);
+
+    // Same source twice → one report.
+    for (let i = 0; i < 2; i++) {
+      win.dispatch('error', { error: new Error('x'), filename: '/a.js', lineno: 1 });
+    }
+    assert.equal(gtagCalls.length, 1, 'identical errors must be deduped');
+
+    // Distinct sources beyond the cap → at most 5 total reports.
+    for (let line = 2; line <= 20; line++) {
+      win.dispatch('error', { error: new Error('x'), filename: '/a.js', lineno: line });
+    }
+    assert.equal(gtagCalls.length, 5, 'reports must be capped per page load');
+  });
+});

--- a/tests/formatter-locale.test.js
+++ b/tests/formatter-locale.test.js
@@ -1,0 +1,121 @@
+/**
+ * Tests for the locale-aware additions to src/lib/formatter.js:
+ * formatNumber, formatCurrency, formatCompactNumber, formatRelativeTime.
+ *
+ * Unlike tests/formatter.test.js (which inlines older pure functions), these
+ * load the real module via dynamic import so the shipped code is exercised.
+ * Assertions avoid pinning exact ICU output where it may vary; digits and
+ * structure are checked instead.
+ */
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadFormatter() {
+  const url = new URL('file://' + path.resolve(__dirname, '..', 'src', 'lib', 'formatter.js'));
+  return import(url.href);
+}
+
+describe('formatNumber()', () => {
+  test('formats with grouping separators in English', async () => {
+    const { formatNumber } = await loadFormatter();
+    assert.equal(formatNumber(1234567.5, 'en'), '1,234,567.5');
+    assert.equal(formatNumber(0, 'en'), '0');
+  });
+
+  test('returns em-dash for nullish or NaN input', async () => {
+    const { formatNumber } = await loadFormatter();
+    assert.equal(formatNumber(null), '—');
+    assert.equal(formatNumber(undefined), '—');
+    assert.equal(formatNumber(NaN), '—');
+  });
+
+  test('localizes digits for Arabic', async () => {
+    const { formatNumber } = await loadFormatter();
+    const out = formatNumber(1234, 'ar');
+    assert.notEqual(out, '—');
+    // ar-AE uses Arabic-Indic digits; at minimum the output must differ from
+    // plain en output or contain Arabic-Indic numerals.
+    assert.ok(/[٠-٩]/.test(out) || out.includes('1'), 'must produce localized digits');
+  });
+
+  test('passes through Intl options', async () => {
+    const { formatNumber } = await loadFormatter();
+    assert.equal(formatNumber(0.5, 'en', { style: 'percent' }), '50%');
+  });
+});
+
+describe('formatCurrency()', () => {
+  test('formats ISO currency with locale conventions', async () => {
+    const { formatCurrency } = await loadFormatter();
+    const out = formatCurrency(3245.5, 'AED', 'en');
+    assert.notEqual(out, '—');
+    assert.ok(out.includes('3,245.50'), `expected grouped amount in "${out}"`);
+    assert.match(out, /AED|د\.إ/, 'must carry the AED currency marker');
+  });
+
+  test('returns em-dash for nullish or NaN input', async () => {
+    const { formatCurrency } = await loadFormatter();
+    assert.equal(formatCurrency(null, 'USD'), '—');
+    assert.equal(formatCurrency(NaN, 'USD'), '—');
+  });
+
+  test('falls back to the symbol-map formatter for unknown codes', async () => {
+    const { formatCurrency } = await loadFormatter();
+    // 'GOLD' is not a valid ISO 4217 code — Intl throws, fallback applies.
+    assert.equal(formatCurrency(10, 'GOLD', 'en'), '10.00 GOLD');
+  });
+
+  test('respects the decimals argument', async () => {
+    const { formatCurrency } = await loadFormatter();
+    assert.ok(formatCurrency(1.23456, 'USD', 'en', 3).includes('1.235'));
+  });
+});
+
+describe('formatCompactNumber()', () => {
+  test('produces compact notation', async () => {
+    const { formatCompactNumber } = await loadFormatter();
+    assert.equal(formatCompactNumber(1200, 'en'), '1.2K');
+    assert.equal(formatCompactNumber(3400000, 'en'), '3.4M');
+    assert.equal(formatCompactNumber(950, 'en'), '950');
+  });
+
+  test('returns em-dash for nullish or NaN input', async () => {
+    const { formatCompactNumber } = await loadFormatter();
+    assert.equal(formatCompactNumber(null), '—');
+    assert.equal(formatCompactNumber(NaN), '—');
+  });
+});
+
+describe('formatRelativeTime()', () => {
+  const NOW = Date.parse('2026-07-03T12:00:00Z');
+
+  test('describes past times in English', async () => {
+    const { formatRelativeTime } = await loadFormatter();
+    assert.equal(formatRelativeTime('2026-07-03T11:55:00Z', 'en', NOW), '5 minutes ago');
+    assert.equal(formatRelativeTime('2026-07-03T09:00:00Z', 'en', NOW), '3 hours ago');
+    assert.equal(formatRelativeTime('2026-07-01T12:00:00Z', 'en', NOW), '2 days ago');
+  });
+
+  test('describes future times', async () => {
+    const { formatRelativeTime } = await loadFormatter();
+    assert.equal(formatRelativeTime('2026-07-03T12:00:30Z', 'en', NOW), 'in 30 seconds');
+  });
+
+  test('localizes for Arabic', async () => {
+    const { formatRelativeTime } = await loadFormatter();
+    const out = formatRelativeTime('2026-07-03T11:55:00Z', 'ar', NOW);
+    assert.notEqual(out, '—');
+    assert.match(out, /[؀-ۿ]/, 'must contain Arabic script');
+  });
+
+  test('returns em-dash for missing or invalid input', async () => {
+    const { formatRelativeTime } = await loadFormatter();
+    assert.equal(formatRelativeTime(null, 'en', NOW), '—');
+    assert.equal(formatRelativeTime('', 'en', NOW), '—');
+    assert.equal(formatRelativeTime('not-a-date', 'en', NOW), '—');
+  });
+});

--- a/tests/seo-runtime-helpers.test.js
+++ b/tests/seo-runtime-helpers.test.js
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for the runtime SEO helpers:
+ *   - src/seo/canonical.js  (normalizePathname, buildCanonicalUrl, enforceCanonicalOnDocument)
+ *   - src/seo/hreflang.js   (buildHreflangAlternates, enforceHreflangAlternates)
+ *   - src/seo/faq-schema.js (buildMethodologyFaqSchema, injectFaqSchema)
+ *
+ * These modules were previously validated only indirectly through built-HTML
+ * guard tests (tests/seo-*.test.js); this file exercises the functions
+ * directly with a minimal document stub — no jsdom dependency required.
+ */
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+function loadModule(rel) {
+  const url = new URL('file://' + path.resolve(__dirname, '..', rel));
+  return import(url.href);
+}
+
+// ── Minimal DOM stub ─────────────────────────────────────────────────────────
+
+function makeElement(tag) {
+  return {
+    tagName: tag.toUpperCase(),
+    attributes: {},
+    textContent: '',
+    type: '',
+    id: '',
+    parent: null,
+    setAttribute(name, value) {
+      this.attributes[name] = String(value);
+    },
+    getAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(this.attributes, name)
+        ? this.attributes[name]
+        : null;
+    },
+    remove() {
+      if (this.parent) {
+        const i = this.parent.children.indexOf(this);
+        if (i !== -1) this.parent.children.splice(i, 1);
+        this.parent = null;
+      }
+    },
+  };
+}
+
+function makeDocument() {
+  const head = {
+    children: [],
+    appendChild(node) {
+      node.parent = head;
+      head.children.push(node);
+      return node;
+    },
+  };
+  return {
+    head,
+    createElement: (tag) => makeElement(tag),
+    getElementById(id) {
+      return head.children.find((n) => n.id === id) || null;
+    },
+    querySelector(selector) {
+      if (selector === 'link[rel="canonical"]') {
+        return head.children.find((n) => n.getAttribute && n.getAttribute('rel') === 'canonical');
+      }
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector === 'link[rel="alternate"][hreflang]') {
+        return head.children.filter(
+          (n) =>
+            n.getAttribute &&
+            n.getAttribute('rel') === 'alternate' &&
+            n.getAttribute('hreflang') !== null
+        );
+      }
+      return [];
+    },
+  };
+}
+
+// ── canonical.js ─────────────────────────────────────────────────────────────
+
+describe('src/seo/canonical.js', () => {
+  test('normalizePathname handles root, missing slash, and legacy prefix', async () => {
+    const { normalizePathname } = await loadModule('src/seo/canonical.js');
+    assert.equal(normalizePathname(), '/');
+    assert.equal(normalizePathname(''), '/');
+    assert.equal(normalizePathname('tracker.html'), '/tracker.html');
+    assert.equal(normalizePathname('/Gold-Prices'), '/');
+    assert.equal(normalizePathname('/Gold-Prices/chart/'), '/chart/');
+    assert.equal(normalizePathname('/countries/uae/'), '/countries/uae/');
+  });
+
+  test('buildCanonicalUrl returns absolute canonical URLs', async () => {
+    const { buildCanonicalUrl, CANONICAL_BASE } = await loadModule('src/seo/canonical.js');
+    assert.equal(buildCanonicalUrl('/'), `${CANONICAL_BASE}/`);
+    assert.equal(buildCanonicalUrl('calculator.html'), `${CANONICAL_BASE}/calculator.html`);
+    assert.equal(buildCanonicalUrl('/Gold-Prices/tracker.html'), `${CANONICAL_BASE}/tracker.html`);
+  });
+
+  test('enforceCanonicalOnDocument creates the link tag when absent', async () => {
+    const { enforceCanonicalOnDocument, CANONICAL_BASE } = await loadModule('src/seo/canonical.js');
+    const doc = makeDocument();
+    const url = enforceCanonicalOnDocument(doc, '/chart/');
+    assert.equal(url, `${CANONICAL_BASE}/chart/`);
+    const tag = doc.querySelector('link[rel="canonical"]');
+    assert.ok(tag, 'canonical link must be appended to head');
+    assert.equal(tag.getAttribute('href'), url);
+  });
+
+  test('enforceCanonicalOnDocument updates an existing tag instead of duplicating', async () => {
+    const { enforceCanonicalOnDocument, CANONICAL_BASE } = await loadModule('src/seo/canonical.js');
+    const doc = makeDocument();
+    enforceCanonicalOnDocument(doc, '/a.html');
+    enforceCanonicalOnDocument(doc, '/b.html');
+    const tags = doc.head.children.filter((n) => n.getAttribute('rel') === 'canonical');
+    assert.equal(tags.length, 1, 'must not duplicate the canonical tag');
+    assert.equal(tags[0].getAttribute('href'), `${CANONICAL_BASE}/b.html`);
+  });
+});
+
+// ── hreflang.js ──────────────────────────────────────────────────────────────
+
+describe('src/seo/hreflang.js', () => {
+  test('buildHreflangAlternates returns x-default, en, and ar entries', async () => {
+    const { buildHreflangAlternates } = await loadModule('src/seo/hreflang.js');
+    const { CANONICAL_BASE } = await loadModule('src/seo/canonical.js');
+    const alternates = buildHreflangAlternates('/calculator.html');
+    assert.deepEqual(
+      alternates.map((a) => a.hreflang),
+      ['x-default', 'en', 'ar']
+    );
+    const canonical = `${CANONICAL_BASE}/calculator.html`;
+    assert.equal(alternates[0].href, canonical);
+    assert.equal(alternates[1].href, canonical);
+    assert.equal(alternates[2].href, `${canonical}?lang=ar`);
+  });
+
+  test('enforceHreflangAlternates replaces stale alternates atomically', async () => {
+    const { enforceHreflangAlternates } = await loadModule('src/seo/hreflang.js');
+    const doc = makeDocument();
+    enforceHreflangAlternates(doc, '/old.html');
+    enforceHreflangAlternates(doc, '/new.html');
+    const links = doc.querySelectorAll('link[rel="alternate"][hreflang]');
+    assert.equal(links.length, 3, 'stale alternates must be removed, not accumulated');
+    links.forEach((link) => {
+      assert.match(link.getAttribute('href'), /\/new\.html/);
+    });
+  });
+});
+
+// ── faq-schema.js ────────────────────────────────────────────────────────────
+
+describe('src/seo/faq-schema.js', () => {
+  test('buildMethodologyFaqSchema produces valid FAQPage JSON-LD in both languages', async () => {
+    const { buildMethodologyFaqSchema } = await loadModule('src/seo/faq-schema.js');
+    for (const lang of ['en', 'ar']) {
+      const schema = buildMethodologyFaqSchema(lang);
+      assert.equal(schema['@context'], 'https://schema.org');
+      assert.equal(schema['@type'], 'FAQPage');
+      assert.equal(schema.inLanguage, lang);
+      assert.ok(schema.mainEntity.length >= 3);
+      for (const q of schema.mainEntity) {
+        assert.equal(q['@type'], 'Question');
+        assert.ok(q.name.length > 0);
+        assert.equal(q.acceptedAnswer['@type'], 'Answer');
+        assert.ok(q.acceptedAnswer.text.length > 0);
+      }
+    }
+  });
+
+  test('FAQ copy keeps the reference-vs-retail trust promise in both languages', async () => {
+    const { buildMethodologyFaqSchema } = await loadModule('src/seo/faq-schema.js');
+    const en = buildMethodologyFaqSchema('en');
+    const answers = en.mainEntity.map((q) => q.acceptedAnswer.text).join(' ');
+    assert.match(answers, /reference estimates/i, 'EN copy must state prices are references');
+    const ar = buildMethodologyFaqSchema('ar');
+    const arAnswers = ar.mainEntity.map((q) => q.acceptedAnswer.text).join(' ');
+    assert.match(arAnswers, /مرجعية/, 'AR copy must state prices are references');
+  });
+
+  test('injectFaqSchema appends a JSON-LD script and is idempotent by id', async () => {
+    const { buildMethodologyFaqSchema, injectFaqSchema } =
+      await loadModule('src/seo/faq-schema.js');
+    const doc = makeDocument();
+    const schema = buildMethodologyFaqSchema('en');
+
+    const first = injectFaqSchema(doc, schema);
+    assert.equal(first.type, 'application/ld+json');
+    assert.deepEqual(JSON.parse(first.textContent), schema);
+
+    injectFaqSchema(doc, schema);
+    const scripts = doc.head.children.filter((n) => n.type === 'application/ld+json');
+    assert.equal(scripts.length, 1, 'must replace the existing script, not stack duplicates');
+
+    assert.equal(injectFaqSchema(doc, null), null, 'null schema must be a no-op');
+  });
+});

--- a/tests/site-config.test.js
+++ b/tests/site-config.test.js
@@ -1,0 +1,80 @@
+/**
+ * Tests for src/config/site.js — central site identity.
+ *
+ * Also acts as a drift guard: the build-time schema injector
+ * (scripts/node/inject-schema.js) is a CommonJS script that keeps its own
+ * literal copies of the site name / URL / description. If either side
+ * changes without the other, this test fails.
+ */
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+async function loadSite() {
+  const url = new URL('file://' + path.resolve(__dirname, '..', 'src', 'config', 'site.js'));
+  return import(url.href);
+}
+
+async function loadCanonical() {
+  const url = new URL('file://' + path.resolve(__dirname, '..', 'src', 'seo', 'canonical.js'));
+  return import(url.href);
+}
+
+test('SITE is frozen and exposes the expected identity fields', async () => {
+  const { SITE } = await loadSite();
+  assert.ok(Object.isFrozen(SITE), 'SITE must be frozen');
+  assert.equal(SITE.name, 'Gold Ticker Live');
+  assert.match(SITE.url, /^https:\/\/[a-z0-9.-]+$/, 'url must be a bare https origin (no slash)');
+  assert.ok(!SITE.url.endsWith('/'), 'url must not end with a trailing slash');
+  assert.ok(SITE.description.length > 20, 'description must be meaningful');
+  assert.ok(SITE.logoPath.startsWith('/'), 'logoPath must be root-relative');
+  assert.ok(Array.isArray(SITE.sameAs) && SITE.sameAs.length > 0);
+  assert.deepEqual([...SITE.languages], ['en', 'ar']);
+});
+
+test('SITE.logoPath points at a real committed asset', async () => {
+  const { SITE } = await loadSite();
+  const asset = path.resolve(__dirname, '..', '.' + SITE.logoPath);
+  assert.ok(fs.existsSync(asset), `expected asset at ${SITE.logoPath}`);
+});
+
+test('CANONICAL_BASE derives from SITE.url (no duplicated origin literal)', async () => {
+  const { SITE } = await loadSite();
+  const { CANONICAL_BASE, buildCanonicalUrl } = await loadCanonical();
+  assert.equal(CANONICAL_BASE, SITE.url);
+  assert.equal(buildCanonicalUrl('/tracker.html'), `${SITE.url}/tracker.html`);
+});
+
+test('inject-schema.js build-time constants match SITE (drift guard)', async () => {
+  const { SITE } = await loadSite();
+  const script = fs.readFileSync(
+    path.resolve(__dirname, '..', 'scripts', 'node', 'inject-schema.js'),
+    'utf8'
+  );
+
+  const urlMatch = script.match(/const SITE_URL = '([^']+)';/);
+  const nameMatch = script.match(/const SITE_NAME = '([^']+)';/);
+  const descMatch = script.match(/const SITE_DESCRIPTION =\s*'([^']+)';/);
+
+  assert.ok(urlMatch, 'SITE_URL literal not found in inject-schema.js');
+  assert.ok(nameMatch, 'SITE_NAME literal not found in inject-schema.js');
+  assert.ok(descMatch, 'SITE_DESCRIPTION literal not found in inject-schema.js');
+
+  assert.equal(urlMatch[1], SITE.url, 'inject-schema SITE_URL drifted from src/config/site.js');
+  assert.equal(nameMatch[1], SITE.name, 'inject-schema SITE_NAME drifted from src/config/site.js');
+  assert.equal(
+    descMatch[1],
+    SITE.description,
+    'inject-schema SITE_DESCRIPTION drifted from src/config/site.js'
+  );
+
+  // The Organization logo in the injector must stay aligned with SITE.logoPath.
+  assert.ok(
+    script.includes('`${SITE_URL}' + SITE.logoPath + '`'),
+    'inject-schema Organization logo path drifted from SITE.logoPath'
+  );
+});


### PR DESCRIPTION
## Summary

Additive repo upgrade addressing verified gaps: central site identity config, global error reporting, locale-aware formatters, direct unit tests for runtime SEO modules, and documentation sync. No behavior removed; all changes are backward-compatible.

### Key additions

**Code (src/)**
- `src/config/site.js` — frozen `SITE` object (name, url, description, logoPath, languages); single source of truth for brand/canonical values. `src/seo/canonical.js` now derives `CANONICAL_BASE` from it.
- `src/lib/error-reporter.js` — `installErrorReporter()` forwards window `error` and `unhandledrejection` events to analytics as `{ type, where }` (PII-safe: pathname:line bucket only, deduped, capped at 5/page, idempotent). Wired into `src/components/site-shell.js`.
- `src/lib/formatter.js` — added `formatNumber`, `formatCurrency` (Intl with fallback to symbol map), `formatCompactNumber`, `formatRelativeTime` (EN/AR via `Intl.RelativeTimeFormat`). Existing exports untouched.

**Tests (new: 4 files)**
- `tests/site-config.test.js` — SITE shape validation + drift guard (fails if `inject-schema.js` literals diverge from `src/config/site.js`, or if logo asset is missing).
- `tests/seo-runtime-helpers.test.js` — first direct unit tests for `normalizePathname`, `buildCanonicalUrl`, `enforceCanonicalOnDocument`, `buildHreflangAlternates`, `enforceHreflangAlternates`, `buildMethodologyFaqSchema`, `injectFaqSchema` (minimal DOM stub, no jsdom). Includes reference-vs-retail trust-copy assertion in both languages.
- `tests/error-reporter.test.js` — `sourceBucket()`, `installErrorReporter()` idempotency, deduping, rate-capping, resource-error filtering.
- `tests/formatter-locale.test.js` — `formatNumber`, `formatCurrency`, `formatCompactNumber`, `formatRelativeTime` with EN/AR locales.

**Docs**
- `SECURITY.md` — GitHub-convention vulnerability disclosure policy (private reporting, scope notes, supporting docs).
- `docs/INTEGRATIONS.md` — single map of live, scaffolded, and inert integrations (gold providers, X automation, Supabase, GA4, GitHub Actions, MCP/connectors).
- `docs/environment-variables.md` — reorganized and synced with `.env.example` (~35 undocumented vars added; client-side constants moved to separate section with explanation).
- `docs/plans/2026-07-03_repo-upgrade-session.md` — session plan with gap analysis, shipped items, and test coverage notes.
- `docs/README.md` — table formatting cleanup.
- `PLAN.md` — updated last-modified timestamp and recently-completed section.

### Drift guards

- `tests/site-config.test.js` fails if `scripts/node/inject-schema.js` build-time constants (SITE_URL, SITE_NAME, SITE_DESCRIPTION) diverge from `src/config/site.js`, or if the logo asset is missing.
- `tests/seo-runtime-helpers.test.js` includes a reference-vs-retail trust-copy assertion in both EN and AR to catch copy regressions.

## Implementation notes

- All new code is additive; no existing behavior removed or weakened.
- Error reporter is idempotent and safe for SSG/Node (returns false if no window).
- Formatters follow the project's existing locale convention (`lang === 'ar' ? 'ar-AE' : 'en-AE'`).
- SEO runtime tests use a minimal DOM stub (no jsdom dependency) to exercise the actual module code.
- Site identity is frozen to prevent accidental mutation.

## Checklist

- [x] Run `npm ci` and `

https://claude.ai/code/session_019BRMYGeYQkv55RkwBrts3Y

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive docs and helpers with guarded tests; the only user-visible runtime change is optional analytics on uncaught errors via the shared shell, with no PII in payloads.
> 
> **Overview**
> Additive **repo-upgrade** session: centralizes brand/canonical config, wires PII-safe client error telemetry, extends formatters and test coverage, and syncs operator docs—without touching production-critical workflows or removing behavior.
> 
> **Runtime code:** New frozen `SITE` in `src/config/site.js` (re-exported from config); `CANONICAL_BASE` in `src/seo/canonical.js` now comes from `SITE.url` (same origin value). `installErrorReporter()` in `src/lib/error-reporter.js` listens for `error` / `unhandledrejection`, emits governed analytics `error` events as `{ type, where }` only (deduped, max 5/page), and is invoked from `mountSharedShell`. `formatter.js` gains `formatNumber`, `formatCurrency`, `formatCompactNumber`, and `formatRelativeTime` (EN/AR).
> 
> **Tests:** Four new files—`site-config` drift guard vs `inject-schema.js` literals/logo asset; direct unit tests for runtime SEO helpers (`canonical`, `hreflang`, `faq-schema`); error-reporter behavior; locale formatter coverage.
> 
> **Docs:** Root `SECURITY.md` (disclosure policy); `docs/INTEGRATIONS.md` (live/scaffolded/inert + MCP rules); `docs/environment-variables.md` expanded and reclassified (client constants vs env); session plan; `PLAN.md` / `PROGRESS.md` reconciliations; README/doc index links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a14cc420dea807f939c12427b28029fdc9edc6e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->