### PR TITLE
feat(seo,ia): surface World Map + Portfolio in the homepage tools grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -777,6 +777,23 @@
               </p>
               <span class="tool-card-cta" id="tool-countries-cta">All Countries →</span>
             </a>
+            <a href="heatmap.html" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-map"/></svg></div>
+              <h3 class="tool-card-title" id="tool-heatmap-title">World Gold Map</h3>
+              <p class="tool-card-desc" id="tool-heatmap-desc">
+                A colour-coded world map of spot-linked reference gold prices, country by country.
+              </p>
+              <span class="tool-card-cta" id="tool-heatmap-cta">Open Map →</span>
+            </a>
+            <a href="portfolio.html" class="tool-card">
+              <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-coins"/></svg></div>
+              <h3 class="tool-card-title" id="tool-portfolio-title">Portfolio Tracker</h3>
+              <p class="tool-card-desc" id="tool-portfolio-desc">
+                Value your own gold holdings privately — everything stays in your browser, no
+                account needed.
+              </p>
+              <span class="tool-card-cta" id="tool-portfolio-cta">Open Portfolio →</span>
+            </a>
             <a href="learn.html" class="tool-card">
               <div class="tool-card-icon" aria-hidden="true"><svg class="ti" aria-hidden="true" focusable="false"><use href="#i-book"/></svg></div>
               <h3 class="tool-card-title" id="tool-learn-title">Learn &amp; Glossary</h3>


### PR DESCRIPTION
## Problem
The SEO audit (PR #507) found **heatmap.html** and **portfolio.html** were the only two indexable tools **missing from the homepage body** — reachable from the footer sitemap but absent from the main tools grid (tracker, calculator, compare, shops, learn, insights, methodology, investing). That starved two real product pages of internal link equity and made them hard to discover from the front door.

## What changed
Added two tool cards to the homepage `.tools-grid`, matching the existing pattern (icon, title, honest description, CTA):
- **World Gold Map** → `heatmap.html`
- **Portfolio Tracker** → `portfolio.html`

Copy stays reference-honest ("spot-linked reference gold prices", "everything stays in your browser, no account needed").

## Pages affected
`index.html`.

## Verification
- `npm run build`; `npm run validate` **PASS (0 errors)**
- `i18n-sitewide-guard` + `routes-integrity` tests green
- Both cards render with correct links.

## Risk
Very low — additive static markup on the homepage, no JS/data changes.

## Follow-ups (master plan · internal-linking strategy)
Contextual "related tools" blocks across compare / methodology / learn once those pages' in-flight PRs (#497/#499 etc.) land, plus a shared six-tool footer cluster. Deferred here to avoid conflicts with the open education-stack PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive static HTML on the homepage only; no runtime, data, or auth changes.
> 
> **Overview**
> Adds **two tool cards** to the homepage **Everything You Need** `.tools-grid`, using the same pattern as existing entries (icon, title, description, CTA).
> 
> **World Gold Map** links to `heatmap.html` and describes the colour-coded, spot-linked reference price map. **Portfolio Tracker** links to `portfolio.html` and highlights browser-local valuation with no account.
> 
> Copy stays reference-honest (spot-linked prices, local-only portfolio data). No JS, styling, or i18n updates in this diff—only static `index.html` markup for discoverability and internal linking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aec599dd2f3daa75733ade05aa2fba6b2ce765c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->