### PR TITLE
fix(admin): stop auth-method tab labels clipping on the login screen

### DIFF
--- a/admin/login/index.html
+++ b/admin/login/index.html
@@ -392,18 +392,23 @@
 
       /* ── Tabs & forms ───────────────────────────────────── */
       .tab-list {
-        display: grid;
-        grid-template-columns: repeat(5, minmax(0, 1fr));
+        display: flex;
+        flex-wrap: wrap;
         gap: 6px;
         margin-bottom: 16px;
       }
       .tab-btn {
+        flex: 1 1 0;
+        min-width: max-content;
+        text-align: center;
+        white-space: nowrap;
         background: var(--surface-2);
         border: 1px solid var(--border);
         border-radius: var(--radius-sm);
         color: var(--text-muted);
         cursor: pointer;
-        padding: 10px 8px;
+        padding: 10px 10px;
+        font-size: 13px;
         font-weight: 600;
         transition:
           border-color 0.2s,


### PR DESCRIPTION
## What

Fixes a visible layout defect on the **admin login screen** (`/admin/login/`): the sign-in method tab strip clipped its longer labels — **"Password" rendered as "Passwo"** and **"Phone OTP" wrapped awkwardly** mid-control.

## Root cause & fix

The tab strip used a fixed 5-column grid (`repeat(5, minmax(0, 1fr))`) inside the narrow login card — too tight for the longer labels. Switched to a **wrapping flex row of content-sized buttons**:

```css
.tab-list { display: flex; flex-wrap: wrap; gap: 6px; }
.tab-btn  { flex: 1 1 0; min-width: max-content; white-space: nowrap; font-size: 13px; }
```

Every label now renders in full, and the strip wraps cleanly to a second row (3 + 2) when the row can't hold all five. `min-width: max-content` guarantees no clipping regardless of label length or language (robust for Arabic too).

**Before:** `OAuth · Magic link · Passwo · Phone OTP(wrapped) · MFA`
**After:** `OAuth · Magic link · Password` / `Phone OTP · MFA` — all intact.

## Scope note

The login screen is the **only** admin surface renderable without Supabase credentials, so this focused fix is fully verified end-to-end. The authenticated dashboards (settings, pricing, orders, etc.) need real admin access to render and iterate on safely — happy to polish those next if you can share access or screenshots.

## Verification
- `admin-static` import-resolution test — green (2/2)
- Playwright render of `/admin/login/` — confirmed no clipped labels, active-tab styling intact
- CSS-only change in the login page's own `<style>` block; does not touch shared `admin.css` or any authenticated flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Login-page layout CSS only; no auth, API, or shared stylesheet changes.
> 
> **Overview**
> Fixes clipped and awkwardly wrapped labels on the admin login **sign-in method** tab strip inside the narrow login card.
> 
> **`.tab-list`** no longer uses a fixed five-column grid (`repeat(5, minmax(0, 1fr))`). It is now a **wrapping flex row** with `gap: 6px`. **`.tab-btn`** uses `flex: 1 1 0`, `min-width: max-content`, `white-space: nowrap`, centered text, slightly wider padding (`10px`), and `font-size: 13px` so labels like **Password** and **Phone OTP** render in full and the row can wrap (e.g. 3 + 2) instead of truncating.
> 
> CSS-only change in `admin/login/index.html`; shared `admin.css` and auth logic are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74cab08fae7fa6c17c4a679dcbc43ad8a34ae830. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->