### PR TITLE
fix(seo): dedupe sitemap generator (delegator) + add Dubai inbound link from market

### DIFF
--- a/build/generateSitemap.js
+++ b/build/generateSitemap.js
@@ -1,83 +1,26 @@
 #!/usr/bin/env node
 /**
  * build/generateSitemap.js
- * Generates sitemap.xml from the surviving public page set.
- * Run: node build/generateSitemap.js
+ * Thin delegator to the canonical filesystem-walk sitemap generator
+ * (scripts/node/generate-sitemap.js — the same one deploy.yml regenerates with).
  *
- * 2026-07-04 radical page reduction: the countries/ and content/ trees (and the
- * insights/invest root pages) were removed, so this list is now just the kept
- * public surfaces. 404.html and offline.html are intentionally excluded, as
- * before. The canonical filesystem-walk generator is
- * scripts/node/generate-sitemap.js; this hardcoded list feeds `npm run build`.
+ * Kept as a path-stable shim because `npm run build` (package.json) and
+ * scripts/node/generate-baseline-inventory.js invoke this file by path. It used
+ * to hold a hardcoded staticPages list that drifted from the site (it omitted
+ * dubai-gold-price.html, glossary.html, market.html — three real indexable
+ * pages). Do NOT re-add a page list here — the walk generator derives URLs from
+ * the HTML on disk and skips noindex, so it can never miss a shipped page.
  */
 
-const fs   = require('fs');
-const path = require('path');
+'use strict';
 
-const ROOT     = path.resolve(__dirname, '..');
-const SITE_URL = 'https://goldtickerlive.com';
-const TODAY    = new Date().toISOString().slice(0, 10);
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
 
-function isNoindexFile(filePath) {
-  try {
-    const html = fs.readFileSync(filePath, 'utf8');
-    return /<meta[^>]+name=["']robots["'][^>]*content=["'][^"']*noindex/i.test(html);
-  } catch {
-    return false;
-  }
-}
+const ROOT = path.resolve(__dirname, '..');
+const CANONICAL_GENERATOR = path.join(ROOT, 'scripts', 'node', 'generate-sitemap.js');
 
-function sitemapUrlToFilePath(loc) {
-  const pathname = new URL(loc).pathname;
-  if (pathname === '/') return path.join(ROOT, 'index.html');
-  const rel = pathname.replace(/^\/+/, '');
-  if (rel.endsWith('.html')) return path.join(ROOT, rel);
-  return path.join(ROOT, rel, 'index.html');
-}
-
-function url(loc, changefreq, priority) {
-  return `
-  <url>
-    <loc>${loc}</loc>
-    <lastmod>${TODAY}</lastmod>
-    <xhtml:link rel="alternate" hreflang="x-default" href="${loc}"/>
-    <xhtml:link rel="alternate" hreflang="en" href="${loc}"/>
-    <xhtml:link rel="alternate" hreflang="ar" href="${loc}?lang=ar"/>
-    <changefreq>${changefreq}</changefreq>
-    <priority>${priority}</priority>
-  </url>`;
-}
-
-const urls = [];
-
-// Kept public pages (the 2026-07-04 reduction survivors). 404.html and
-// offline.html are excluded by convention.
-const staticPages = [
-  { loc: `${SITE_URL}/`,                  changefreq: 'hourly',  priority: '1.0' },
-  { loc: `${SITE_URL}/tracker.html`,      changefreq: 'always',  priority: '0.95' },
-  { loc: `${SITE_URL}/compare.html`,      changefreq: 'always',  priority: '0.80' },
-  { loc: `${SITE_URL}/heatmap.html`,      changefreq: 'daily',   priority: '0.70' },
-  { loc: `${SITE_URL}/shops.html`,        changefreq: 'weekly',  priority: '0.85' },
-  { loc: `${SITE_URL}/calculator.html`,   changefreq: 'monthly', priority: '0.75' },
-  { loc: `${SITE_URL}/portfolio.html`,    changefreq: 'weekly',  priority: '0.60' },
-  { loc: `${SITE_URL}/learn.html`,        changefreq: 'monthly', priority: '0.65' },
-  { loc: `${SITE_URL}/methodology.html`,  changefreq: 'monthly', priority: '0.55' },
-  { loc: `${SITE_URL}/privacy.html`,      changefreq: 'yearly',  priority: '0.30' },
-  { loc: `${SITE_URL}/terms.html`,        changefreq: 'yearly',  priority: '0.30' },
-];
-
-for (const p of staticPages) {
-  const filePath = sitemapUrlToFilePath(p.loc);
-  if (fs.existsSync(filePath) && isNoindexFile(filePath)) continue;
-  urls.push(url(p.loc, p.changefreq, p.priority));
-}
-
-const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:xhtml="http://www.w3.org/1999/xhtml">
-${urls.join('')}
-</urlset>`;
-
-const outPath = path.join(ROOT, 'sitemap.xml');
-fs.writeFileSync(outPath, xml, 'utf8');
-console.log(`✅ sitemap.xml written with ${urls.length} URLs`);
+execFileSync(process.execPath, [CANONICAL_GENERATOR, ...process.argv.slice(2)], {
+  cwd: ROOT,
+  stdio: 'inherit',
+});

--- a/market.html
+++ b/market.html
@@ -624,6 +624,12 @@
                 <h3 class="mkt-router-title">Compare countries</h3>
                 <p class="mkt-router-text">Reference prices side by side across markets.</p>
               </a>
+              <a class="mkt-router-card" href="dubai-gold-price.html">
+                <h3 class="mkt-router-title">Dubai &amp; UAE gold price</h3>
+                <p class="mkt-router-text">
+                  Reference gold rate per gram in AED, by karat, with making charges and VAT.
+                </p>
+              </a>
               <a class="mkt-router-card" href="heatmap.html">
                 <h3 class="mkt-router-title">World map</h3>
                 <p class="mkt-router-text">A retail-estimate heatmap, country by country.</p>
@@ -649,6 +655,12 @@
               <a class="mkt-router-card" href="compare.html">
                 <h3 class="mkt-router-title">قارن الدول</h3>
                 <p class="mkt-router-text">أسعار مرجعية جنباً إلى جنب عبر الأسواق.</p>
+              </a>
+              <a class="mkt-router-card" href="dubai-gold-price.html">
+                <h3 class="mkt-router-title">سعر الذهب في دبي والإمارات</h3>
+                <p class="mkt-router-text">
+                  سعر الذهب المرجعي للغرام بالدرهم، حسب العيار، مع المصنعية وضريبة القيمة المضافة.
+                </p>
               </a>
               <a class="mkt-router-card" href="heatmap.html">
                 <h3 class="mkt-router-title">خريطة العالم</h3>


### PR DESCRIPTION
Two Phase-2 audit **SEO P2s** (`docs/audits/2026-07-04_deep-audit.md`).

- **Duplicate/stale sitemap generator** — `build/generateSitemap.js` hardcoded an **11-page** `staticPages` list (wired into `npm run build`) that **omitted** `dubai-gold-price.html`, `glossary.html`, `market.html` — three real indexable pages. `deploy.yml` separately re-runs the canonical filesystem-walk `scripts/node/generate-sitemap.js`, so production was fine, but the build-time generator was a stale footgun. Replaced it with a **thin delegator** to the canonical generator (keeps both callers — `npm run build` and `generate-baseline-inventory.js` — working); it now emits **14 URLs** including the 3 missing pages. No hardcoded list can drift again.
- **Thin inbound links to the Dubai landing** — `dubai-gold-price.html` (flagship UAE page) had a single inbound link. Added a contextual "Dubai & UAE gold price" card to `market.html`'s "Where to go next" router, mirrored across **both EN + AR** `data-lang-block` twins, reference-honest copy (AED per gram by karat, making charges + VAT).

## Verification
Delegator emits **14 URLs** (dubai/glossary/market present) · market.html carries the link in **both** language twins · `eslint` clean · `npm test` **1276/0** · `npm run validate` PASS (reference-language-sweep + `inject-schema --check` green) · `npm run build` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh

---
_Generated by [Claude Code](https://claude.ai/code/session_014KUnV8mFxHb35BNKs1GNTh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SEO/build plumbing and static internal links only; no auth, pricing logic, or runtime behavior changes.
> 
> **Overview**
> **`build/generateSitemap.js`** no longer maintains its own hardcoded `staticPages` list (which had drifted and omitted `dubai-gold-price.html`, `glossary.html`, and `market.html`). It now **execs the canonical** `scripts/node/generate-sitemap.js` so `npm run build` and other path-stable callers get the same filesystem-walk output as deploy, with **noindex** pages skipped automatically.
> 
> **`market.html`** adds a **“Dubai & UAE gold price”** router card in the **“Where to go next”** section, linking to `dubai-gold-price.html`, mirrored in **both EN and AR** `data-lang-block` twins with AED-per-gram / making-charge / VAT copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7296a79f284d1bf165bbc535b70a651acdeb40f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->