### PR TITLE
fix(i18n): close parity-guard gaps + remove two orphan keys

### DIFF
--- a/learn.html
+++ b/learn.html
@@ -587,7 +587,7 @@
           <div class="invest-planner">
             <div class="invest-planner-panel">
               <div class="invest-field">
-                <label class="invest-label" for="budget-input" id="budget-label" data-i18n="budgetLabel">Investment Budget</label>
+                <label class="invest-label" for="budget-input" id="budget-label">Investment Budget</label>
                 <div class="invest-input-row">
                   <input
                     type="number"

--- a/src/pages/submit-shop.js
+++ b/src/pages/submit-shop.js
@@ -27,7 +27,6 @@ const T = {
     errorShopName: 'Shop name is required.',
     success:
       'Your shop has been submitted and is pending moderation. The Gold Ticker Live team will review it before any public listing appears.',
-    successAr: null,
     error:
       'Could not submit right now. Please try again — no listing is published until it is reviewed.',
   },

--- a/tests/i18n-local-dict-parity.test.js
+++ b/tests/i18n-local-dict-parity.test.js
@@ -41,6 +41,9 @@ const LOCAL_DICTS = [
   ['src/pages/glossary.js', 'T'],
   ['src/pages/market.js', 'T'],
   ['src/pages/dubai-gold-price.js', 'T'],
+  ['src/pages/submit-shop.js', 'T'],
+  ['src/pages/terms.js', 'T'],
+  ['src/pages/privacy.js', 'T'],
 ];
 
 const propKey = (p) => (p.key.type === 'Identifier' ? p.key.name : p.key.value);


### PR DESCRIPTION
Two Phase-2 audit **I18N P2s** (`docs/audits/2026-07-04_deep-audit.md`).

- **Parity-guard gaps** — the local-dict EN/AR parity guard omitted `submit-shop.js`, `terms.js`, `privacy.js` (all own a top-level `const T = { en, ar }`). Added them to `LOCAL_DICTS`, so a one-language string can't ship on those pages either.
- **Orphan key (submit-shop)** — shipped an EN-only `successAr: null` referenced nowhere. Removed it so the page passes the newly-extended guard.
- **Orphan `data-i18n` (learn)** — `learn.html` carried `data-i18n="budgetLabel"` with no matching translation key, resolving to the raw key pre-hydration. Removed the dead attribute (`invest.js` already owns/localizes `#budget-label` after hydration).

## Verification
`i18n-local-dict-parity` now covers **13 pages (13/13)** · `npm test` **1276/0** · `eslint` clean · `npm run validate` PASS · `npm run build` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test coverage and dead i18n attribute removal only; no runtime behavior or security-sensitive logic changes beyond fixing a pre-hydration label flash.
> 
> **Overview**
> Closes **i18n parity-guard gaps** by registering `submit-shop.js`, `terms.js`, and `privacy.js` in `LOCAL_DICTS`, so CI enforces identical EN/AR key sets on those pages’ local `T` dictionaries (13 pages total).
> 
> **Orphan cleanup:** removes the unused English-only `successAr: null` from `submit-shop.js`, and strips `data-i18n="budgetLabel"` from the investment budget label on `learn.html` (no matching key; `invest.js` already sets `#budget-label` after hydration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d07cd950e62f3e0ef9054679a07525db998e29b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->