### PR TITLE
fix(reliability): sitewide fail-open reveal hardening

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="/assets/analytics.js" defer></script>

--- a/calculator.html
+++ b/calculator.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="assets/analytics.js" defer></script>

--- a/compare.html
+++ b/compare.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="assets/analytics.js" defer></script>

--- a/heatmap.html
+++ b/heatmap.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="assets/analytics.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="assets/analytics.js" defer></script>

--- a/learn.html
+++ b/learn.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="assets/analytics.js" defer></script>

--- a/methodology.html
+++ b/methodology.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="assets/analytics.js" defer></script>

--- a/offline.html
+++ b/offline.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="/assets/analytics.js" defer></script>

--- a/portfolio.html
+++ b/portfolio.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="assets/analytics.js" defer></script>

--- a/privacy.html
+++ b/privacy.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="assets/analytics.js" defer></script>

--- a/scripts/node/generate-internal-index-stubs.js
+++ b/scripts/node/generate-internal-index-stubs.js
@@ -25,6 +25,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const { SNIPPET: THEME_PREINIT } = require('./inject-theme-preinit.js');
+
 const ROOT = path.resolve(__dirname, '../..');
 const CHECK = process.argv.includes('--check');
 
@@ -69,24 +71,7 @@ function renderStub(dir) {
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
-    <script>
-      (function () {
-        try {
-          var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
-          var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
-          var resolved =
-            mode === 'light' || mode === 'dark'
-              ? mode
-              : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-                ? 'dark'
-                : 'light';
-          var el = document.documentElement;
-          el.setAttribute('data-theme', resolved);
-          el.setAttribute('data-theme-mode', mode);
-        } catch (e) {}
-      })();
-    </script>
+${THEME_PREINIT}
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />

--- a/scripts/node/inject-theme-preinit.js
+++ b/scripts/node/inject-theme-preinit.js
@@ -30,10 +30,19 @@ const CHECK = process.argv.includes('--check');
 const THEME_MARKER = 'gtl-theme-preinit';
 
 // 4-space indented to match the existing <head> child indentation in these pages.
+// Besides the theme (mirrors src/components/nav.js) this render-blocking snippet:
+//   1. adds `.js` to <html> before first paint, which is what arms the
+//      `[data-reveal]{opacity:0}` hide — CSS fails open to visible without it,
+//      so a JS-disabled visitor never sees blank sections; and
+//   2. installs an inline reveal fail-safe (chunk-independent, so it survives a
+//      stale/404 hashed chunk) that reveals any on-screen [data-reveal] element
+//      the reveal module never got to. The module still owns the scroll animation.
 const SNIPPET = [
-  '    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->',
+  '    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->',
   '    <script>',
   '      (function () {',
+  '        var el = document.documentElement;',
+  "        el.classList.add('js');",
   '        try {',
   "          var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');",
   "          var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';",
@@ -43,13 +52,29 @@ const SNIPPET = [
   "              : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches",
   "                ? 'dark'",
   "                : 'light';",
-  '          var el = document.documentElement;',
   "          el.setAttribute('data-theme', resolved);",
   "          el.setAttribute('data-theme-mode', mode);",
   '        } catch (e) {}',
+  '        window.addEventListener(',
+  "          'load',",
+  '          function () {',
+  '            setTimeout(function () {',
+  '              var vh = window.innerHeight || 0;',
+  "              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');",
+  '              for (var i = 0; i < nodes.length; i++) {',
+  '                var r = nodes[i].getBoundingClientRect();',
+  "                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');",
+  '              }',
+  '            }, 900);',
+  '          }',
+  '        );',
   '      })();',
   '    </script>',
 ].join('\n');
+
+// Matches an already-injected snippet (any version) from its marker comment
+// through the closing </script>, so an out-of-date snippet can be replaced.
+const SNIPPET_RE = /[ \t]*<!-- gtl-theme-preinit:[\s\S]*?<\/script>/;
 
 // Directories whose HTML should NOT get the public-site theme preinit.
 const EXCLUDE_DIRS = new Set([
@@ -93,51 +118,84 @@ function inject(html) {
   return null; // no <head> — skip (fragment / partial)
 }
 
-const files = walk(ROOT).filter((f) => {
-  const rel = path.relative(ROOT, f).replace(/\\/g, '/');
-  return !EXCLUDE_FRAGMENTS.some((frag) => rel.includes(frag));
-});
+// Single source of truth for the preinit snippet so generators (e.g.
+// generate-internal-index-stubs.js) stamp the identical block and never drift.
+module.exports = { SNIPPET, THEME_MARKER, SNIPPET_RE, inject };
 
-let changed = 0;
-let already = 0;
-let skipped = 0;
-const missing = [];
+if (require.main === module) {
+  main();
+}
 
-for (const file of files) {
-  const html = fs.readFileSync(file, 'utf8');
-  if (!/<head[^>]*>/i.test(html)) {
-    skipped += 1;
-    continue; // not a full document
+function main() {
+  const files = walk(ROOT).filter((f) => {
+    const rel = path.relative(ROOT, f).replace(/\\/g, '/');
+    return !EXCLUDE_FRAGMENTS.some((frag) => rel.includes(frag));
+  });
+
+  let changed = 0;
+  let already = 0;
+  let skipped = 0;
+  const missing = [];
+  const outdated = [];
+
+  for (const file of files) {
+    const html = fs.readFileSync(file, 'utf8');
+    if (!/<head[^>]*>/i.test(html)) {
+      skipped += 1;
+      continue; // not a full document
+    }
+    if (html.includes(THEME_MARKER)) {
+      // Marker present — make sure the snippet is the current version, replacing a
+      // stale one so snippet changes (e.g. the reveal fail-safe) propagate to every
+      // page. If the block can't be located we leave the page untouched.
+      const current = html.match(SNIPPET_RE);
+      if (!current || current[0].trim() === SNIPPET.trim()) {
+        already += 1;
+        continue;
+      }
+      if (CHECK) {
+        outdated.push(path.relative(ROOT, file));
+        continue;
+      }
+      fs.writeFileSync(file, html.replace(SNIPPET_RE, SNIPPET));
+      changed += 1;
+      continue;
+    }
+    if (CHECK) {
+      missing.push(path.relative(ROOT, file));
+      continue;
+    }
+    const out = inject(html);
+    if (out == null) {
+      skipped += 1;
+      continue;
+    }
+    fs.writeFileSync(file, out);
+    changed += 1;
   }
-  if (html.includes(THEME_MARKER)) {
-    already += 1;
-    continue;
-  }
+
   if (CHECK) {
-    missing.push(path.relative(ROOT, file));
-    continue;
+    if (missing.length || outdated.length) {
+      if (missing.length) {
+        console.error(`  ❌  ${missing.length} HTML page(s) missing the theme preinit script:`);
+        for (const m of missing.slice(0, 25)) console.error(`        ${m}`);
+        if (missing.length > 25) console.error(`        … and ${missing.length - 25} more`);
+      }
+      if (outdated.length) {
+        console.error(
+          `  ❌  ${outdated.length} HTML page(s) have an out-of-date theme preinit script:`
+        );
+        for (const m of outdated.slice(0, 25)) console.error(`        ${m}`);
+        if (outdated.length > 25) console.error(`        … and ${outdated.length - 25} more`);
+      }
+      console.error('      Run: node scripts/node/inject-theme-preinit.js');
+      process.exit(1);
+    }
+    console.log(`  ✅  All ${already} document(s) have the current theme preinit script.`);
+    process.exit(0);
   }
-  const out = inject(html);
-  if (out == null) {
-    skipped += 1;
-    continue;
-  }
-  fs.writeFileSync(file, out);
-  changed += 1;
-}
 
-if (CHECK) {
-  if (missing.length) {
-    console.error(`  ❌  ${missing.length} HTML page(s) missing the theme preinit script:`);
-    for (const m of missing.slice(0, 25)) console.error(`        ${m}`);
-    if (missing.length > 25) console.error(`        … and ${missing.length - 25} more`);
-    console.error('      Run: node scripts/node/inject-theme-preinit.js');
-    process.exit(1);
-  }
-  console.log(`  ✅  All ${already} document(s) have the theme preinit script.`);
-  process.exit(0);
+  console.log(
+    `  ✅  theme preinit: ${changed} injected, ${already} already present, ${skipped} skipped (no <head>).`
+  );
 }
-
-console.log(
-  `  ✅  theme preinit: ${changed} injected, ${already} already present, ${skipped} skipped (no <head>).`
-);

--- a/shops.html
+++ b/shops.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="assets/analytics.js" defer></script>

--- a/styles/partials/utilities.css
+++ b/styles/partials/utilities.css
@@ -1427,6 +1427,17 @@ textarea:focus,
   will-change: opacity, transform;
 }
 
+/* Fail-open: the hide above only applies once JS has confirmed it can run — the
+   theme-preinit inline script adds `.js` to <html> before first paint. If
+   JavaScript is disabled (or never boots), `.js` is absent and every
+   [data-reveal] element renders fully visible instead of stranded at opacity:0.
+   Scoped via `:root:not(.js)` so it disappears the moment JS is present and can
+   never fight `.is-in-view` (which only exists while JS is running). */
+:root:not(.js) [data-reveal] {
+  opacity: 1;
+  transform: none;
+}
+
 [data-reveal][data-reveal-delay='1'] {
   transition-delay: 60ms;
 }

--- a/terms.html
+++ b/terms.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="assets/analytics.js" defer></script>

--- a/tests/reveal-fail-open.test.js
+++ b/tests/reveal-fail-open.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * Guards the [data-reveal] "fail-open" invariant.
+ *
+ * Background: `[data-reveal]{opacity:0}` hides sections until JS adds
+ * `.is-in-view`. If JS is disabled, never boots, or a hashed chunk 404s, that
+ * hide must NOT strand content invisible — this is the exact class of bug that
+ * blanked the Learn hub ("Read 0 of 9 featured guides" over an empty grid) and
+ * threatened the homepage hero. These tests fail loudly if the fail-open path
+ * is ever removed.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+const utilities = read('styles/partials/utilities.css');
+
+test('utilities.css keeps the [data-reveal] hidden resting state (animation intact)', () => {
+  assert.match(utilities, /\[data-reveal\]\s*\{[^}]*opacity:\s*0/);
+});
+
+test('utilities.css fails open: :root:not(.js) [data-reveal] is visible', () => {
+  // Without the `.js` class (JS disabled / never ran) reveal content must render.
+  assert.match(
+    utilities,
+    /:root:not\(\.js\)\s+\[data-reveal\]\s*\{[^}]*opacity:\s*1/,
+    'Missing the :root:not(.js) [data-reveal] fail-open rule — JS-disabled visitors would see blank sections.'
+  );
+});
+
+// Pages that actually use the reveal animation must carry the preinit that arms
+// the hide (`.js`) AND the chunk-independent inline reveal fail-safe.
+for (const page of ['index.html', 'tracker.html', 'learn.html']) {
+  test(`${page}: theme-preinit arms .js and ships the reveal fail-safe`, () => {
+    const html = read(page);
+    assert.ok(html.includes('gtl-theme-preinit'), `${page} missing the theme-preinit block`);
+    assert.match(html, /classList\.add\('js'\)/, `${page} preinit does not add the .js class`);
+    // The inline fail-safe reveals on-screen [data-reveal] nodes if the module dies.
+    assert.match(
+      html,
+      /\[data-reveal\]:not\(\.is-in-view\)/,
+      `${page} preinit is missing the inline reveal fail-safe`
+    );
+  });
+}

--- a/tracker.html
+++ b/tracker.html
@@ -2,9 +2,11 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <!-- gtl-theme-preinit: set theme before first paint to avoid a flash (mirrors src/components/nav.js) -->
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
     <script>
       (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
         try {
           var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
           var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
@@ -14,10 +16,22 @@
               : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
-          var el = document.documentElement;
           el.setAttribute('data-theme', resolved);
           el.setAttribute('data-theme-mode', mode);
         } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
       })();
     </script>
     <script src="assets/analytics.js" defer></script>


### PR DESCRIPTION
## Problem
`[data-reveal]` hides sections at `opacity:0` until JS adds `.is-in-view`. If JS is disabled, never boots, or a hashed chunk 404s after deploy, that hide **strands content invisible** — the exact bug that blanked the Learn hub (fixed in #506) and still threatened **index.html's hero (16 `[data-reveal]` sections)** and **tracker.html (3)** (per the audit / PR #507).

## Root cause
The reveal system fails **closed**: the resting state is invisible and depends entirely on JS to reveal. Nothing shows the content if the reveal path doesn't run.

## Fix — fail *open*, no flash, CSP-safe, animation intact
1. **CSS fail-open** (`utilities.css`): `:root:not(.js) [data-reveal] { opacity:1; transform:none }`. The base hide now only applies once the theme-preinit adds `.js` to `<html>` before first paint, so a JS-disabled/never-booted visitor always sees content. Scoped via `:root:not(.js)` to avoid any specificity fight with `.is-in-view` or the reduced-motion reset.
2. **Chunk-independent fail-safe**: the existing render-blocking theme-preinit inline script now (a) adds `.js` and (b) on `load`+900ms reveals any **on-screen** `[data-reveal]` the reveal module never got to. Being inline, it survives a stale/404 chunk. Below-fold sections keep their scroll-reveal.
3. **Self-healing injector**: the preinit injector now **replaces an out-of-date snippet** (was skip-if-present) and `--check` flags stale snippets, so snippet changes propagate to every page. The snippet is now the **single source of truth** — `generate-internal-index-stubs.js` imports it instead of hardcoding a copy (require-guarded so importing doesn't run the injector).
4. **Regression guard** (`tests/reveal-fail-open.test.js`): locks the invariant.

## Pages affected
All 13 public pages (preinit snippet update) + `styles/partials/utilities.css` + `scripts/node/{inject-theme-preinit,generate-internal-index-stubs}.js` + new test.

## Verification
- `eslint` + `stylelint` clean; `npm run build`; `npm run validate` **PASS** (0 errors; preinit `--check` all 41 current; stubs current; schemas ok); guard test **5/5**.
- **Playwright on index.html across 4 modes — all PASS:**
  | mode | result |
  | --- | --- |
  | JS **disabled** | 16/16 reveal elements visible |
  | JS normal | 0 above-fold stuck (observer reveals; below-fold scroll-reveal preserved) |
  | reduced-motion | 16/16 visible |
  | **chunk failure** (all `.js` blocked) | 0 above-fold stuck — inline fail-safe revealed them |

## Risk
Low–medium. Sitewide CSS + preinit change, but behaviour on healthy loads is unchanged (`.js` set pre-paint → normal animation), and all failure modes now fail open. No new inline scripts beyond the existing theme-preinit (CSP unchanged).

## Dependencies / follow-ups
Independent of the other open PRs. Complements #506 (Learn hub) which fixed the dynamic-insertion case; this covers the static + boot-failure cases sitewide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sitewide CSS and every page’s render-blocking preinit, but healthy loads should behave the same; main risk is subtle timing or visibility edge cases around the 900ms fail-safe vs normal scroll-reveal.
> 
> **Overview**
> Hardens **`[data-reveal]`** so sections no longer stay invisible when JavaScript fails, matching the Learn-hub blank-grid class of bugs.
> 
> **CSS:** Adds `:root:not(.js) [data-reveal]` so content stays visible when JS never runs; the hide-at-`opacity:0` behavior only applies after preinit adds **`.js`** on `<html>`.
> 
> **Preinit (all public HTML):** The existing theme-preinit block now adds **`.js`** before paint and, on `load` + 900ms, applies **`.is-in-view`** to any on-screen `[data-reveal]` nodes still hidden—so above-fold content shows even if a hashed chunk 404s; scroll-reveal below the fold is unchanged.
> 
> **Tooling:** `inject-theme-preinit.js` exports the snippet as the single source of truth, **replaces** stale injected blocks (not skip-if-present), and `--check` fails on outdated snippets; `generate-internal-index-stubs.js` imports that snippet instead of duplicating it.
> 
> **Tests:** New `tests/reveal-fail-open.test.js` locks the CSS fail-open rule and preinit invariants on key pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05af2450cf664275d5c496fe6958b8f9321af158. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->