### PR TITLE
fix(a11y): legal-page body links meet WCAG AA contrast

### DIFF
--- a/styles/pages/terms.css
+++ b/styles/pages/terms.css
@@ -160,7 +160,10 @@
 }
 
 .legal-section a {
-  color: var(--color-gold);
+  /* --color-gold (#b07d1f) is a value-signal accent only and fails WCAG AA
+     (~3.5:1) as small text on the light legal surface. Use the AA-locked,
+     theme-aware text gold (matches the site-wide `a` default in base.css). */
+  color: var(--color-gold-dark);
   text-decoration: underline;
   text-underline-offset: 2px;
 }


### PR DESCRIPTION
## Problem found
Every inline link in the **terms.html** and **privacy.html** body copy (`.legal-section a`) rendered in `--color-gold` (#b07d1f), which is only **~3.62:1 on white** and **~3.50:1 on the parchment legal surface** — below the WCAG 2.1 **1.4.3** AA minimum of 4.5:1 for normal-size text. This is the resting color, on many links (9 in terms, 10 in privacy), and was **ungated** (the a11y contrast gate checks `--color-gold-dark`/`--text-accent` but not `--color-gold`).

## Root cause
`--color-gold` is documented in `tokens.css` as *"value signal only, never small text."* The legal stylesheet used it for body links anyway.

## What changed
`.legal-section a` now uses `--color-gold-dark` — the AA-locked, **theme-aware** text gold that is already the site-wide `<a>` default (`base.css`).

## Contrast (computed)
| | on white | on parchment #fdfbf5 | dark theme |
| --- | --- | --- | --- |
| **before** `--color-gold` #b07d1f | 3.62:1 ❌ | 3.50:1 ❌ | — |
| **after** `--color-gold-dark` | 6.32:1 ✅ | 6.10:1 ✅ | 6.62:1 ✅ (#c4902e on #0f1118) |

## Pages affected
`terms.html`, `privacy.html` (both load `terms.css`).

## Verification
- `stylelint` — clean
- Contrast ratios computed for both themes (table above) — all pass AA.

## Risk
Very low — single CSS declaration; new value matches the global link color and is already theme-token-managed.

## Follow-up (captured in the master plan, P1-3)
Other small-text uses of `--color-gold` (`.eyebrow--gold`/`.kicker--gold` in base.css, an insights label) should be audited **per-surface** and moved behind a lint gate — deferred here to avoid dark-surface regressions from a blanket swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS color declaration on legal pages only; aligns with existing global link token with no auth or data impact.
> 
> **Overview**
> Inline links in **terms** and **privacy** body copy (`.legal-section a`) no longer use `--color-gold`, which failed WCAG 2.1 AA (~3.5:1) on the light legal surface.
> 
> They now use **`--color-gold-dark`**, the same theme-aware text gold as the site-wide default in `base.css`, bringing contrast above 4.5:1 on white, parchment, and dark theme. A short comment in `terms.css` documents why the accent token is not used for small text links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1c42de96860b177828fdc7bffa1cdf87435a747. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->