### PR TITLE
fix(test): pin clock in freshness tests so weekend runs stay green

### DIFF
--- a/tests/realtime-fallback-integration.test.js
+++ b/tests/realtime-fallback-integration.test.js
@@ -18,9 +18,24 @@
  * fundamental contract of `docs/realtime-validation-report.md` is broken.
  */
 
-const { test } = require('node:test');
+const { test, beforeEach, afterEach, mock } = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
+
+// Pin the clock to a market-OPEN instant (Wed 2026-06-10 14:00 UTC). spotBar and
+// ticker both apply the market-closed overlay (src/lib/live-status.js#applyMarketClosedOverlay),
+// which repaints freshness (including "fallback") as "closed" while the gold
+// market is shut — i.e. every Saturday/Sunday. These integration cases assert the
+// fallback state reaches the DOM; without pinning they pass Mon–Fri and fail on
+// weekend CI runs. The pure-engine case below (getLiveFreshness) is unaffected
+// either way since it never applies the overlay.
+const MARKET_OPEN_MS = new Date('2026-06-10T14:00:00Z').getTime();
+beforeEach(() => {
+  mock.timers.enable({ apis: ['Date'], now: MARKET_OPEN_MS });
+});
+afterEach(() => {
+  mock.timers.reset();
+});
 
 function importModule(relPath) {
   const url = new URL('file://' + path.resolve(__dirname, '..', relPath));

--- a/tests/spot-bar-freshness.test.js
+++ b/tests/spot-bar-freshness.test.js
@@ -8,9 +8,23 @@
  * `data-freshness` ends up matching `getLiveFreshness()`'s contract.
  */
 
-const { test } = require('node:test');
+const { test, beforeEach, afterEach, mock } = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
+
+// Pin the clock to a market-OPEN instant (Wed 2026-06-10 14:00 UTC). spotBar
+// applies the market-closed overlay (src/lib/live-status.js#applyMarketClosedOverlay),
+// which repaints every freshness key as "closed" while the gold market is shut —
+// i.e. every Saturday/Sunday. These tests assert the pure freshness vocabulary
+// (live/cached/stale/delayed/fallback); without pinning they pass Mon–Fri and
+// fail on weekend CI runs. The closed overlay itself is covered separately.
+const MARKET_OPEN_MS = new Date('2026-06-10T14:00:00Z').getTime();
+beforeEach(() => {
+  mock.timers.enable({ apis: ['Date'], now: MARKET_OPEN_MS });
+});
+afterEach(() => {
+  mock.timers.reset();
+});
 
 async function loadSpotBar() {
   const url = new URL('file://' + path.resolve(__dirname, '..', 'src', 'components', 'spotBar.js'));

--- a/tests/ticker-freshness.test.js
+++ b/tests/ticker-freshness.test.js
@@ -10,9 +10,23 @@
  * matches `getLiveFreshness()`'s contract.
  */
 
-const { test } = require('node:test');
+const { test, beforeEach, afterEach, mock } = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
+
+// Pin the clock to a market-OPEN instant (Wed 2026-06-10 14:00 UTC). The ticker
+// applies the market-closed overlay (src/lib/live-status.js#applyMarketClosedOverlay),
+// which repaints every freshness key as "closed" while the gold market is shut —
+// i.e. every Saturday/Sunday. These tests assert the pure freshness vocabulary
+// (live/cached/stale/fallback); without pinning they pass Mon–Fri and fail on
+// weekend CI runs. The closed overlay itself is covered separately.
+const MARKET_OPEN_MS = new Date('2026-06-10T14:00:00Z').getTime();
+beforeEach(() => {
+  mock.timers.enable({ apis: ['Date'], now: MARKET_OPEN_MS });
+});
+afterEach(() => {
+  mock.timers.reset();
+});
 
 async function loadTicker() {
   const url = new URL('file://' + path.resolve(__dirname, '..', 'src', 'components', 'ticker.js'));


### PR DESCRIPTION
## The bug: freshness tests fail on weekends

`spotBar` and `ticker` apply the **market-closed overlay** (`src/lib/live-status.js#applyMarketClosedOverlay`), which repaints every freshness key as `"closed"` while the gold market is shut (21:00 UTC Fri → 22:00 UTC Sun). The spot-bar / ticker / fallback-integration tests assert the *pure* freshness vocabulary (`live` / `cached` / `stale` / `delayed` / `fallback`) but never pinned the clock — so they pass Mon–Fri and fail on any run that happens on a weekend:

```
'closed' !== 'live'
```

Reproduced today (2026-07-04, a Saturday): `npm test` fails **12 tests** across these three files on a clean `main`, purely because the runner's wall-clock is a weekend. Nothing is actually wrong in the product.

### Where this bites

- **Local `npm test`** — anyone running the suite on a Sat/Sun sees 12 red tests and has to guess whether it's real.
- **The `npm test` merge gate** (`ci.yml` → "Validate & Build" → *Run unit tests*) — this would flip red on any weekend run.

> Context I verified while triaging: the `CI` workflow (`ci.yml`) is currently **`disabled_manually`** (since 2026-04-24), so it is **not** presently gating these PRs — the checks you see come from CodeQL / Lighthouse / link-check / Playwright workflows, none of which run `npm test`. So this PR is not un-reding a currently-red check; it removes real calendar flakiness from the suite so `npm test` is trustworthy locally and green whenever that gate is turned back on. (Separately worth a look: the primary validate/lint/test/build gate having been off for ~2.5 months.)

## The fix

Pin each affected file's clock to a market-**open** instant (Wed 2026-06-10 14:00 UTC) via `mock.timers.enable({ apis: ['Date'], now })` in a `beforeEach` — the exact idiom `tests/cache-revalidation.test.js` and `tests/provider-failover.test.js` already use. The `Date`-arg constructors the tests use for relative timestamps (`Date.now() - 90*60*1000`, etc.) stay correct because only the no-arg clock is frozen.

**No production code changes.** The overlay's own closed-market behaviour is unchanged and remains covered elsewhere (`getLiveFreshness` stays a pure signal; the integration file's engine-level case never touches the overlay and passes either way). This only makes the freshness-*vocabulary* assertions deterministic regardless of which day the tests run.

## Files

- `tests/spot-bar-freshness.test.js`
- `tests/ticker-freshness.test.js`
- `tests/realtime-fallback-integration.test.js`

## Verification

- `npm test` — **1236 pass, 0 fail** (was 12 failing on weekends)
- `npm run lint` — clean
- Each file individually green (spot-bar 6/6, ticker 6/6, integration 3/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh