### PR TITLE
fix(correctness): repoint stale METHODOLOGY_FRAGMENTS to real methodology anchors

### DIFF
--- a/src/lib/cross-page-links.js
+++ b/src/lib/cross-page-links.js
@@ -17,11 +17,12 @@ const ALLOWED_RANGES = new Set(['24H', '7D', '30D', '90D', '1Y', '3Y', '5Y', 'AL
 const ISO_COUNTRY_CODE = /^[A-Za-z]{2}$/;
 const METHODOLOGY_FRAGMENTS = new Set([
   '',
-  'spot-vs-retail',
-  'formula',
-  'sources',
-  'freshness',
-  'karats',
+  'not-included',
+  'live-formula',
+  'gold-data',
+  'fx-rates',
+  'freshness-states',
+  'karat-conversion',
 ]);
 
 /**

--- a/tests/cross-page-links.test.js
+++ b/tests/cross-page-links.test.js
@@ -83,8 +83,8 @@ test('buildMethodologyHref supports fragment and lang', async () => {
   const mod = await loadModule();
   assert.equal(mod.buildMethodologyHref(), 'methodology.html');
   assert.equal(
-    mod.buildMethodologyHref({ fragment: 'spot-vs-retail', lang: 'ar' }),
-    'methodology.html?lang=ar#spot-vs-retail'
+    mod.buildMethodologyHref({ fragment: 'not-included', lang: 'ar' }),
+    'methodology.html?lang=ar#not-included'
   );
   assert.equal(mod.buildMethodologyHref({ fragment: 'bogus' }), 'methodology.html');
 });


### PR DESCRIPTION
Phase-2 audit **CORRECTNESS P2** (`docs/audits/2026-07-04_deep-audit.md`).

`METHODOLOGY_FRAGMENTS` in `cross-page-links.js` listed 5 anchors (`spot-vs-retail`, `formula`, `sources`, `freshness`, `karats`) — **none exist** as `id=` anchors in `methodology.html`, so `buildMethodologyHref()` would silently drop a valid fragment to the page top. Remapped each to a verified real anchor:

| old | new |
|---|---|
| `spot-vs-retail` | `not-included` (matches this session's tracker repoint) |
| `formula` | `live-formula` |
| `sources` | `gold-data` (+ `fx-rates`) |
| `freshness` | `freshness-states` |
| `karats` | `karat-conversion` |

All six confirmed present in `methodology.html`. Updated the paired assertion in `tests/cross-page-links.test.js`.

## Verification
`cross-page-links.test.js` **9/9** · `npm test` **1276/0** · `eslint` clean · `npm run validate` PASS · `npm run build` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small allowlist correction for link generation and tests only; no runtime pricing, auth, or data-path changes.
> 
> **Overview**
> **Fixes broken deep links** to `methodology.html` by replacing five stale fragment names in `METHODOLOGY_FRAGMENTS` with anchors that actually exist on the page (`not-included`, `live-formula`, `gold-data`, `fx-rates`, `freshness-states`, `karat-conversion`).
> 
> `buildMethodologyHref()` only keeps fragments on that allowlist, so the old IDs were being dropped and users landed at the page top instead of the intended section. The cross-page-links unit test now asserts `not-included` with Arabic `lang` instead of the removed `spot-vs-retail` fragment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e513d39f951892cf1466d1384f10d7d2f6227ad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->