### PR TITLE
fix(automation): capture the posted tweet_id (tweepy returns a dict, not an object)

### DIFF
--- a/scripts/python/post_gold_price.py
+++ b/scripts/python/post_gold_price.py
@@ -1448,9 +1448,16 @@ def post_tweet(text, post_type='hourly'):
     )
     try:
         response = client.create_tweet(text=text)
+        # tweepy>=4 returns response.data as a plain dict ({"id": ..., "text": ...}),
+        # so the old hasattr(response.data, "id") was always False and tweet_id
+        # stayed None on every post (breaking run reconciliation). Read the id
+        # defensively: dict access first, then attribute fallback.
         tweet_id = None
-        if hasattr(response, "data") and response.data and hasattr(response.data, "id"):
-            tweet_id = str(response.data.id)
+        data = getattr(response, "data", None)
+        if data is not None:
+            raw_id = data.get("id") if isinstance(data, dict) else getattr(data, "id", None)
+            if raw_id is not None:
+                tweet_id = str(raw_id)
         if tweet_id:
             print(f"✅ Tweet posted successfully — X post ID: {tweet_id}")
         else:


### PR DESCRIPTION
Phase 2 audit fix (`docs/audits/2026-07-04_deep-audit.md`, **OBSERVABILITY P1**).

`post_gold_price.py` read the posted id via `hasattr(response.data, "id")`, but **tweepy ≥4** (pinned `4.16.0`) returns `response.data` as a **plain dict**, so that check was always `False` and `tweet_id` was `None` on every post — **242/242** POSTED runs in `data/automation_runs.json` logged `"tweet_id": null`, so no run could be reconciled against the actual X post.

Reads the id defensively: dict access first (`data.get("id")`), then attribute fallback (`getattr(data, "id", None)`). No change to posting behavior — only to how the id is captured for the run record / `last_tweet_state`.

## Verification
- `ast.parse` OK; logic checked against both dict (`{"id": …}`) and object (`.id`) shapes and a `None` response → returns id / id / None respectively.
- Pre-existing ruff "extraneous f-prefix" warnings elsewhere in this file (lines 1648/2005/2038-2041) are unrelated and left out of scope.

_Note: `scripts/python/**` is in `deploy.yml`'s `paths-ignore`, so this doesn't redeploy the site — it takes effect on the next scheduled X-automation run._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path parsing change in `post_tweet` after a successful API call; no change to credentials, guards, or tweet content.
> 
> **Overview**
> Fixes **observability/reconciliation** for X automation: after a successful `create_tweet`, the script now reads the returned post id from **tweepy ≥4**’s `response.data` dict (`data.get("id")`), with an attribute fallback for older object-shaped responses.
> 
> The previous `hasattr(response.data, "id")` check never passed when `data` was a dict, so **`tweet_id` was always `None`** in run records (`automation_runs.json`), `RunResult` output, and `last_tweet_state` updates—even though tweets were posted. Posting and error handling are unchanged; only id capture and logging (including the “X post ID” success line) are fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 499f4d9b3e1df4bbd8127e05bf60f1995532e5cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->