### PR TITLE
Phase 6 — Fix shops spot bar vs ticker freshness divergence (Track B)

### DIFF
--- a/reports/qa/phase6-freshness-unification-2026-07-07.md
+++ b/reports/qa/phase6-freshness-unification-2026-07-07.md
@@ -1,0 +1,52 @@
+# Phase 6 — Unified freshness/fallback labeling (Track B)
+
+Fixes the confirmed live bug where `shops.html`'s sticky top price bar showed offline
+`—`/unavailable while the bottom ticker on the same page showed the (cached) price — by making
+**both widgets consume the same freshness/snapshot source**.
+
+## Root cause
+
+`src/pages/shops.js` imported and called **only** `updateTicker(...)`. It mounted the shared sticky
+spot bar (`mountSharedShell({ withSpotBar: true })`) but **never called `updateSpotBar(...)`**, so
+the bar stayed at its injected default (`data-freshness="unavailable"`, values `—`) forever, while
+the ticker was populated from `cache.getFallbackGoldPrice()`. Every other price page (`compare.js`,
+`heatmap.js`, home, tracker) calls **both** `updateTicker` and `updateSpotBar` from the same
+snapshot — shops was the lone exception.
+
+Confirmed shops has exactly one price-update path (a single cache-populate at init; no live refresh
+loop), so a single added `updateSpotBar` call is the complete fix. The spot bar's language is
+already handled by the shared shell (`site-shell.js` → `updateSpotBarLang`).
+
+## Fix
+
+In `src/pages/shops.js`, after the existing `updateTicker({...})` populate:
+
+```js
+import { updateSpotBar } from '../components/spotBar.js';
+…
+updateSpotBar({
+  xauUsd: spot,
+  aed24kGram: aedGram('24'),
+  updatedAt: cachedGold.updatedAt || null,
+  hasLiveFailure: true, // cached snapshot → labelled cached/fallback, never "Live"
+});
+```
+
+Both widgets now read the **same** cached snapshot and the **same** freshness classifier
+(`getLiveFreshness` in `src/lib/live-status.js`), so their states can no longer diverge. Because the
+data is a committed cache entry, `hasLiveFailure: true` keeps the bar honestly labelled
+cached/fallback — it is never shown as "Live" (consistent with the Phase 4 finding that the
+committed/age path must not claim "Live").
+
+## Not changed
+
+- The two-freshness-system reconciliation (live-API 5/60/300 s vs age 30/75 min) is a documentation
+  concern already captured in Phase 4; this phase does not alter thresholds or the `live-status.js`
+  / `freshness-policy.js` primitives — it wires shops onto the existing shared source.
+- `sw.js` (owner-gated) untouched.
+
+## Verification
+
+`npm run validate` / `npm test` / `npm run build` green. Playwright: with a fresh cached price
+seeded in `localStorage`, `shops.html`'s `#spot-price-bar` now renders the cached 24K AED/g +
+XAU/USD with a non-`unavailable` freshness state (cached/fallback) instead of `—`.

--- a/src/pages/shops.js
+++ b/src/pages/shops.js
@@ -2,6 +2,7 @@ import { COUNTRIES } from '../config/countries.js';
 import { SHOPS as FALLBACK_SHOPS } from '../../data/shops.js';
 import { fetchShops as fetchSupabaseShops } from '../lib/supabase-data.js';
 import { updateTicker } from '../components/ticker.js';
+import { updateSpotBar } from '../components/spotBar.js';
 import { mountSharedShell } from '../components/site-shell.js';
 import { injectBreadcrumbs } from '../components/breadcrumbs.js';
 import * as cache from '../lib/cache.js';
@@ -2325,6 +2326,16 @@ function init() {
       uae18k: aedGram('18'),
       updatedAt: cachedGold.updatedAt || null,
       // Cached fallback data is, by definition, not a live response.
+      hasLiveFailure: true,
+    });
+    // Feed the shared sticky spot bar from the SAME cached snapshot as the ticker,
+    // so it never shows offline "—" while the ticker shows the (cached) price. Both
+    // widgets now read one freshness/snapshot source. hasLiveFailure keeps the bar
+    // honestly labelled cached/fallback (never "Live") for committed-cache data.
+    updateSpotBar({
+      xauUsd: spot,
+      aed24kGram: aedGram('24'),
+      updatedAt: cachedGold.updatedAt || null,
       hasLiveFailure: true,
     });
   }


### PR DESCRIPTION
## What

Phase 6 (Track B). Fixes the **confirmed live bug**: on `shops.html` the sticky top price bar showed offline `—`/unavailable while the bottom ticker on the same page showed the (cached) price. Now both widgets consume the **same** freshness/snapshot source.

## Root cause

`src/pages/shops.js` mounted the shared sticky spot bar (`mountSharedShell({ withSpotBar: true })`) and populated the **ticker** from `cache.getFallbackGoldPrice()`, but **never called `updateSpotBar(...)`** — so the bar stayed at its injected default (`data-freshness="unavailable"`, `—`). Every other price page (compare, heatmap, home, tracker) updates *both* widgets from one snapshot; shops was the lone exception. Confirmed shops has a single price-update path (no live refresh loop), so one added call is the complete fix.

## How

```js
import { updateSpotBar } from '../components/spotBar.js';
…
updateSpotBar({ xauUsd: spot, aed24kGram: aedGram('24'), updatedAt: cachedGold.updatedAt || null, hasLiveFailure: true });
```

`hasLiveFailure: true` keeps the bar honestly labelled **cached/fallback** (never "Live") for committed-cache data — consistent with the Phase 4 finding.

## Files touched

`src/pages/shops.js` (2-line import + one call) + report. `sw.js` (owner-gated) untouched.

## Tests run

`npm run validate` (0), `npm test` (**1286/1286**), `npm run build` (0). **Playwright behavioral check:** seeding a fresh cached price, `#spot-price-bar` now renders `aed=474.83`, `xau=$4,021.50`, `data-freshness="cached"` (was `unavailable`/`—`) → **PASS**.

## Risk

**Low** — additive; feeds an already-mounted widget from the existing shared source; no threshold/logic change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive wiring on one page using existing `updateSpotBar`; no auth, pricing logic, or freshness policy changes.
> 
> **Overview**
> Fixes **shops.html** showing conflicting price UI: the sticky `#spot-price-bar` stayed on default `—` / `unavailable` while the bottom ticker showed values from `cache.getFallbackGoldPrice()`.
> 
> **`src/pages/shops.js`** now imports `updateSpotBar` and, in the same init block as `updateTicker`, passes the identical cached snapshot (`xauUsd`, 24K AED/g, `updatedAt`) with **`hasLiveFailure: true`** so freshness stays **cached/fallback**, not "Live". No changes to freshness thresholds or `live-status.js` / `sw.js`.
> 
> Adds **`reports/qa/phase6-freshness-unification-2026-07-07.md`** documenting root cause, fix, and verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d7807c48ee9677d403377b0b4ab76af8f88f44c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->