### PR TITLE
fix(i18n): localize document.title in Arabic on home/calculator/shops/methodology

### DIFF
--- a/src/config/translations.js
+++ b/src/config/translations.js
@@ -865,6 +865,7 @@ export const TRANSLATIONS = {
     'home.actionMarketLabel': 'How gold is priced',
     'home.actionMarketDesc':
       'Spot, making charges, VAT — how a reference price becomes a shop quote.',
+    'home.docTitle': 'Gold Ticker Live — Reference Gold Prices UAE & GCC Today',
     'home.snapshotKicker': 'Market snapshot',
     'home.snapshotTitle': 'Reference context for mobile',
     'home.snapshotUaeLabel': 'UAE reference',
@@ -2283,6 +2284,7 @@ export const TRANSLATIONS = {
     'home.actionMarketKicker': 'التسعير',
     'home.actionMarketLabel': 'كيف يُسعّر الذهب',
     'home.actionMarketDesc': 'الفوري ورسوم الصياغة والضريبة — كيف يصبح السعر المرجعي سعر محل.',
+    'home.docTitle': 'Gold Ticker Live — أسعار الذهب المرجعية للإمارات والخليج',
     'home.snapshotKicker': 'ملخص السوق',
     'home.snapshotTitle': 'سياق مرجعي مناسب للموبايل',
     'home.snapshotUaeLabel': 'مرجع الإمارات',

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -89,6 +89,7 @@ function shopVsRefT(key) {
 // ── Translations ────────────────────────────────────────────────────────────
 const T = {
   en: {
+    docTitle: 'Gold Calculator — Value, Scrap, Zakat | Gold Ticker Live',
     pageTitle: 'Gold Calculator',
     pageSub: 'Spot-linked reference estimates · Multiple karats · AED & USD',
     spotLabel: 'Spot:',
@@ -226,6 +227,7 @@ const T = {
     skip_to_main: 'Skip to main content',
   },
   ar: {
+    docTitle: 'حاسبة الذهب — القيمة والخردة والزكاة | Gold Ticker Live',
     pageTitle: 'حاسبة الذهب',
     pageSub: 'تقديرات مرجعية مرتبطة بالسعر الفوري · عيارات متعددة · درهم ودولار',
     spotLabel: 'السعر الفوري:',
@@ -1235,6 +1237,7 @@ function applyLang() {
 
   document.documentElement.lang = STATE.lang;
   document.documentElement.dir = STATE.lang === 'ar' ? 'rtl' : 'ltr';
+  document.title = t('docTitle');
   populateKaratSelects();
   populateUnitSelects();
   refreshMobileDockForActiveTab();

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -1031,6 +1031,7 @@ function applyLangToPage() {
   const isAr = lang === 'ar';
   document.documentElement.lang = lang;
   document.documentElement.dir = isAr ? 'rtl' : 'ltr';
+  document.title = tx('docTitle');
   hydrateHomeI18n();
 
   setTextById('hero-live-label', tx('heroLive'));

--- a/src/pages/methodology.js
+++ b/src/pages/methodology.js
@@ -13,6 +13,7 @@ const STATE = { lang: 'en' };
 
 const T = {
   en: {
+    docTitle: 'Data Sources & Methodology | Gold Ticker Live',
     'method-hero-tag': 'Transparency & Trust',
     'method-h1': 'Data Sources & Methodology',
     'method-sub':
@@ -54,6 +55,7 @@ const T = {
     'disclaimer-h2': 'Disclaimer',
   },
   ar: {
+    docTitle: 'مصادر البيانات والمنهجية | Gold Ticker Live',
     'method-hero-tag': 'الشفافية والثقة',
     'method-h1': 'مصادر البيانات والمنهجية',
     'method-sub': 'كيف نحسب كل سعر تراه — خطوة بخطوة، مع الإسناد الكامل للمصادر.',
@@ -102,7 +104,9 @@ function t(key) {
 function applyLanguage() {
   document.documentElement.lang = STATE.lang;
   document.documentElement.dir = STATE.lang === 'ar' ? 'rtl' : 'ltr';
+  document.title = t('docTitle');
   Object.keys(T.en).forEach((key) => {
+    // `docTitle` is a virtual key (no matching element id) — used only above.
     const el = document.getElementById(key);
     if (el) el.textContent = t(key);
   });

--- a/src/pages/shops.js
+++ b/src/pages/shops.js
@@ -93,6 +93,7 @@ const REGIONS = {
 
 const TXT = {
   en: {
+    docTitle: 'Gold Shops & Markets Directory by Region | Gold Ticker Live',
     kicker: 'Shops by region',
     title: 'Explore Gold Shops & Known Gold Markets',
     lead: 'Browse directory listings across countries covered on Gold Ticker Live. Use filters to narrow by region, country, city, and specialty. Shop information is for reference, and business details are shown where available.',
@@ -249,6 +250,7 @@ const TXT = {
     compareMaxReached: 'Maximum 3 shops for comparison',
   },
   ar: {
+    docTitle: 'دليل محلات وأسواق الذهب حسب المنطقة | Gold Ticker Live',
     kicker: 'محلات حسب المنطقة',
     title: 'استكشف محلات الذهب والأسواق المعروفة',
     lead: 'تصفح إدراجات الدليل ضمن الدول التي يغطيها Gold Ticker Live. استخدم الفلاتر حسب المنطقة والدولة والمدينة والتخصص. معلومات المحلات مرجعية، وتظهر تفاصيل النشاط حيثما كانت متاحة.',
@@ -982,6 +984,7 @@ function closeModal({ clearShopParam = true } = {}) {
 function applyStaticText() {
   document.documentElement.lang = STATE.lang;
   document.documentElement.dir = STATE.lang === 'ar' ? 'rtl' : 'ltr';
+  document.title = t('docTitle');
 
   document.getElementById('shops-kicker').textContent = t('kicker');
   document.getElementById('shops-title').textContent = t('title');


### PR DESCRIPTION
Phase 2 audit fix (`docs/audits/2026-07-04_deep-audit.md`, **I18N P1**).

`home`, `calculator`, `shops`, `methodology` never set `document.title`, so in `?lang=ar` the **browser tab** and the **screen-reader page-title announcement** stayed English — an EN/AR parity gap (an immutable constraint) on the flagship home page. Six other pages already localize it via `t('docTitle')`; this brings these four in line.

- Added a `docTitle` string (EN + AR) to each page's dict — `home` via the global `translations` table (`home.docTitle`); calculator/shops/methodology via their local `T`/`TXT` dicts (EN/AR parity guards stay green).
- Assigned `document.title` in each page's language-apply path so the tab title flips with the toggle.
- **`invest.js` intentionally excluded** — it renders inside `learn.html` and documents (`invest.js:712`) that the host page owns `document.title` (audit false-positive).

## Verification
`npm run lint` clean · `npm test` **1273/0** (global + local-dict i18n parity guards) · `npm run validate` **PASS** · `npm run build` **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only i18n and `document.title` updates with no auth, pricing logic, or API changes.
> 
> **Overview**
> Fixes an EN/AR parity gap where **home**, **calculator**, **shops**, and **methodology** left the browser tab title (and screen-reader page title) in English when Arabic was selected.
> 
> Adds **`docTitle`** strings in EN and AR—**home** via `home.docTitle` in the shared translations table; the other three via their local `T`/`TXT` dicts—and sets **`document.title`** in each page’s language-apply path so the tab updates with the language toggle, matching pages that already use `t('docTitle')`.
> 
> On **methodology**, `docTitle` is applied only to `document.title`; a short comment notes it is not mapped to a DOM element id so the existing id-based text loop does not touch it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2a9faac845f39438934ceedb148aa058a63135a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->