### PR TITLE
fix(i18n,ux): make the glossary jump-nav bilingual (EN/AR parity)

### DIFF
--- a/glossary.html
+++ b/glossary.html
@@ -118,12 +118,19 @@
         </div>
       </section>
 
-      <nav class="glossary-jump" aria-label="Glossary sections">
+      <nav class="glossary-jump" aria-label="Glossary sections" data-lang-block="en">
         <span class="glossary-jump-label" id="glossary-jump-label">Jump to a section</span>
         <a href="#group-pricing">Pricing &amp; value</a>
         <a href="#group-units">Units &amp; purity</a>
         <a href="#group-products">Products</a>
         <a href="#group-markets">Markets &amp; benchmarks</a>
+      </nav>
+      <nav class="glossary-jump" aria-label="أقسام المسرد" data-lang-block="ar" lang="ar" dir="rtl">
+        <span class="glossary-jump-label">الانتقال إلى قسم</span>
+        <a href="#group-pricing">التسعير والقيمة</a>
+        <a href="#group-units">الوحدات والنقاء</a>
+        <a href="#group-products">المنتجات</a>
+        <a href="#group-markets">الأسواق والمؤشرات المرجعية</a>
       </nav>
 
       <section class="gloss-group" id="group-pricing" aria-labelledby="group-pricing-title-en group-pricing-title-ar">

--- a/styles/pages/glossary.css
+++ b/styles/pages/glossary.css
@@ -49,6 +49,21 @@ html[lang='ar'] [data-lang-block='en'] {
 }
 
 /* ── Jump nav ─────────────────────────────────────────────────────────── */
+
+/* .glossary-jump sets display:flex, which has equal specificity to the generic
+   [data-lang-block='ar']{display:none} toggle, so source order would otherwise
+   keep the inactive-language jump nav visible. Scope the toggle to .glossary-jump
+   so exactly one language's nav shows (mirrors .mkt-jump in market.css). */
+.glossary-jump[data-lang-block='ar'] {
+  display: none;
+}
+html[lang='ar'] .glossary-jump[data-lang-block='ar'] {
+  display: flex;
+}
+html[lang='ar'] .glossary-jump[data-lang-block='en'] {
+  display: none;
+}
+
 .glossary-jump {
   max-width: 1000px;
   margin-inline: auto;


### PR DESCRIPTION
Phase 2 audit fix (`docs/audits/2026-07-04_deep-audit.md`, UX P1).

The glossary in-page jump navigation was a single English-only `<nav>`, so in Arabic mode it rendered English link text ("Pricing & value", …) over Arabic section headings — breaking **EN/AR parity** (an immutable project constraint) on the page's primary navigation. The sibling market page already duplicates its jump nav per language.

Mirrors that pattern: split into `data-lang-block="en"/"ar"` twins with translated link text + `aria-label`, plus the scoped `.glossary-jump[data-lang-block]` CSS override (the nav's `display:flex` has equal specificity to the generic language toggle, so without scoping the inactive-language nav would leak). Zero-JS.

## Verification
`eslint` + `stylelint` clean (own files) · `npm test` **1273/0** · `npm run validate` **PASS** · `npm run build` **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static HTML/CSS i18n on the glossary page only; no auth, data, or runtime logic changes.
> 
> **Overview**
> Fixes **EN/AR parity** on the glossary page’s in-page jump navigation by replacing a single English-only `<nav>` with paired **`data-lang-block="en"`** and **`data-lang-block="ar"`** blocks (translated labels, section links, and Arabic `aria-label` / `lang` / `dir`), matching the market page pattern. No JavaScript.
> 
> Adds **scoped CSS** on `.glossary-jump[data-lang-block]` so the language toggle does not fight `.glossary-jump`’s `display: flex` (same specificity fix as `.mkt-jump` in `market.css`), ensuring only the active language’s jump nav is visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74055435fd659905f7ec9501cd36e6f30a07cdbb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->