### PR TITLE
Phase 5 — Spot-vs-retail parity fix on compare + heatmap (Track B)

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -158,7 +158,9 @@
             <span class="compare-fresh" id="compare-freshness" data-state="unavailable"></span>
           </div>
           <p class="compare-trust-note">
-            Spot-linked reference estimates — not final retail quotes.
+            <span id="compare-trust-text"
+              >Spot-linked reference estimates — not final retail quotes.</span
+            >
             <a id="compare-methodology" href="methodology.html">How prices work →</a>
           </p>
         </div>

--- a/heatmap.html
+++ b/heatmap.html
@@ -167,7 +167,9 @@
             <span class="heatmap-fresh" id="heatmap-freshness" data-state="unavailable"></span>
           </div>
           <p class="heatmap-trust-note">
-            Spot-linked reference estimates — not final retail quotes.
+            <span id="heatmap-trust-text"
+              >Spot-linked reference estimates — not final retail quotes.</span
+            >
             <a id="heatmap-methodology" href="methodology.html">How prices work →</a>
           </p>
         </div>

--- a/reports/qa/phase5-spot-vs-retail-2026-07-07.md
+++ b/reports/qa/phase5-spot-vs-retail-2026-07-07.md
@@ -1,0 +1,48 @@
+# Phase 5 — Spot-vs-retail hardening (Track B)
+
+Verifies and hardens the spot-linked-reference vs retail-quote separation across every price
+surface, per the non-negotiable "reference ≠ retail" rule and EN/AR parity.
+
+## Audit result — separation is already strong
+
+Every price surface already carries explicit spot-vs-retail framing:
+
+| Surface       | Framing present                                                                                                                                        | Bilingual?                          |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
+| index (home)  | `#trust-banner-copy` "spot-linked reference estimates, not final retail…"                                                                              | ✅ id, localized by `home.js`       |
+| tracker       | multiple ("bullion estimates — not retail or jewelry quotes", method "Retail vs bullion")                                                              | ✅ translations.js keys             |
+| calculator    | `#calc-trust-note` built in JS with "not final retail jewelry quotes"                                                                                  | ✅ `calculator.js:1052` (EN/AR)     |
+| compare       | `.compare-trust-note` "Spot-linked reference estimates — not final retail quotes."                                                                     | ❌ **sentence was EN-only** → fixed |
+| heatmap       | `.heatmap-trust-note` "Spot-linked reference estimates — not final retail quotes."                                                                     | ❌ **sentence was EN-only** → fixed |
+| portfolio     | reference-valuation framing (making charges called out)                                                                                                | ✅                                  |
+| shops         | `#shops-price-disclaimer` "spot-based estimates, not actual shop prices; retail quotes include making charges…" + "Why shop prices differ from spot →" | ✅ `shops.js` localized             |
+| country pages | market-intel VAT/making-charge/retail-estimate panels                                                                                                  | ✅                                  |
+
+## The one real gap fixed — EN/AR parity on the compare + heatmap trust note
+
+On `compare.html` and `heatmap.html`, the trust sentence sat as a bare text node inside
+`<p class="*-trust-note">`, and each page's `applyLang()` localized the neighbouring methodology
+link but **not** the sentence. So in Arabic (`?lang=ar`) the most prominent spot-vs-retail statement
+on those two pages **stayed in English** — a violation of the non-negotiable EN/AR parity rule on
+exactly the kind of trust copy that must not diverge.
+
+**Fix (mirrors the proven pattern already used for `*-sub`, `*-h1`, etc.):**
+
+- Wrapped the sentence in `<span id="compare-trust-text">` / `<span id="heatmap-trust-text">`.
+- Added a `trustNote` key to both the EN and AR dictionaries in `src/pages/compare.js` and
+  `src/pages/heatmap.js`.
+- Added `set('…-trust-text', dict.trustNote)` inside each `applyLang()`.
+
+AR copy: **«تقديرات مرجعية مرتبطة بالسعر الفوري — وليست أسعار تجزئة نهائية.»** — semantic parity
+with the EN, matching the site's existing AR reference/retail vocabulary.
+
+## Not changed (intentionally)
+
+- Calculator density / preset copy — owned by **PR #535**; not touched.
+- Heatmap legend/keyboard/table polish — **Phase 25**; the spot/retail _lens toggle_ — **Phase 31**.
+- Methodology deep-link enrichment — **Phase 7**.
+
+## Verification
+
+`npm run validate`, `npm test`, `npm run build` all green; the two pages render the Arabic trust
+note under `?lang=ar` (verified against the built bundle).

--- a/src/pages/compare.js
+++ b/src/pages/compare.js
@@ -101,6 +101,7 @@ const T = {
     disclaimer:
       'Gold value per gram is globally identical in USD — differences below come from local VAT and typical making charges. All figures are spot-linked reference estimates, not final retail quotes or financial advice.',
     methodology: 'How prices work →',
+    trustNote: 'Spot-linked reference estimates — not final retail quotes.',
     unavailable: 'Unavailable',
     freshness: {
       live: 'Live',
@@ -147,6 +148,7 @@ const T = {
     disclaimer:
       'قيمة غرام الذهب متطابقة عالمياً بالدولار — الفروق أدناه ناتجة عن الضريبة المحلية والمصنعية المعتادة. جميع الأرقام تقديرات مرجعية مرتبطة بالسعر الفوري وليست أسعار تجزئة نهائية ولا نصيحة مالية.',
     methodology: 'كيف تُحتسب الأسعار ←',
+    trustNote: 'تقديرات مرجعية مرتبطة بالسعر الفوري — وليست أسعار تجزئة نهائية.',
     unavailable: 'غير متاح',
     freshness: {
       live: 'مباشر',
@@ -752,6 +754,7 @@ function applyLang() {
   set('compare-sub', dict.sub);
   set('compare-selected-label', dict.selected);
   set('compare-disclaimer', dict.disclaimer);
+  set('compare-trust-text', dict.trustNote);
   const addLabel = document.querySelector('#compare-add-btn .compare-add-label');
   if (addLabel) addLabel.textContent = dict.addCountry;
   const methodLink = document.getElementById('compare-methodology');

--- a/src/pages/heatmap.js
+++ b/src/pages/heatmap.js
@@ -97,6 +97,7 @@ const T = {
     disclaimer:
       'Gold value per gram is globally identical in USD — the map colors reflect local VAT and typical making charges only. All figures are spot-linked reference estimates, not final retail quotes or financial advice.',
     methodology: 'How prices work →',
+    trustNote: 'Spot-linked reference estimates — not final retail quotes.',
     freshness: {
       live: 'Live',
       delayed: 'Delayed',
@@ -160,6 +161,7 @@ const T = {
     disclaimer:
       'قيمة الذهب لكل جرام متطابقة عالمياً بالدولار — ألوان الخريطة تعكس الضريبة المحلية وأجور الصياغة المعتادة فقط. جميع الأرقام تقديرات مرجعية مرتبطة بالسعر الفوري، وليست أسعار تجزئة نهائية ولا نصيحة مالية.',
     methodology: 'كيف تُحسب الأسعار ←',
+    trustNote: 'تقديرات مرجعية مرتبطة بالسعر الفوري — وليست أسعار تجزئة نهائية.',
     freshness: {
       live: 'مباشر',
       delayed: 'متأخر',
@@ -815,6 +817,7 @@ function applyLang() {
   set('heatmap-how-2', dict.how2);
   set('heatmap-how-3', dict.how3);
   set('heatmap-disclaimer', dict.disclaimer);
+  set('heatmap-trust-text', dict.trustNote);
   const methodLink = document.getElementById('heatmap-methodology');
   if (methodLink) methodLink.textContent = dict.methodology;
   const svg = document.querySelector('.heatmap-svg');


### PR DESCRIPTION
## What

Phase 5 (Track B — data trust). Spot-vs-retail hardening sweep across all 8 price surfaces, fixing the one genuine gap found: the **compare + heatmap trust note stayed English in Arabic mode**.

## Why

The line *"Spot-linked reference estimates — not final retail quotes."* is the most prominent reference-vs-retail statement on `compare.html` and `heatmap.html`. It sat as a bare text node inside `<p class="*-trust-note">`; each page's `applyLang()` localized the adjacent methodology link but **not** the sentence — so under `?lang=ar` it rendered in English. That violates the non-negotiable EN/AR parity rule on exactly the trust copy that must not diverge.

## How

Mirrors the proven pattern already used for `*-h1` / `*-sub`:
- Wrapped the sentence in `<span id="compare-trust-text">` / `<span id="heatmap-trust-text">`.
- Added a `trustNote` key to the **EN and AR** dicts in `src/pages/compare.js` and `src/pages/heatmap.js` (AR: «تقديرات مرجعية مرتبطة بالسعر الفوري — وليست أسعار تجزئة نهائية.»).
- Wired `set('*-trust-text', dict.trustNote)` into each `applyLang()`.

Audit of the other six surfaces (home / tracker / calculator / portfolio / shops / country) confirms their reference-vs-retail framing is already bilingual — documented in `reports/qa/phase5-spot-vs-retail-2026-07-07.md`.

## Files touched

`compare.html`, `src/pages/compare.js`, `heatmap.html`, `src/pages/heatmap.js`, + report. **No overlap** with PR #535 (calc/shops density) or Phases 7/25/31.

## Tests run

`npm run validate` (0), `npm test` (**1286/1286**), `npm run build` (0). **Playwright behavioral check:** both pages render the Arabic trust note with `dir=rtl` under `?lang=ar` → PASS.

## Risk

**Low** — additive i18n wiring on two static pages; no pricing/logic change; invariants untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only i18n wiring on two static pages; no pricing, FX, or calculation logic changes.
> 
> **Overview**
> Fixes **EN/AR parity** for the hero spot-vs-retail trust line on **compare** and **heatmap**, where Arabic mode (`?lang=ar`) still showed the English sentence while the methodology link was already localized.
> 
> The trust copy is wrapped in `#compare-trust-text` / `#heatmap-trust-text`, **`trustNote`** is added to each page’s EN/AR dictionaries in `compare.js` and `heatmap.js`, and **`applyLang()`** now sets those spans like other hero strings. A Phase 5 QA note documents the surface audit and that other price pages were already bilingual.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a6d8cb95de45a1f459e519cf543febb569cfe28. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->