### PR TITLE
perf: drop dead hand-authored modulepreload hints (unminified JS + base64 bloat)

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -74,9 +74,6 @@
     <link rel="preload" as="style" href="./styles/critical.css" />
     <link rel="preload" as="style" href="./styles/global.css" />
     <link rel="preload" as="style" href="./styles/pages/calculator.css" />
-    <link rel="modulepreload" href="./src/pages/calculator.js" />
-    <link rel="modulepreload" href="./src/lib/api.js" />
-    <link rel="modulepreload" href="./src/components/site-shell.js" />
     <link rel="stylesheet" href="./styles/critical.css" />
     <link rel="stylesheet" href="./styles/global.css" />
     <link rel="stylesheet" href="./styles/pages/calculator.css" />

--- a/compare.html
+++ b/compare.html
@@ -74,9 +74,6 @@
     <link rel="preload" as="style" href="./styles/critical.css" />
     <link rel="preload" as="style" href="./styles/global.css" />
     <link rel="preload" as="style" href="./styles/pages/compare.css" />
-    <link rel="modulepreload" href="./src/pages/compare.js" />
-    <link rel="modulepreload" href="./src/lib/api.js" />
-    <link rel="modulepreload" href="./src/components/site-shell.js" />
     <link rel="stylesheet" href="./styles/critical.css" />
     <link rel="stylesheet" href="./styles/global.css" />
     <link rel="stylesheet" href="./styles/pages/compare.css" />

--- a/dubai-gold-price.html
+++ b/dubai-gold-price.html
@@ -72,8 +72,6 @@
     <link rel="preload" as="style" href="./styles/critical.css" />
     <link rel="preload" as="style" href="./styles/global.css" />
     <link rel="preload" as="style" href="./styles/pages/dubai-gold-price.css" />
-    <link rel="modulepreload" href="./src/pages/dubai-gold-price.js" />
-    <link rel="modulepreload" href="./src/components/site-shell.js" />
     <link rel="stylesheet" href="./styles/critical.css" />
     <link rel="stylesheet" href="./styles/global.css" />
     <link rel="stylesheet" href="./styles/pages/dubai-gold-price.css" />

--- a/glossary.html
+++ b/glossary.html
@@ -72,8 +72,6 @@
     <link rel="preload" as="style" href="./styles/critical.css" />
     <link rel="preload" as="style" href="./styles/global.css" />
     <link rel="preload" as="style" href="./styles/pages/glossary.css" />
-    <link rel="modulepreload" href="./src/pages/glossary.js" />
-    <link rel="modulepreload" href="./src/components/site-shell.js" />
     <link rel="stylesheet" href="./styles/critical.css" />
     <link rel="stylesheet" href="./styles/global.css" />
     <link rel="stylesheet" href="./styles/pages/glossary.css" />

--- a/heatmap.html
+++ b/heatmap.html
@@ -77,9 +77,6 @@
     <link rel="preload" as="style" href="./styles/critical.css" />
     <link rel="preload" as="style" href="./styles/global.css" />
     <link rel="preload" as="style" href="./styles/pages/heatmap.css" />
-    <link rel="modulepreload" href="./src/pages/heatmap.js" />
-    <link rel="modulepreload" href="./src/lib/api.js" />
-    <link rel="modulepreload" href="./src/components/site-shell.js" />
     <link rel="stylesheet" href="./styles/critical.css" />
     <link rel="stylesheet" href="./styles/global.css" />
     <link rel="stylesheet" href="./styles/pages/heatmap.css" />

--- a/index.html
+++ b/index.html
@@ -90,10 +90,6 @@
     <link rel="preload" as="style" href="styles/critical.css" />
     <link rel="preload" as="style" href="styles/global.css" />
     <link rel="preload" as="style" href="styles/pages/home.css" />
-    <link rel="modulepreload" href="src/pages/home.js" />
-    <link rel="modulepreload" href="src/lib/api.js" />
-    <link rel="modulepreload" href="src/lib/realtime-pricing-engine.js" />
-    <link rel="modulepreload" href="src/components/site-shell.js" />
 
     <!-- Resource Hints for Prefetching -->
     <link rel="prefetch" href="compare.html" as="document" />

--- a/market.html
+++ b/market.html
@@ -72,8 +72,6 @@
     <link rel="preload" as="style" href="./styles/critical.css" />
     <link rel="preload" as="style" href="./styles/global.css" />
     <link rel="preload" as="style" href="./styles/pages/market.css" />
-    <link rel="modulepreload" href="./src/pages/market.js" />
-    <link rel="modulepreload" href="./src/components/site-shell.js" />
     <link rel="stylesheet" href="./styles/critical.css" />
     <link rel="stylesheet" href="./styles/global.css" />
     <link rel="stylesheet" href="./styles/pages/market.css" />

--- a/portfolio.html
+++ b/portfolio.html
@@ -77,9 +77,6 @@
     <link rel="preload" as="style" href="./styles/critical.css" />
     <link rel="preload" as="style" href="./styles/global.css" />
     <link rel="preload" as="style" href="./styles/pages/portfolio.css" />
-    <link rel="modulepreload" href="./src/pages/portfolio.js" />
-    <link rel="modulepreload" href="./src/lib/api.js" />
-    <link rel="modulepreload" href="./src/components/site-shell.js" />
     <link rel="stylesheet" href="./styles/critical.css" />
     <link rel="stylesheet" href="./styles/global.css" />
     <link rel="stylesheet" href="./styles/pages/portfolio.css" />

--- a/shops.html
+++ b/shops.html
@@ -73,9 +73,6 @@
     <link rel="preload" as="style" href="./styles/global.css" />
     <link rel="preload" as="style" href="./styles/pages/shops.css" />
     <link rel="preload" as="style" href="./styles/components/shops-map.css" />
-    <link rel="modulepreload" href="./src/pages/shops.js" />
-    <link rel="modulepreload" href="./src/lib/api.js" />
-    <link rel="modulepreload" href="./src/components/site-shell.js" />
     <link rel="stylesheet" href="./styles/critical.css" />
     <link rel="stylesheet" href="./styles/global.css" />
     <link rel="stylesheet" href="./styles/pages/shops.css" />

--- a/tracker.html
+++ b/tracker.html
@@ -80,10 +80,6 @@
 <link rel="preload" as="style" href="styles/global.css" />
     <link rel="preload" as="style" href="styles/pages/tracker-pro.css" />
     <link rel="preload" as="style" href="styles/components/alert-manager.css" />
-    <link rel="modulepreload" href="src/pages/tracker-pro.js" />
-    <link rel="modulepreload" href="src/lib/api.js" />
-    <link rel="modulepreload" href="src/tracker/inline-calc.js" />
-    <link rel="modulepreload" href="src/components/site-shell.js" />
 
     <!-- Resource hints for common navigation paths -->
     <link rel="prefetch" href="index.html" as="document" />


### PR DESCRIPTION
Phase 2 audit fix (`docs/audits/2026-07-04_deep-audit.md`, **PERF P1**).

10 page heads hand-authored `<link rel="modulepreload" href="[./]src/…">` hints to **raw source paths**. Vite turned each into:
- a verbatim **unminified duplicate asset** (e.g. `calculator-DtM62FSx.js` — the real executed entry is the *minified* `calculator-oY6g6luJ.js`), and
- an inlined **base64 `data:` URL** of `site-shell.js` source, right in the HTML.

None are the executed entry — they roughly doubled first-load JS and (bare imports like `../config`) spawned **404 sub-requests + console errors** on the CDN. Removed all **29** hand-authored hints across the 10 pages. Vite already auto-injects the correct hashed `crossorigin` modulepreloads for the real entry chunks, so preloading of the actual code is unchanged.

## Verification (post-removal)
- `npm run build` PASS — `dist/calculator.html` now carries **only** Vite's hashed `crossorigin` preloads (no `src/` paths, no base64 blob); minified entry `calculator-oY6g6luJ.js` intact; **0** unminified duplicate copies remain in `dist/assets`.
- Diff is **29 deletions, 0 additions**. `npm test` **1273/0** · `npm run validate` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only HTML head cleanup with no logic changes; intended to reduce build-time bloat and mistaken preloads while Vite continues to preload the executed entry chunks.
> 
> **Overview**
> Removes **29** `<link rel="modulepreload" href="src/…">` tags from the `<head>` of **10** pages (`index`, `tracker`, `calculator`, `compare`, `shops`, `heatmap`, `portfolio`, `dubai-gold-price`, `glossary`, `market`). Those hints pointed at **unbundled source** (`src/pages/*.js`, `src/lib/api.js`, `src/components/site-shell.js`, etc.), not the chunks the browser actually runs.
> 
> On build, Vite treated them as extra entry points—shipping **unminified duplicate** JS alongside the real hashed entry, sometimes inlining **base64** source in HTML—and the preloaded modules’ bare imports could trigger **404** sub-requests on the CDN. **CSS `preload` links and the existing `<script type="module">` tags are unchanged**; Vite still injects the correct hashed `crossorigin` modulepreloads for the real bundles.
> 
> This is the **PERF P1** fix from the deep audit: less wasted first-load JS and cleaner production HTML without changing app behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae12d5d4ddcf550f423b7da1928531fb38de70df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->