### PR TITLE
fix(observability): analytics-inventory --check now fails on drift instead of no-op

### DIFF
--- a/scripts/node/export-analytics-inventory.js
+++ b/scripts/node/export-analytics-inventory.js
@@ -35,17 +35,17 @@ async function main() {
 
   if (CHECK_ONLY) {
     if (!fs.existsSync(OUTPUT_ABS)) {
-      console.warn(
+      console.error(
         `[analytics-inventory] ${OUTPUT_REL} is missing. Run \`node scripts/node/export-analytics-inventory.js\`.`
       );
-      return;
+      process.exit(1);
     }
     const existing = fs.readFileSync(OUTPUT_ABS, 'utf8');
     if (normalize(existing) !== normalize(text)) {
-      console.warn(
+      console.error(
         `[analytics-inventory] ${OUTPUT_REL} is stale. Run \`node scripts/node/export-analytics-inventory.js\`.`
       );
-      return;
+      process.exit(1);
     }
     console.log(`[analytics-inventory] check ok (${report.totals.events} events)`);
     return;


### PR DESCRIPTION
Phase-2 audit **OBSERVABILITY P2** (`docs/audits/2026-07-04_deep-audit.md`).

The analytics event-inventory gate in `npm run validate` only `console.warn`'d and `return`ed on a missing/stale inventory, so the process still **exited 0** — event-tracking drift was never actually caught (silent no-op).

Both `--check` failure branches now `console.error` + `process.exit(1)`. The committed `reports/analytics/event-inventory.json` is already in sync (check ok, 38 events), so `validate` stays green.

## Verification (proven end-to-end)
- in-sync → exit **0** ✓ · corrupted inventory → exit **1** ✓ · restored → exit **0** ✓
- `eslint` clean · `npm run validate` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/validate script behavior only; no runtime app, auth, or data-path changes.
> 
> **Overview**
> **Makes the analytics event-inventory gate in `npm run validate` actually block on drift** instead of logging a warning and exiting successfully.
> 
> When `export-analytics-inventory.js` runs with `--check`, missing `reports/analytics/event-inventory.json` or a stale diff (vs live `src/lib/analytics.js`) now logs with `console.error` and **`process.exit(1)`** instead of `console.warn` + early `return`. In-sync checks still exit 0 with the existing success message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1246f494b3c7cb5c8c73f03a45ab099df44fb780. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->