### PR TITLE
polish(perf,rtl): drop dead MarketSummaryTicker CSS + flip market router arrow for RTL

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -2,7 +2,6 @@
 @import url('./partials/price-display.css');
 @import url('./partials/shell.css');
 @import url('./partials/skeleton.css');
-@import url('./partials/market-summary-ticker.css');
 @import url('./partials/tokens.css');
 @import url('./partials/base.css');
 @import url('./partials/layout.css');

--- a/styles/pages/market.css
+++ b/styles/pages/market.css
@@ -344,6 +344,11 @@ html[lang='ar'] .mkt-jump[data-lang-block='en'] {
   color: var(--color-gold-dark, var(--color-gold));
 }
 
+/* Flip the "go here" arrow for RTL: → (U+2192) becomes ← (U+2190) in Arabic. */
+html[lang='ar'] .mkt-router-title::after {
+  content: ' \2190';
+}
+
 .mkt-router-text {
   margin: 0;
   font-size: var(--text-sm);


### PR DESCRIPTION
Two Phase-2 audit P2s (`docs/audits/2026-07-04_deep-audit.md`).

- **PERF** — `styles/partials/market-summary-ticker.css` (165 lines) was `@import`ed by the render-blocking `styles/global.css` on **all 16 pages**, but the `MarketSummaryTicker` component is imported/mounted **nowhere** in production (only a unit test references it). Removed the `@import` so the dead CSS no longer ships sitewide. Component + stylesheet + test stay in the tree for future use; the core-partials a11y gate doesn't require this partial, so validate stays green and the dist CSS bundle no longer contains it.
- **UX/RTL** — the market "next steps" router titles used `.mkt-router-title::after { content: ' \2192' }` (→) with no RTL variant, so in Arabic the "go here" arrow pointed the wrong way. Added an `html[lang='ar']` override to ← (U+2190).

## Verification
`stylelint` clean · `npm run validate` PASS (core-partials gate ok) · `npm run build` PASS (dist CSS no longer references `market-summary-ticker`) · `npm test` **1273/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes: dropping an unused global import and a scoped RTL pseudo-element override on the market page, with no auth, data, or runtime logic impact.
> 
> **Overview**
> Stops **unused `MarketSummaryTicker` styles** from being bundled on every page by removing the `market-summary-ticker.css` `@import` from `styles/global.css`. The partial is no longer in the render-blocking global stylesheet; the component and its CSS file remain in the repo for possible future use.
> 
> On the **market page**, Arabic (`html[lang='ar']`) now shows a **left arrow** (←) on “next steps” router titles instead of the default right arrow (→), so the “go here” cue matches RTL reading direction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110d678ec91892d558da645e063515375e4f27dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->