### PR TITLE
feat(portfolio): gold portfolio education — allocation, scenarios, rebalancing, risks

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -83,6 +83,7 @@
     <link rel="stylesheet" href="./styles/critical.css" />
     <link rel="stylesheet" href="./styles/global.css" />
     <link rel="stylesheet" href="./styles/pages/portfolio.css" />
+    <link rel="stylesheet" href="./styles/components/edu.css" />
     <link rel="apple-touch-icon" href="assets/apple-touch-icon.png" />
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png" />
@@ -219,6 +220,449 @@
             costs are never converted at today’s FX rate.
           </li>
         </ul>
+      </section>
+
+      <!-- Gold portfolio education — static educational hub (edu-* system) -->
+      <!-- Gold portfolio EDUCATION hub — appended inside <main> below the private holdings tracker.
+           Educational only. Not financial advice. All figures are illustrative examples, not recommendations. -->
+
+      <section class="edu-section" id="gold-role" aria-labelledby="gold-role-heading">
+        <div class="edu-inner">
+          <div data-lang-block="en">
+            <p class="edu-eyebrow">Portfolio strategy</p>
+            <h2 class="edu-heading" id="gold-role-heading">What role can gold play in a portfolio?</h2>
+            <p class="edu-lede">Gold is one tool among many. This page explains, for educational purposes only, how some people think about gold's role — it is not financial advice, and every figure shown is an illustrative example, not a recommendation. Any prices shown elsewhere on this site are spot-linked reference values, not live quotes.</p>
+            <div class="edu-grid edu-grid--3">
+              <article class="edu-card">
+                <h3 class="edu-card-title">Diversification</h3>
+                <p class="edu-card-text">Gold often moves differently from stocks and bonds, so a small position can smooth a portfolio's ups and downs. That low-to-negative correlation is not fixed and can change over time.</p>
+              </article>
+              <article class="edu-card">
+                <h3 class="edu-card-title">Inflation hedge</h3>
+                <p class="edu-card-text">Over long periods gold has tended to hold purchasing power. Over months or a few years it is an unreliable hedge, and it can fall even while inflation is rising.</p>
+              </article>
+              <article class="edu-card">
+                <h3 class="edu-card-title">Crisis hedge</h3>
+                <p class="edu-card-text">In market stress or geopolitical shocks, some investors move toward gold. This "safe-haven" behaviour is a tendency observed in the past, not a guarantee.</p>
+              </article>
+              <article class="edu-card">
+                <h3 class="edu-card-title">Liquidity reserve</h3>
+                <p class="edu-card-text">Gold is recognised and tradable worldwide, which can make it a reserve you are able to convert to cash across many countries.</p>
+              </article>
+              <article class="edu-card">
+                <h3 class="edu-card-title">Currency-risk hedge</h3>
+                <p class="edu-card-text">Gold is priced in US dollars globally. If your local currency weakens, gold priced in that currency can rise, offsetting some currency risk — though this is imperfect.</p>
+              </article>
+            </div>
+            <p class="edu-verdict"><strong>These roles are tendencies, not promises.</strong> Gold pays no interest or dividends, and it can underperform other assets for long stretches.</p>
+          </div>
+          <div data-lang-block="ar" lang="ar" dir="rtl">
+            <p class="edu-eyebrow">استراتيجية المحفظة</p>
+            <h2 class="edu-heading" id="gold-role-heading-ar">ما الدور الذي يمكن أن يؤديه الذهب في المحفظة؟</h2>
+            <p class="edu-lede">الذهب أداة واحدة من بين أدوات عديدة. تشرح هذه الصفحة، لأغراض تعليمية فقط، كيف يفكّر بعض الأشخاص في دور الذهب — وهي ليست نصيحة مالية، وكل رقم وارد هنا مثال توضيحي وليس توصية. وأي أسعار تظهر في مواضع أخرى من الموقع هي قيم مرجعية مرتبطة بالسعر الفوري، وليست أسعاراً لحظية.</p>
+            <div class="edu-grid edu-grid--3">
+              <article class="edu-card">
+                <h3 class="edu-card-title">التنويع</h3>
+                <p class="edu-card-text">كثيراً ما يتحرك الذهب بشكل مختلف عن الأسهم والسندات، فقد يخفّف مركز صغير منه من تقلبات المحفظة صعوداً وهبوطاً. وهذا الارتباط المنخفض أو السالب ليس ثابتاً وقد يتغير مع الوقت.</p>
+              </article>
+              <article class="edu-card">
+                <h3 class="edu-card-title">التحوّط من التضخم</h3>
+                <p class="edu-card-text">على المدى الطويل مال الذهب إلى الحفاظ على القوة الشرائية. أما على مدى أشهر أو بضع سنوات فهو تحوّط غير موثوق، وقد ينخفض حتى بينما يرتفع التضخم.</p>
+              </article>
+              <article class="edu-card">
+                <h3 class="edu-card-title">ملاذ في الأزمات</h3>
+                <p class="edu-card-text">في أوقات ضغط الأسواق أو الصدمات الجيوسياسية يتجه بعض المستثمرين إلى الذهب. وسلوك "الملاذ الآمن" هذا ميل لوحظ في الماضي وليس ضماناً.</p>
+              </article>
+              <article class="edu-card">
+                <h3 class="edu-card-title">احتياطي سائل</h3>
+                <p class="edu-card-text">الذهب معروف وقابل للتداول في أنحاء العالم، ما قد يجعله احتياطياً يمكنك تحويله إلى نقد في كثير من الدول.</p>
+              </article>
+              <article class="edu-card">
+                <h3 class="edu-card-title">تحوّط من مخاطر العملة</h3>
+                <p class="edu-card-text">يُسعّر الذهب عالمياً بالدولار الأمريكي. فإذا ضعفت عملتك المحلية، قد يرتفع سعر الذهب مقوّماً بها، ما يعوّض جزءاً من مخاطر العملة — وإن كان ذلك غير كامل.</p>
+              </article>
+            </div>
+            <p class="edu-verdict"><strong>هذه الأدوار ميول لا وعود.</strong> الذهب لا يدفع فائدة ولا أرباحاً، وقد يكون أداؤه أضعف من أصول أخرى لفترات طويلة.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="edu-section" id="allocation-ranges" aria-labelledby="allocation-ranges-heading">
+        <div class="edu-inner">
+          <div data-lang-block="en">
+            <p class="edu-eyebrow">Illustrative only</p>
+            <h2 class="edu-heading" id="allocation-ranges-heading">Illustrative allocation ranges</h2>
+            <p class="edu-lede">The ranges below are illustrative teaching examples showing how different risk appetites might size a gold position. They are <strong>not recommendations</strong>, not tailored to you, and not a suggestion that any of them is "right". A licensed advisor can help with your own situation.</p>
+            <p><span class="edu-chip">Illustrative</span> <span class="edu-chip">Not advice</span> <span class="edu-chip">Examples only</span></p>
+            <div class="edu-grid edu-grid--2">
+              <article class="edu-card">
+                <span class="edu-stat">5–10%</span>
+                <h3 class="edu-card-title">Conservative <span class="edu-tag edu-tag--low">Lower concentration</span></h3>
+                <p class="edu-card-text">A small position for diversification without letting one asset dominate the portfolio.</p>
+              </article>
+              <article class="edu-card">
+                <span class="edu-stat">10–15%</span>
+                <h3 class="edu-card-title">Balanced <span class="edu-tag edu-tag--medium">Moderate concentration</span></h3>
+                <p class="edu-card-text">A moderate weighting for those who want more of the diversification benefit.</p>
+              </article>
+              <article class="edu-card">
+                <span class="edu-stat">15–25%</span>
+                <h3 class="edu-card-title">Defensive / inflation-focused <span class="edu-tag edu-tag--high">Higher concentration</span></h3>
+                <p class="edu-card-text">A larger tilt used by people especially worried about inflation or currency risk — with correspondingly more exposure to gold's swings.</p>
+              </article>
+              <article class="edu-card">
+                <span class="edu-stat">25%+</span>
+                <h3 class="edu-card-title">High-conviction / gold-heavy <span class="edu-tag edu-tag--high">High concentration risk</span></h3>
+                <p class="edu-card-text">Concentrating a large share in gold increases risk: gold has no yield, can fall sharply, and can lag other assets for years. Few diversified plans go this high.</p>
+              </article>
+            </div>
+            <p class="edu-verdict"><strong>A bigger gold weighting is not "safer".</strong> More concentration means more exposure to gold's own downturns and to its lack of income.</p>
+          </div>
+          <div data-lang-block="ar" lang="ar" dir="rtl">
+            <p class="edu-eyebrow">أمثلة توضيحية فقط</p>
+            <h2 class="edu-heading" id="allocation-ranges-heading-ar">نطاقات تخصيص توضيحية</h2>
+            <p class="edu-lede">النطاقات أدناه أمثلة تعليمية توضيحية تبيّن كيف قد يحدد أصحاب درجات المخاطرة المختلفة حجم مركز الذهب. وهي <strong>ليست توصيات</strong>، وليست مفصّلة على وضعك، ولا تعني أن أياً منها هو الخيار "الصحيح". ويمكن لمستشار مرخّص أن يساعدك في ظروفك الخاصة.</p>
+            <p><span class="edu-chip">توضيحية</span> <span class="edu-chip">ليست نصيحة</span> <span class="edu-chip">أمثلة فقط</span></p>
+            <div class="edu-grid edu-grid--2">
+              <article class="edu-card">
+                <span class="edu-stat">5–10%</span>
+                <h3 class="edu-card-title">محافِظ <span class="edu-tag edu-tag--low">تركيز منخفض</span></h3>
+                <p class="edu-card-text">مركز صغير للتنويع دون أن يهيمن أصل واحد على المحفظة.</p>
+              </article>
+              <article class="edu-card">
+                <span class="edu-stat">10–15%</span>
+                <h3 class="edu-card-title">متوازن <span class="edu-tag edu-tag--medium">تركيز معتدل</span></h3>
+                <p class="edu-card-text">وزن متوسط لمن يريد قدراً أكبر من فائدة التنويع.</p>
+              </article>
+              <article class="edu-card">
+                <span class="edu-stat">15–25%</span>
+                <h3 class="edu-card-title">دفاعي / يركّز على التضخم <span class="edu-tag edu-tag--high">تركيز مرتفع</span></h3>
+                <p class="edu-card-text">ميل أكبر يستخدمه من يقلقهم التضخم أو مخاطر العملة بشكل خاص، مع تعرّض أكبر بالمقابل لتقلبات الذهب.</p>
+              </article>
+              <article class="edu-card">
+                <span class="edu-stat">25%+</span>
+                <h3 class="edu-card-title">قناعة عالية / مركّز على الذهب <span class="edu-tag edu-tag--high">مخاطر تركيز عالية</span></h3>
+                <p class="edu-card-text">تركيز حصة كبيرة في الذهب يرفع المخاطر: فالذهب لا يدرّ دخلاً، وقد يهبط بحدّة، وقد يتخلّف عن أصول أخرى لسنوات. وقليل من الخطط المتنوعة يصل إلى هذا الحد.</p>
+              </article>
+            </div>
+            <p class="edu-verdict"><strong>الوزن الأكبر للذهب ليس "أكثر أماناً".</strong> فزيادة التركيز تعني تعرّضاً أكبر لهبوط الذهب نفسه ولافتقاره إلى الدخل.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="edu-section" id="example-portfolios" aria-labelledby="example-portfolios-heading">
+        <div class="edu-inner">
+          <div data-lang-block="en">
+            <p class="edu-eyebrow">Illustrative examples</p>
+            <h2 class="edu-heading" id="example-portfolios-heading">Example portfolios</h2>
+            <p class="edu-lede">The combinations below are illustrative examples to make the idea concrete. They are not recommendations and are not tailored to anyone's circumstances.</p>
+            <div class="edu-table-wrap">
+              <table class="edu-table">
+                <caption class="edu-table-caption">Illustrative example portfolios — not recommendations.</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Profile</th>
+                    <th scope="col">Rough mix</th>
+                    <th scope="col">Why</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Cash + gold</th>
+                    <td>70% cash / 30% gold (illustrative)</td>
+                    <td>A saver who wants some inflation protection on idle cash while keeping most of it liquid.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Stocks + bonds + gold</th>
+                    <td>55% stocks / 35% bonds / 10% gold</td>
+                    <td>A classic diversified mix with a small gold sleeve to cushion down years for stocks and bonds.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Real estate + gold</th>
+                    <td>80% property / 20% gold (of investable assets)</td>
+                    <td>Someone property-heavy adding a liquid, movable asset that isn't tied to one local market.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Business-owner liquidity reserve + gold</th>
+                    <td>Emergency reserve, part held in gold</td>
+                    <td>A business owner keeping a portable, globally saleable reserve outside the business.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Emerging-market currency protection</th>
+                    <td>Local assets + gold as USD-linked ballast</td>
+                    <td>Someone whose salary and savings sit in a weaker local currency, using gold to offset currency risk.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div data-lang-block="ar" lang="ar" dir="rtl">
+            <p class="edu-eyebrow">أمثلة توضيحية</p>
+            <h2 class="edu-heading" id="example-portfolios-heading-ar">نماذج محافظ توضيحية</h2>
+            <p class="edu-lede">التركيبات التالية أمثلة توضيحية لتقريب الفكرة. وهي ليست توصيات وليست مفصّلة على ظروف أحد.</p>
+            <div class="edu-table-wrap">
+              <table class="edu-table">
+                <caption class="edu-table-caption">نماذج محافظ توضيحية — وليست توصيات.</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">الحالة</th>
+                    <th scope="col">مزيج تقريبي</th>
+                    <th scope="col">لماذا</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">نقد + ذهب</th>
+                    <td>70% نقد / 30% ذهب (توضيحي)</td>
+                    <td>مدّخر يريد بعض الحماية من التضخم على النقد الخامل مع إبقاء معظمه سائلاً.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">أسهم + سندات + ذهب</th>
+                    <td>55% أسهم / 35% سندات / 10% ذهب</td>
+                    <td>مزيج متنوّع كلاسيكي مع شريحة ذهب صغيرة لتخفيف سنوات هبوط الأسهم والسندات.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">عقارات + ذهب</th>
+                    <td>80% عقار / 20% ذهب (من الأصول القابلة للاستثمار)</td>
+                    <td>شخص يميل تركّزه نحو العقار فيضيف أصلاً سائلاً وقابلاً للنقل لا يرتبط بسوق محلية واحدة.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">احتياطي سيولة لصاحب عمل + ذهب</th>
+                    <td>احتياطي طوارئ، جزء منه بالذهب</td>
+                    <td>صاحب عمل يحتفظ باحتياطي محمول وقابل للبيع عالمياً خارج نشاطه.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">حماية من عملة سوق ناشئة</th>
+                    <td>أصول محلية + ذهب كموازن مرتبط بالدولار</td>
+                    <td>شخص راتبه ومدّخراته بعملة محلية أضعف، يستخدم الذهب لتعويض مخاطر العملة.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="edu-section" id="rebalancing" aria-labelledby="rebalancing-heading">
+        <div class="edu-inner">
+          <div data-lang-block="en">
+            <p class="edu-eyebrow">Discipline over guesswork</p>
+            <h2 class="edu-heading" id="rebalancing-heading">Rebalancing: keeping your target in check</h2>
+            <p class="edu-lede">Rebalancing means periodically bringing each holding back to its target weight. People commonly do this on a schedule (say once a year) or when a holding drifts past a band (for example ±5 percentage points from target). It removes emotion and can enforce "sell high, buy low" — but it does not guarantee better returns and can trigger costs or taxes.</p>
+            <div class="edu-grid edu-grid--2">
+              <article class="edu-card">
+                <h3 class="edu-card-title">Gold becomes overweight</h3>
+                <p class="edu-card-text">Target 10%. Gold rallies and the position grows to 15% of the portfolio. Rebalancing to target means trimming gold (selling roughly 5%) and topping up what lagged — locking in part of the gain and cutting concentration.</p>
+              </article>
+              <article class="edu-card">
+                <h3 class="edu-card-title">Gold becomes underweight</h3>
+                <p class="edu-card-text">Target 10%. Gold falls and the position shrinks to 6%. Rebalancing means buying gold back up to 10%, funded from what did well — adding at lower prices. There is no guarantee it recovers.</p>
+              </article>
+            </div>
+            <p class="edu-verdict"><strong>Every rebalance can cost money.</strong> Spreads, making charges, fees or taxes add up — rebalance thoughtfully, not constantly.</p>
+          </div>
+          <div data-lang-block="ar" lang="ar" dir="rtl">
+            <p class="edu-eyebrow">انضباط بدل التخمين</p>
+            <h2 class="edu-heading" id="rebalancing-heading-ar">إعادة التوازن: الحفاظ على نسبتك المستهدفة</h2>
+            <p class="edu-lede">تعني إعادة التوازن أن تعيد كل مكوّن دورياً إلى وزنه المستهدف. ويقوم بها كثيرون وفق جدول زمني (مثلاً مرة سنوياً) أو عندما ينحرف المكوّن عن نطاق محدد (مثلاً ±5 نقاط مئوية عن الهدف). وهي تزيل الانفعال وقد تفرض مبدأ "البيع عند الارتفاع والشراء عند الانخفاض" — لكنها لا تضمن عائداً أفضل وقد تترتب عليها تكاليف أو ضرائب.</p>
+            <div class="edu-grid edu-grid--2">
+              <article class="edu-card">
+                <h3 class="edu-card-title">عندما يصبح وزن الذهب زائداً</h3>
+                <p class="edu-card-text">الهدف 10%. يرتفع الذهب فيتضخم المركز إلى 15% من المحفظة. تعني إعادة التوازن إلى الهدف تقليم الذهب (بيع نحو 5%) وتعزيز ما تخلّف — فتثبّت جزءاً من المكسب وتقلّل التركيز.</p>
+              </article>
+              <article class="edu-card">
+                <h3 class="edu-card-title">عندما يصبح وزن الذهب ناقصاً</h3>
+                <p class="edu-card-text">الهدف 10%. يهبط الذهب فينكمش المركز إلى 6%. تعني إعادة التوازن شراء ذهب حتى العودة إلى 10%، بتمويل مما ارتفع — فتضيف عند أسعار أدنى. ولا ضمان لتعافيه.</p>
+              </article>
+            </div>
+            <p class="edu-verdict"><strong>كل عملية إعادة توازن قد تكلّف مالاً.</strong> فروق الأسعار والمصنعية والرسوم أو الضرائب تتراكم — أعد التوازن بتروٍّ لا باستمرار.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="edu-section" id="physical-vs-etf" aria-labelledby="physical-vs-etf-heading">
+        <div class="edu-inner">
+          <div data-lang-block="en">
+            <p class="edu-eyebrow">Two ways to hold</p>
+            <h2 class="edu-heading" id="physical-vs-etf-heading">Physical gold vs gold ETFs for allocation</h2>
+            <p class="edu-lede">The two hold quite differently. ETF availability, taxes and rules vary by country, and none of this is a recommendation — just a comparison to help you understand the trade-offs.</p>
+            <div class="edu-table-wrap">
+              <table class="edu-table">
+                <caption class="edu-table-caption">Illustrative comparison — ETF availability, taxes and rules vary by country; not a recommendation.</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Factor</th>
+                    <th scope="col">Physical gold</th>
+                    <th scope="col">Gold ETF (spot-linked)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Accessibility</th>
+                    <td>Bought at shops or dealers; you hold it yourself.</td>
+                    <td>Bought through a brokerage account; availability and rules vary by country.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Storage &amp; security</th>
+                    <td>You arrange the safe or vault; theft and insurance are your responsibility.</td>
+                    <td>No personal storage; a custodian holds the metal on your behalf.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Costs</th>
+                    <td>Making charge and dealer spread on buy and sell; possibly storage and insurance.</td>
+                    <td>Annual expense ratio plus brokerage/trading costs; no making charge.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Liquidity</th>
+                    <td>Widely sellable, but price and spread vary by shop and hallmark.</td>
+                    <td>Usually quick to trade during market hours at spot-linked prices.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Emergency usefulness</th>
+                    <td>Usable hand-to-hand in a crisis or where banking is disrupted.</td>
+                    <td>Depends on functioning markets and brokers; not physical in your hand.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div data-lang-block="ar" lang="ar" dir="rtl">
+            <p class="edu-eyebrow">طريقتان للاقتناء</p>
+            <h2 class="edu-heading" id="physical-vs-etf-heading-ar">الذهب المادي مقابل صناديق الذهب المتداولة للتخصيص</h2>
+            <p class="edu-lede">تختلف الطريقتان اختلافاً كبيراً في الاقتناء. ويتباين توفّر الصناديق المتداولة وضرائبها وأحكامها من دولة إلى أخرى، ولا شيء من هذا توصية — بل مقارنة تساعدك على فهم الموازنات.</p>
+            <div class="edu-table-wrap">
+              <table class="edu-table">
+                <caption class="edu-table-caption">مقارنة توضيحية — يختلف توفّر الصناديق والضرائب والأحكام حسب الدولة، وهذا ليس توصية.</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">العامل</th>
+                    <th scope="col">ذهب مادي</th>
+                    <th scope="col">صندوق ذهب متداول (مرتبط بالسعر الفوري)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">سهولة الوصول</th>
+                    <td>يُشترى من المحلات أو التجار وتحتفظ به بنفسك.</td>
+                    <td>يُشترى عبر حساب وساطة، ويختلف توفّره وقواعده حسب الدولة.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">التخزين والأمان</th>
+                    <td>أنت من يرتّب الخزنة أو القبو، والسرقة والتأمين مسؤوليتك.</td>
+                    <td>لا تخزين شخصي؛ تحتفظ جهة الحفظ بالمعدن نيابةً عنك.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">التكاليف</th>
+                    <td>مصنعية وفارق سعر التاجر عند البيع والشراء، وربما تخزين وتأمين.</td>
+                    <td>نسبة مصاريف سنوية إضافة إلى رسوم الوساطة والتداول، دون مصنعية.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">السيولة</th>
+                    <td>قابل للبيع على نطاق واسع، لكن السعر والفارق يختلفان حسب المحل والدمغة.</td>
+                    <td>عادةً سريع التداول خلال ساعات السوق بأسعار مرتبطة بالسعر الفوري.</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">الفائدة في الطوارئ</th>
+                    <td>قابل للاستخدام يداً بيد في الأزمات أو حيث تتعطل الخدمات المصرفية.</td>
+                    <td>يعتمد على أسواق ووسطاء يعملون؛ وليس مادياً في يدك.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="edu-section" id="risk-warnings" aria-labelledby="risk-warnings-heading">
+        <div class="edu-inner">
+          <div data-lang-block="en">
+            <p class="edu-eyebrow">Read this carefully</p>
+            <h2 class="edu-heading" id="risk-warnings-heading">Risk warnings</h2>
+            <p class="edu-lede">Before treating gold as part of any plan, weigh these honestly.</p>
+            <article class="edu-card">
+              <h3 class="edu-card-title">What gold will not do for you</h3>
+              <ul class="edu-list">
+                <li><strong>Generates no income</strong> — no interest, dividends or rent; your entire return depends on the price.</li>
+                <li><strong>Can underperform for years</strong> — gold has had long flat or falling stretches versus stocks.</li>
+                <li><strong>Costs money to own</strong> — making charges, dealer spreads, ETF fees, storage and insurance all reduce returns.</li>
+                <li><strong>Is volatile short-term</strong> — prices can swing sharply from week to week.</li>
+                <li><strong>Past performance ≠ future results</strong> — history is not a promise.</li>
+              </ul>
+            </article>
+            <p class="edu-verdict"><strong>If you need regular income or a short holding period, gold may be a poor fit.</strong> Match any holding to your own timeline and needs.</p>
+          </div>
+          <div data-lang-block="ar" lang="ar" dir="rtl">
+            <p class="edu-eyebrow">اقرأ هذا بعناية</p>
+            <h2 class="edu-heading" id="risk-warnings-heading-ar">تحذيرات المخاطر</h2>
+            <p class="edu-lede">قبل اعتبار الذهب جزءاً من أي خطة، وازن هذه النقاط بصدق.</p>
+            <article class="edu-card">
+              <h3 class="edu-card-title">ما الذي لن يفعله الذهب لك</h3>
+              <ul class="edu-list">
+                <li><strong>لا يدرّ دخلاً</strong> — لا فوائد ولا أرباحاً ولا إيجاراً؛ فعائدك كله يعتمد على السعر.</li>
+                <li><strong>قد يضعف أداؤه لسنوات</strong> — مرّ الذهب بفترات طويلة راكدة أو هابطة مقابل الأسهم.</li>
+                <li><strong>امتلاكه مكلف</strong> — المصنعية وفروق التجار ورسوم الصناديق والتخزين والتأمين تقلّل العائد.</li>
+                <li><strong>متقلّب على المدى القصير</strong> — قد يتأرجح السعر بحدّة من أسبوع لآخر.</li>
+                <li><strong>الأداء السابق لا يعادل النتائج المستقبلية</strong> — التاريخ ليس وعداً.</li>
+              </ul>
+            </article>
+            <p class="edu-verdict"><strong>إن كنت تحتاج دخلاً منتظماً أو أفقاً زمنياً قصيراً، فقد لا يناسبك الذهب.</strong> طابِق أي اقتناء مع أفقك الزمني واحتياجاتك.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="edu-section" id="how-to-use" aria-labelledby="how-to-use-heading">
+        <div class="edu-inner">
+          <div data-lang-block="en">
+            <p class="edu-eyebrow">Putting it together</p>
+            <h2 class="edu-heading" id="how-to-use-heading">How to use this page</h2>
+            <p class="edu-lede">Treat everything above as a way to learn the questions to ask — not as a plan handed to you.</p>
+            <div class="edu-grid edu-grid--2">
+              <article class="edu-card">
+                <h3 class="edu-card-title">How to use this</h3>
+                <ul class="edu-list">
+                  <li>Treat every number here as an illustrative example, not a target for you.</li>
+                  <li>Start from your goals, timeline, income needs and risk tolerance — then decide whether gold fits at all.</li>
+                  <li>Weigh the costs and how you would hold it (physical vs ETF).</li>
+                  <li>For decisions about your own money, consult a licensed financial advisor.</li>
+                </ul>
+              </article>
+              <article class="edu-card">
+                <h3 class="edu-card-title">Next steps</h3>
+                <ul class="edu-list">
+                  <li><a href="/compare.html">Compare gold with other assets</a></li>
+                  <li><a href="/calculator.html">Value your gold holdings</a></li>
+                  <li><a href="/learn.html">Read the gold guides</a></li>
+                </ul>
+              </article>
+            </div>
+            <p class="edu-disclaimer">This page is educational only and is not financial, investment, tax or legal advice. All allocations, portfolios and figures are illustrative examples, not recommendations, and are not tailored to your circumstances. Gold carries risk, pays no income, and can lose value. Any prices referenced across this site are spot-linked reference values, not live quotes. For decisions about your own money, consult a licensed professional.</p>
+          </div>
+          <div data-lang-block="ar" lang="ar" dir="rtl">
+            <p class="edu-eyebrow">الخلاصة العملية</p>
+            <h2 class="edu-heading" id="how-to-use-heading-ar">كيف تستفيد من هذه الصفحة</h2>
+            <p class="edu-lede">اعتبر كل ما سبق وسيلة لتتعلّم الأسئلة التي ينبغي طرحها — لا خطة تُسلَّم إليك.</p>
+            <div class="edu-grid edu-grid--2">
+              <article class="edu-card">
+                <h3 class="edu-card-title">كيف تستخدمها</h3>
+                <ul class="edu-list">
+                  <li>اعتبر كل رقم هنا مثالاً توضيحياً لا هدفاً لك.</li>
+                  <li>ابدأ من أهدافك وأفقك الزمني وحاجتك للدخل وقدرتك على تحمّل المخاطر — ثم قرّر إن كان الذهب يناسبك أصلاً.</li>
+                  <li>راعِ التكاليف وطريقة الاقتناء (مادي أم صندوق متداول).</li>
+                  <li>لاتخاذ قرارات تخص أموالك، استشر مستشاراً مالياً مرخّصاً.</li>
+                </ul>
+              </article>
+              <article class="edu-card">
+                <h3 class="edu-card-title">خطوات تالية</h3>
+                <ul class="edu-list">
+                  <li><a href="/compare.html">قارن الذهب بأصول أخرى</a></li>
+                  <li><a href="/calculator.html">قيّم ما تملكه من ذهب</a></li>
+                  <li><a href="/learn.html">اقرأ أدلة الذهب</a></li>
+                </ul>
+              </article>
+            </div>
+            <p class="edu-disclaimer">هذه الصفحة تعليمية فقط وليست نصيحة مالية أو استثمارية أو ضريبية أو قانونية. جميع نسب التخصيص والمحافظ والأرقام أمثلة توضيحية وليست توصيات، وليست مفصّلة على ظروفك. الذهب ينطوي على مخاطر، ولا يدرّ دخلاً، وقد يفقد من قيمته. وأي أسعار مشار إليها عبر الموقع هي قيم مرجعية مرتبطة بالسعر الفوري وليست أسعاراً لحظية. ولاتخاذ قرارات تخص أموالك، استشر مختصاً مرخّصاً.</p>
+          </div>
+        </div>
       </section>
 
       <p class="portfolio-disclaimer" id="portfolio-disclaimer">

--- a/reports/seo/governance.json
+++ b/reports/seo/governance.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-07-04T20:40:32.727Z",
+  "generatedAt": "2026-07-04T20:44:26.488Z",
   "summary": {
     "groups": {
       "core": 45,
@@ -471,7 +471,7 @@
         "ar"
       ],
       "hasSchema": true,
-      "wordCount": 187,
+      "wordCount": 2482,
       "thinRisk": false,
       "missingCanonical": false,
       "missingHreflang": false,


### PR DESCRIPTION
## Summary

Makes `portfolio.html` genuinely useful. Below the existing **private local holdings tracker** (untouched), adds a rich, bilingual **portfolio-strategy education hub** using the shared `edu` system.

## Content added
- **What role gold can play** — diversification, inflation hedge, crisis hedge, liquidity reserve, currency-risk hedge, with an explicit *"tendencies, not promises"* callout.
- **Illustrative allocation ranges** — 5–10% / 10–15% / 15–25% / 25%+, clearly labelled examples (not advice), each with a concentration-risk tag.
- **Example portfolios** table (cash+gold, stocks+bonds+gold, real estate+gold, business liquidity reserve, EM currency protection).
- **Rebalancing** — what it is + worked overweight/underweight examples.
- **Physical gold vs ETFs** for allocation.
- **Risk warnings** — gold pays no income, can underperform for years, spreads/storage cost money, short-term volatility.
- Next-steps links to Compare / Calculator / Learn.

## Trust
Repeatedly framed as **educational, illustrative, not financial advice**; prices are spot-linked reference, never "live". Static-first + bilingual (zero-JS `data-lang-block` twins), so the page is never blank.

## Stacking / merge order
**Stacked on #497** (base = `feat/compare-education`) because it uses the shared `edu.css` introduced there. Merge **after #497**. GitHub will retarget this to `main` once #497 merges. Full order is in the session summary.

## Verification
`npm run validate` green; portfolio content ~22K chars; nav 27 links; no console errors; verified desktop + mobile + AR toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static HTML/CSS only; no changes to holdings logic, APIs, or auth. Allocation examples are illustrative with repeated disclaimers, though financial-education copy still warrants editorial review.
> 
> **Overview**
> Adds a shared **`edu-*` presentation layer** via new `styles/components/edu.css` (bilingual `data-lang-block` EN/AR toggle without JS, cards, tables, disclaimers) and wires it into **`compare.html`** and **`portfolio.html`**.
> 
> **`compare.html`** gains a large static “gold vs other assets” hub (silver, Bitcoin, cash, stocks, real estate, physical vs ETFs, karat comparison, usage guidance), which materially increases on-page copy and clears the prior SEO **thin-content** flag.
> 
> **`portfolio.html`** appends a portfolio-strategy education block below the existing local tracker (gold’s role, illustrative allocation bands, example mixes, rebalancing, physical vs ETF, risk warnings, next-step links), all framed as educational—not advice.
> 
> **`reports/seo/governance.json`** is regenerated with updated word counts and **`thinRiskPages: 0`** for `compare.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a114bcf5734fd662744ed8d58da2c3df7e7c3f20. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->