### PR TITLE
fix(a11y): AA-contrast primary-CTA hover + aria-current on active mobile-nav item

### DIFF
--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -1026,6 +1026,7 @@ function _injectMobileBottomNav(lang, _depth) {
     .map((item) => {
       const isActive = !item.action && typeof item.href === 'string' && isPageMatch(item.href);
       const cls = 'mobile-bottom-nav-item' + (isActive ? ' is-active' : '');
+      const ariaCurrent = isActive ? ' aria-current="page"' : '';
 
       if (item.action === 'menu') {
         return `<button class="${cls}" data-mobile-nav="menu" type="button" aria-label="${item.label}" aria-expanded="false" aria-controls="nav-drawer">
@@ -1034,7 +1035,7 @@ function _injectMobileBottomNav(lang, _depth) {
         </button>`;
       }
 
-      return `<a href="${item.href}" class="${cls}" data-mobile-nav="${item.key}" aria-label="${item.label}">
+      return `<a href="${item.href}" class="${cls}" data-mobile-nav="${item.key}" aria-label="${item.label}"${ariaCurrent}>
         <span class="mobile-bottom-nav-icon" aria-hidden="true">${iconSvg(item.icon)}</span>
         <span class="mobile-bottom-nav-label">${item.label}</span>
       </a>`;

--- a/styles/partials/components.css
+++ b/styles/partials/components.css
@@ -2493,8 +2493,11 @@ main {
 }
 
 .btn-primary:hover {
-  background: var(--color-gold);
-  border-color: var(--color-gold);
+  /* Keep the darker gold on hover: --color-gold (#b07d1f) under the near-white
+     label failed WCAG AA in light theme (~3.42:1); --color-gold-dark reaches
+     ~5.97:1. Hover feedback stays via the lift + shadow. */
+  background: var(--color-gold-dark);
+  border-color: var(--color-gold-dark);
   transform: translateY(-2px);
   box-shadow: var(--shadow-gold-lg), var(--shadow-md);
 }


### PR DESCRIPTION
Two Phase-2 audit **A11Y P2s** (`docs/audits/2026-07-04_deep-audit.md`).

- **CTA hover contrast** — `.btn-primary:hover` used `--color-gold` (#b07d1f) under the near-white label → **~3.42:1** in light theme (fails WCAG AA). Switched hover to `--color-gold-dark` (**~5.97:1**); hover feedback stays via the lift + shadow. Dark theme unaffected (~6.47:1).
- **Mobile-nav `aria-current`** — the active bottom-nav item conveyed "current page" by **color only**. Added `aria-current="page"` to the active anchor (absent on inactive), matching the `ariaCurrent` convention already used in `nav.js`.

## Verification
`eslint` + `stylelint` clean · `npm run validate` PASS (a11y contrast gate) · `npm test` **1273/0** · `npm run build` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted a11y fixes (CSS hover tokens and nav markup attributes) with no auth, data, or API changes.
> 
> **Overview**
> Addresses two Phase-2 accessibility audit items.
> 
> **Primary button hover** — `.btn-primary:hover` no longer switches to `--color-gold`, which dropped light-theme text contrast below WCAG AA (~3.42:1). Hover keeps `--color-gold-dark` (~5.97:1); lift and shadow still signal interaction.
> 
> **Mobile bottom nav** — Active quick-nav links get `aria-current="page"` when the URL matches, so “current page” isn’t conveyed by styling alone. Aligns with the same `ariaCurrent` pattern already used for desktop and drawer nav in `nav.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ac66cfb189fba26e5eade12573d7b6688a8a5de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->