### PR TITLE
fix(shell): isolate shell surfaces so a broken feature can't blank the nav (+ learn guides fallback)

### DIFF
--- a/src/components/site-shell.js
+++ b/src/components/site-shell.js
@@ -5,7 +5,27 @@ import { injectSpotBar, updateSpotBarLang } from './spotBar.js';
 import { installErrorReporter } from '../lib/error-reporter.js';
 
 /**
- * Mount shared public shell surfaces.
+ * Run a shell-mounting step in isolation. A failure in one surface (e.g. the
+ * spot bar or ticker) must never prevent the others — above all the nav —
+ * from mounting. Errors are logged, not thrown, so a single broken feature
+ * can't blank the whole page shell.
+ * @template T
+ * @param {string} label
+ * @param {() => T} fn
+ * @returns {T | null}
+ */
+function safeMount(label, fn) {
+  try {
+    return fn();
+  } catch (error) {
+    console.error(`[site-shell] ${label} failed to mount:`, error);
+    return null;
+  }
+}
+
+/**
+ * Mount shared public shell surfaces. Nav is mounted first and in isolation so
+ * it is resilient to any other surface failing.
  * @param {{ lang?: string; depth?: number; withSpotBar?: boolean }} options
  */
 export function mountSharedShell(options = {}) {
@@ -13,20 +33,22 @@ export function mountSharedShell(options = {}) {
   const depth = Number.isInteger(options.depth) ? options.depth : 0;
   const withSpotBar = options.withSpotBar === true;
 
-  installErrorReporter();
+  safeMount('error-reporter', () => installErrorReporter());
 
-  if (withSpotBar) injectSpotBar(lang, depth);
-  const navCtrl = injectNav(lang, depth);
-  injectFooter(lang, depth);
-  injectTicker(lang, depth);
+  // Nav is the critical surface — mount it before the optional spot bar so a
+  // spot-bar failure can never leave the page without navigation.
+  const navCtrl = safeMount('nav', () => injectNav(lang, depth));
+  if (withSpotBar) safeMount('spot-bar', () => injectSpotBar(lang, depth));
+  safeMount('footer', () => injectFooter(lang, depth));
+  safeMount('ticker', () => injectTicker(lang, depth));
 
   return {
     navCtrl,
     updateLang(nextLang) {
       const lang = nextLang === 'ar' ? 'ar' : 'en';
-      updateNavLang(lang);
-      updateTickerLang(lang);
-      if (withSpotBar) updateSpotBarLang(lang);
+      safeMount('nav-lang', () => updateNavLang(lang));
+      safeMount('ticker-lang', () => updateTickerLang(lang));
+      if (withSpotBar) safeMount('spot-bar-lang', () => updateSpotBarLang(lang));
     },
   };
 }

--- a/src/pages/learn-hub-ui.js
+++ b/src/pages/learn-hub-ui.js
@@ -21,14 +21,29 @@ function t(lang, key, vars = {}) {
 function renderGuideCard(guide, lang) {
   const href = guide.href.startsWith('/') ? guide.href : `/${guide.href}`;
   const read = getLearnProgress().includes(guide.href);
-  return el('a', { href, class: `card card--bordered learn-guide-card card-interactive${read ? ' learn-guide-card--read' : ''}` }, [
-    el('div', { class: 'learn-guide-card__meta' }, [
-      el('span', { class: `badge badge--${guide.level === 'beginner' ? 'info' : 'neutral'}` }, t(lang, `learn.level.${guide.level}`)),
-      el('span', { class: 'learn-guide-card__time' }, t(lang, 'learn.readMin', { n: guide.readMin })),
-    ]),
-    el('h3', { class: 'learn-guide-card__title' }, t(lang, guide.titleKey)),
-    el('p', { class: 'learn-guide-card__desc' }, t(lang, guide.descKey)),
-  ]);
+  return el(
+    'a',
+    {
+      href,
+      class: `card card--bordered learn-guide-card card-interactive${read ? ' learn-guide-card--read' : ''}`,
+    },
+    [
+      el('div', { class: 'learn-guide-card__meta' }, [
+        el(
+          'span',
+          { class: `badge badge--${guide.level === 'beginner' ? 'info' : 'neutral'}` },
+          t(lang, `learn.level.${guide.level}`)
+        ),
+        el(
+          'span',
+          { class: 'learn-guide-card__time' },
+          t(lang, 'learn.readMin', { n: guide.readMin })
+        ),
+      ]),
+      el('h3', { class: 'learn-guide-card__title' }, t(lang, guide.titleKey)),
+      el('p', { class: 'learn-guide-card__desc' }, t(lang, guide.descKey)),
+    ]
+  );
 }
 
 /**
@@ -47,7 +62,11 @@ export function mountLearnHubCatalog(options) {
     LEARN_GUIDE_CATEGORIES.some((c) => c.guides.some((g) => g.href === h))
   ).length;
 
-  const progress = el('p', { class: 'learn-hub-progress', 'aria-live': 'polite' }, t(lang, 'learn.progress', { read: readCount, total }));
+  const progress = el(
+    'p',
+    { class: 'learn-hub-progress', 'aria-live': 'polite' },
+    t(lang, 'learn.progress', { read: readCount, total })
+  );
 
   const filter = el('input', {
     type: 'search',
@@ -90,14 +109,28 @@ export function mountLearnHubCatalog(options) {
   filter.addEventListener('input', () => renderSections(filter.value));
   renderSections();
 
+  // Defensive: never replace the server-rendered static fallback with an empty
+  // guide list. If the catalog somehow resolves to zero cards (e.g. a partial
+  // deploy where a lazily-loaded chunk is stale), keep the static cards that
+  // are already in `root` rather than blanking the "featured guides" area.
+  if (!sectionsHost.children.length || !total) return;
+
   root.replaceChildren(
     el('section', { class: 'learn-hub-catalog card card--bordered' }, [
       progress,
       filter,
       sectionsHost,
       el('div', { class: 'learn-hub-related-row' }, [
-        el('a', { href: 'methodology.html', class: 'related-tool-link' }, t(lang, 'learn.relatedMethod')),
-        el('a', { href: 'calculator.html', class: 'related-tool-link' }, t(lang, 'learn.relatedCalc')),
+        el(
+          'a',
+          { href: 'methodology.html', class: 'related-tool-link' },
+          t(lang, 'learn.relatedMethod')
+        ),
+        el(
+          'a',
+          { href: 'calculator.html', class: 'related-tool-link' },
+          t(lang, 'learn.relatedCalc')
+        ),
       ]),
     ])
   );


### PR DESCRIPTION
## Summary

**Root-cause fix for the "no navbar / empty page" reports** on compare/heatmap/portfolio/learn. Those pages render their nav and much of their content via JS. Two fragilities could blank them:

1. **`mountSharedShell` had no error isolation** and injected the optional **spot bar before the nav**. If any surface threw (e.g. a stale/partial chunk after a deploy), the exception happened *before* `injectNav` ran → the whole page rendered with **no navigation**.
2. **`mountLearnHubCatalog` replaced the server-rendered static fallback** with whatever the catalog produced — if that resolved to zero cards, it blanked the "featured guides" area, producing the **"Read 0 of 9 featured guides" empty state**.

## What changed
- `src/components/site-shell.js`: every surface (error-reporter, nav, spot bar, footer, ticker) now mounts inside a `safeMount()` try/catch; **nav mounts first and in isolation**, so no other surface can prevent navigation from appearing. Language-toggle updates are isolated too.
- `src/pages/learn-hub-ui.js`: if the catalog resolves to **zero guide cards**, keep the static fallback cards already in the DOM instead of replacing them with nothing.

## Why separate
This is a pure reliability bug-fix with no content/design change — independent of the content-enrichment PRs, so it can merge first and immediately.

## Verification
- `npm run lint` clean; learn tests pass; local production build renders nav on every page (25–36 links) with these changes.
- No HTML/CSS/content touched.

## Risks
Minimal — behaviour only changes on the failure path (previously: blank; now: nav still mounts / static guides remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes apply mainly on error or empty-catalog paths; happy-path behavior is unchanged aside from nav-before-spot-bar ordering.
> 
> **Overview**
> **Hardens the public page shell** so one throwing injector (spot bar, ticker, footer, error reporter, or lang updates) no longer aborts the rest of the mount — especially navigation.
> 
> `mountSharedShell` now runs each step through **`safeMount`**, logs failures instead of throwing, and **mounts nav before the optional spot bar** so a spot-bar error cannot run before `injectNav`. Language-toggle updates use the same isolation.
> 
> On the learn hub, **`mountLearnHubCatalog` bails out** when `sectionsHost` has no children or `countTotalGuides()` is zero, leaving server-rendered static guide cards in place instead of `replaceChildren` with an empty catalog (e.g. stale chunk after deploy). Remaining learn-hub edits are formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 858d1194fa13960032a6e3e7941484b4611c81c0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->