### PR TITLE
Phase 7 — Methodology parity verification + tool deep-links (Track B)

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -169,7 +169,7 @@
           <p class="calc-disclaimer" id="calc-trust-note">
             Calculator outputs are spot-linked reference estimates — not final retail jewelry quotes.
             Actual shop prices add making charges, premiums, and taxes.
-            <a href="methodology.html">Spot vs retail explained →</a>
+            <a href="methodology.html#not-included">Spot vs retail explained →</a>
             · <a href="methodology.html">Full methodology →</a>
           </p>
           <div class="calc-hero-breakdown" id="calc-hero-breakdown">

--- a/portfolio.html
+++ b/portfolio.html
@@ -169,7 +169,7 @@
           </div>
           <p class="portfolio-trust-note">
             <span id="portfolio-privacy">Stored only on this device — holdings are never uploaded.</span>
-            <a id="portfolio-methodology" href="methodology.html">How prices work →</a>
+            <a id="portfolio-methodology" href="methodology.html#live-formula">How prices work →</a>
           </p>
         </div>
       </section>

--- a/reports/qa/phase7-methodology-2026-07-07.md
+++ b/reports/qa/phase7-methodology-2026-07-07.md
@@ -1,0 +1,46 @@
+# Phase 7 — Methodology as source of truth + deep links (Track B)
+
+Verifies the methodology page's formulas match the code **exactly** (no math change), and upgrades
+the plain methodology CTAs on the tools that still linked to the top of the page into **section deep
+links**.
+
+## Formula parity — exact match (no change made)
+
+| Methodology statement                       | Code                                                                           | Match    |
+| ------------------------------------------- | ------------------------------------------------------------------------------ | -------- |
+| `÷ 31.1035` (troy ounce → gram)             | `CONSTANTS.TROY_OZ_GRAMS = 31.1035` (`price-calculator.js` `usdPerGram`)       | ✅       |
+| `× (karat ÷ 24)`                            | `karats.js` purity = literally `22/24`, `21/24`, … (24K = 1.0)                 | ✅ exact |
+| `× FX`                                      | `localPrice(usdPrice, fxRate) = usdPrice * fxRate`                             | ✅       |
+| AED = fixed **3.6725** peg (never from API) | `CONSTANTS.AED_PEG = 3.6725`; FX AED value stripped and replaced at call sites | ✅       |
+
+Additionally, methodology.html renders a **live** formula (`#method-formula-pipeline` via
+`methodology.js`) computed through the same pipeline, so the displayed formula and the live prices
+share one code path — parity is guaranteed by construction, not by manual sync. **No pricing
+constant or karat factor was touched** (they are owner-gated).
+
+Anchor validity: every methodology anchor the tools link to (`#gold-data`, `#fx-rates`,
+`#karat-conversion`, `#not-included`, `#fallback`, `#disclaimer`, `#live-formula`, `#aed-peg`,
+`#freshness-states`, `#before-you-shop`) exists as a real section id — no broken deep links.
+
+## Deep-link upgrades (this phase)
+
+Tracker already deep-links to specific methodology sections (the gold-standard pattern). Brought two
+more tools up to that standard:
+
+| Tool       | Before                                          | After                                                                            |
+| ---------- | ----------------------------------------------- | -------------------------------------------------------------------------------- |
+| portfolio  | `methodology.html` "How prices work →"          | `methodology.html#live-formula`                                                  |
+| calculator | `methodology.html` "Spot vs retail explained →" | `methodology.html#not-included` (the section on making charges / premiums / VAT) |
+
+## Deferred (collision-avoidance, not skipped)
+
+`compare.html` and `heatmap.html` also have a plain `methodology.html` "How prices work →" link —
+but that link sits inside the exact `<p class="*-trust-note">` block **already modified by Phase 5
+(PR #542)**. To avoid a merge conflict between the two open PRs, their anchor upgrade to
+`#live-formula` is deferred; apply it when #542 merges (one-line `href` change each). Logged here so
+it isn't lost.
+
+## Verification
+
+`npm run validate` / `npm test` / `npm run build` green. Links resolve to existing methodology
+section ids.


### PR DESCRIPTION
## What

Phase 7 (Track B). Verifies methodology.html is the true source of truth (formulas match code **exactly**, no math change) and upgrades two plain methodology CTAs into section deep links.

## Formula parity — exact (nothing changed)

| Methodology | Code | |
|---|---|---|
| `÷ 31.1035` | `CONSTANTS.TROY_OZ_GRAMS = 31.1035` | ✅ |
| `× (karat ÷ 24)` | `karats.js` purity = literally `22/24`, `21/24`… (24K=1.0) | ✅ exact |
| `× FX` | `localPrice = usdPrice * fxRate` | ✅ |
| AED fixed `3.6725` | `CONSTANTS.AED_PEG = 3.6725` (API AED stripped) | ✅ |

The page also renders a **live** formula (`#method-formula-pipeline`) through the same pipeline, so parity is guaranteed by construction. Owner-gated pricing constants/karat factors were **not** touched. All existing tool→methodology anchor links resolve to real section ids.

## How (the one code change)

Brought two tools up to tracker's deep-link standard:
- portfolio: `methodology.html` → `methodology.html#live-formula`
- calculator "Spot vs retail explained": `methodology.html` → `methodology.html#not-included`

## Deferred (documented, not silently skipped)

compare/heatmap's methodology CTA sits inside the trust-note block **already edited by Phase 5 (#542)**. To avoid a merge collision between two open PRs, their `#live-formula` anchor upgrade is deferred — apply when #542 merges (one-line each). Recorded in the report.

## Files touched

`portfolio.html`, `calculator.html` (one `href` each) + `reports/qa/phase7-methodology-2026-07-07.md`.

## Tests run

`npm run validate` (0), `npm test` (**1286/1286**), `npm run build` (0).

## Risk

**Very low** — two anchor href changes + a verification report; no logic/pricing change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only two `href` anchor updates and a documentation report; no application logic or pricing constants were modified.
> 
> **Overview**
> **Phase 7 (Track B)** documents that `methodology.html` formulas already match pricing code (troy oz, karat purity, FX, AED peg) with **no math or constant changes**, and aligns two tool CTAs with tracker-style **section deep links**.
> 
> On **portfolio**, “How prices work →” now opens `methodology.html#live-formula`. On **calculator**, “Spot vs retail explained →” now opens `methodology.html#not-included` (making charges / VAT context).
> 
> Adds `reports/qa/phase7-methodology-2026-07-07.md` with the parity table, anchor checklist, and a note that **compare** / **heatmap** `#live-formula` link updates are deferred until Phase 5 (#542) merges to avoid trust-note merge conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4f648c9a6b5046b1326ee79abb31f79cdd320f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->