### PR TITLE
Phase 2 — Runtime error audit &amp; defect register (30-phase revamp, Track A)

### DIFF
--- a/reports/qa/phase2-runtime-defect-register-2026-07-07.md
+++ b/reports/qa/phase2-runtime-defect-register-2026-07-07.md
@@ -1,0 +1,61 @@
+# Phase 2 — Runtime error audit & defect register (register only)
+
+**Scope:** `compare.html`, `heatmap.html`, `portfolio.html`, `tracker.html`, `calculator.html`, each
+in EN (default) and AR (`?lang=ar`). **This phase does not fix anything** — it records what a later
+phase must address. Method: (1) the Phase 1 Playwright console capture
+(`reports/qa/console-baseline-2026-07-07.json`), (2) a static runtime-risk scan of the page entry
+modules, (3) cross-reference with the live-site audit `docs/revamp/00-AUDIT.md`.
+
+## 1. Runtime console / exception result
+
+| Page            | EN console.error | AR console.error | pageerror (uncaught) |
+| --------------- | ---------------: | ---------------: | -------------------: |
+| calculator.html |                0 |                0 |                    0 |
+| compare.html    |                0 |                0 |                    0 |
+| heatmap.html    |                0 |                0 |                    0 |
+| portfolio.html  |                0 |                0 |                    0 |
+| tracker.html    |                0 |                0 |                    0 |
+
+**All five pages: zero uncaught exceptions and zero console errors** in the deploy-staged build (see
+Phase 1 caveat: outbound egress is blocked in this sandbox, so the live gold/FX/Supabase fetches
+fail — but the app absorbs those via its fallback chain and the global `unhandledrejection` reporter
+(`src/lib/error-reporter.js`), producing no console error and no crash. That graceful degradation is
+correct behaviour, not a defect).
+
+## 2. Static runtime-risk scan (code-level)
+
+| Check                                    | Result                                                                                                        |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `setInterval` / `clearInterval` pairing  | ✅ balanced on all 5 pages (calc 2/2, heatmap 2/2, portfolio 2/2, compare 2/2, tracker 2/3)                   |
+| `visibilitychange` / `pagehide` teardown | ✅ present on all 5 pages (pauses/cleans timers off-screen)                                                   |
+| Promise `.then` without `.catch`         | ✅ none — every `.then` chain has a `.catch`, and unhandled rejections are backstopped by the global reporter |
+| `alert()` / `confirm()` in these pages   | ✅ none                                                                                                       |
+| DOM sinks (`innerHTML`)                  | ✅ 0 baseline (enforced by `npm run validate` `check-unsafe-dom`)                                             |
+
+No new **code-level** runtime defect found in the five pages. Interval/promise hygiene is clean.
+
+## 3. Candidate defects carried forward (need a live feed to reproduce — NOT fixed here)
+
+These come from `docs/revamp/00-AUDIT.md` (observed on the live site with a real price feed) and
+cannot be reproduced in this no-egress sandbox. Logged here so the owning phase closes them:
+
+| ID   | Page                           | Symptom (from live audit)                                                                                                                                                            | Severity       | Owning phase                                                                       |
+| ---- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- | ---------------------------------------------------------------------------------- |
+| R-01 | calculator (+ shared spot bar) | A ~9-min-old price still labelled **"Live"** (12-min stale window is too generous)                                                                                                   | high (trust)   | **Phase 6** (freshness policy)                                                     |
+| R-02 | calculator                     | Mixed-direction bidi glitch: `AED 435.37 د.إ per gram` renders the currency glyph out of order                                                                                       | medium (i18n)  | **Phase 20** (RTL/bidi)                                                            |
+| R-03 | calculator                     | "Compare in the live tracker" handoff column wraps ~3 words/line with dead space                                                                                                     | low (layout)   | **Phase 23** (calc UX) — reconcile with PR #535 which already touched calc density |
+| R-04 | tracker                        | Ensure the SVG chart's last value and the hero spot value never disagree (homepage had a TradingView-vs-spot mismatch, P1-2; verify tracker's own chart is fed from the same series) | medium (trust) | **Phase 22** (tracker integrity)                                                   |
+| R-05 | heatmap                        | Legend/keyboard/table-fallback clarity (not an error; polish)                                                                                                                        | low            | **Phase 25**                                                                       |
+| R-06 | portfolio                      | Confirm honest-gain rules never total cross-currency or partial-cost-basis holdings                                                                                                  | high (trust)   | **Phase 26** (preserve rules + tests)                                              |
+
+### Related (outside the 5 pages, noted for their owning phases)
+
+- Homepage quick-convert blank on first paint (P1-5) → Phase 21. Homepage two-prices (P1-2) →
+  Phase 21. Nav overlap at tablet widths (P1-3) → Phase 18/21. Muted-text contrast < AA (P1-4) →
+  Phase 19. `favicon.svg` 404 (P2-1) → Phase 9.
+
+## 4. Verdict
+
+Runtime layer is **healthy** — no uncaught errors, clean timer/promise teardown across all five
+tools. The real risks are **trust-label and i18n** issues (R-01, R-02, R-04, R-06) that require a
+live feed to observe; each is assigned to its Track B/E/F owning phase. No fixes applied in Phase 2.


### PR DESCRIPTION
## What

Phase 2 (Track A) — a **register-only** runtime audit of `compare` / `heatmap` / `portfolio` / `tracker` / `calculator` in EN + AR. Adds one report, `reports/qa/phase2-runtime-defect-register-2026-07-07.md`. **No code fixed** (by design — fixes belong to later phases).

## Why

Establish an evidence-based defect register before Track B–F start, so each real issue is assigned to the phase that owns its fix and nothing is missed or double-fixed.

## Findings

- **Runtime is healthy:** 0 uncaught exceptions and 0 console errors across all 5 pages × {EN, AR} (deploy-staged build). Blocked external fetches in the sandbox are absorbed by the fallback chain + the global `unhandledrejection` reporter — graceful degradation, not a defect.
- **Static scan clean:** balanced `setInterval`/`clearInterval`, `visibilitychange`/`pagehide` teardown on every page, `.catch` on every promise chain, no `alert()`/`confirm()`, 0 `innerHTML` sinks.
- **6 candidate defects carried forward** (R-01…R-06) — all require a live price feed to reproduce (can't be seen in a no-egress sandbox), each assigned to its owning phase: freshness "9-min Live" → Phase 6; bidi glyph → Phase 20; calc handoff layout → Phase 23; tracker chart-vs-spot parity → Phase 22; heatmap legend → Phase 25; portfolio honest-gain rules → Phase 26.

## Files touched

`reports/qa/phase2-runtime-defect-register-2026-07-07.md` only.

## Tests run

`npm run validate` (exit 0), `npm test` (**1286/1286**). No source touched, so runtime behaviour is unchanged.

## Risk

**None** — a report doc only.

## Manual QA notes

Register honestly flags that live-feed-dependent items were **not** reproduced here and defers them (with page + severity + owning phase) rather than claiming they're fixed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no source or runtime behaviour impact.
> 
> **Overview**
> **Adds** `reports/qa/phase2-runtime-defect-register-2026-07-07.md` as Track A Phase 2 deliverable: **no application code changes**, only an evidence-based defect register for later phases.
> 
> The report **documents** that `compare`, `heatmap`, `portfolio`, `tracker`, and `calculator` (EN + `?lang=ar`) showed **zero** `console.error` and uncaught `pageerror` on the deploy-staged build, with a note that blocked egress in QA is handled by fallbacks and `error-reporter.js` rather than treated as defects. A **static scan** records clean timer pairing, visibility teardown, promise `.catch` coverage, and no unsafe DOM sinks on those pages.
> 
> It **carries forward** six live-feed-dependent issues from `docs/revamp/00-AUDIT.md` (R-01–R-06) with severity and **owning phase** (e.g. stale “Live” label → Phase 6, RTL bidi → Phase 20, tracker chart vs spot → Phase 22, portfolio honest-gain → Phase 26), plus related homepage items outside scope. **Verdict:** runtime layer healthy; trust/i18n items deferred, not fixed here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5135a7d4319e3c1329c3c077d3d048ac64f5d2a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->