### PR TITLE
fix(shops): render ampersand correctly in listings stat label

### DIFF
--- a/src/pages/shops.js
+++ b/src/pages/shops.js
@@ -101,7 +101,7 @@ const TXT = {
     directoryReviewed: 'Directory last reviewed {date}',
     featuredNote:
       'Featured: editorially selected markets for this region. Not a paid placement and not an endorsement of any individual shop inside the market.',
-    statListings: 'Shops &amp; markets',
+    statListings: 'Shops & markets',
     statCountries: 'Countries',
     statRegions: 'Regions',
     popularMarkets: 'Popular markets',


### PR DESCRIPTION
## What

Fixes a small but visible rendering bug on **shops.html**: the "Shops & markets" stat label rendered literally as **`Shops &amp; markets`** on the page.

## Root cause

The English label was authored as the HTML-entity string `'Shops &amp; markets'` in the shops `TXT` dictionary (`src/pages/shops.js`), but the label is applied to the DOM via **`textContent`** (`shops.js:1052`), which does not decode entities — so `&amp;` showed up verbatim. Changed it to a plain ampersand. The Arabic label (`محلات وأسواق`) was already correct.

## Context — audit of the wider "polish" batch

While here I audited the pages the owner grouped for a polish pass (home, tracker, shops, calculator, methodology). **home, tracker, methodology and calculator are already production-quality** — premium design, exhaustive honest freshness/provenance framing, no broken UI — so I've deliberately not churned them. On **shops** this ampersand was the one genuine visible defect. I also swept `src/**/*.js` for other double-encoded entities applied via `textContent`; this was the only real one (the other `&amp;` hits are legitimate HTML-escaping utilities in `safe-dom.js` / `nav.js`).

## Verification
- `eslint` — clean
- `i18n-local-dict-parity` test — green (7/7)
- `npm run build` — succeeds
- Playwright render check — EN now shows **"Shops & markets"**, AR shows **"محلات وأسواق"**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single English i18n string change with no logic, API, or security impact.
> 
> **Overview**
> Fixes a visible copy bug on the shops page hero stats: the English **listings** stat label showed **`Shops &amp; markets`** instead of **Shops & markets**.
> 
> The English `statListings` string in `src/pages/shops.js` used the HTML entity `&amp;`, but `applyStaticText()` assigns labels with **`textContent`**, which does not decode entities. The change replaces the entity with a plain **`&`** in that dictionary entry only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 029b994d0292c0c695f6af8124f92822b8f1b224. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->