### PR TITLE
Phase 8 — Secondary-provider cross-validation (flagged, owner-gated) (Track B)

### DIFF
--- a/reports/data/phase8-cross-validation-2026-07-07.md
+++ b/reports/data/phase8-cross-validation-2026-07-07.md
@@ -1,0 +1,46 @@
+# Phase 8 — Secondary-provider cross-validation (Track B · 🟡 flagged, owner-gated to enable)
+
+Adds **divergence detection** between the primary and secondary gold providers, behind a build
+feature flag that is **OFF by default**. Enabling it live — and surfacing the "under review" state
+to users — is an **owner decision** (it changes what users are told about price trust). No peg/troy
+math is touched; the displayed price is never altered by this module.
+
+## What ships (dormant)
+
+| File                                          | Role                                                                                                  |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `src/config/feature-flags.js`                 | New flags module (separate from the owner-gated `constants.js`). `CROSS_VALIDATION_ENABLED: false`.   |
+| `src/lib/quote-providers/cross-validation.js` | Pure comparison logic: `computeDivergencePct`, `evaluateCrossValidation`, `isCrossValidationEnabled`. |
+| `tests/cross-validation.test.js`              | 8 unit tests (disabled default, agree/under-review, insufficient-data, threshold math).               |
+
+## Behaviour
+
+`evaluateCrossValidation({ primaryUsd, secondaryUsd })` returns one of:
+
+- `disabled` — the flag is OFF (production default). **Nothing changes.**
+- `insufficient-data` — a secondary price isn't available or is invalid → **no false positives**.
+- `agree` — divergence ≤ threshold (default **0.75%**, symmetric vs the mean).
+- `under-review` — divergence > threshold → a consumer may show an "under review" trust chip.
+
+Divergence is symmetric (`|a−b| / mean × 100`), so it doesn't matter which provider is "primary".
+
+## Why this is safe now
+
+- **Flag defaults OFF** — the module short-circuits to `disabled`, so no runtime path, UI, or price
+  changes until the owner flips one boolean and rebuilds.
+- **Non-authoritative** — it produces a _status_, never a price. The peg (3.6725) and troy (31.1035)
+  constants are untouched (and their file was not edited).
+- **Builds on existing plumbing** — `secondary-provider.js` and the `secondaryHealth` snapshot in
+  `realtime-pricing-engine.js` already exist; this only adds the comparison.
+
+## Owner gate — to enable live (do NOT do without owner approval)
+
+1. Set `CROSS_VALIDATION_ENABLED: true` in `src/config/feature-flags.js`.
+2. Wire it where both provider quotes are in scope — e.g. in `realtime-pricing-engine.js`'s flag
+   computation, call `evaluateCrossValidation({ primaryUsd, secondaryUsd })` and, on `under-review`,
+   push a warning flag (e.g. `provider_divergence_under_review`) alongside the existing SLO flags.
+3. Optionally surface an "under review" freshness chip on price surfaces (reuse the freshness pill).
+4. Confirming the **secondary provider is populated in production** requires the owner-gated
+   `gold-price-fetch.yml` (writes `data/gold_price.json` provider fields) — **not changed here**.
+
+Until then, the detection is tested and ready but inert.

--- a/src/config/feature-flags.js
+++ b/src/config/feature-flags.js
@@ -1,0 +1,25 @@
+/**
+ * feature-flags.js — build-time feature flags for opt-in, owner-gated capabilities.
+ *
+ * Every flag defaults to OFF. Flipping one to `true` enables the feature site-wide on the next
+ * build. Kept deliberately separate from `constants.js` so toggling a flag never touches the
+ * owner-gated pricing constants (AED peg, troy ounce). Enabling any flag that changes what users
+ * see about pricing is an owner decision.
+ */
+export const FEATURE_FLAGS = Object.freeze({
+  /**
+   * Secondary-provider cross-validation (Phase 8). When `true`, the pricing layer compares the
+   * primary and secondary provider spot prices and surfaces an "under review" trust state if they
+   * diverge beyond the configured threshold. OFF until the owner approves enabling it live — it must
+   * not change the peg/troy math or the displayed price, only add a review signal.
+   */
+  CROSS_VALIDATION_ENABLED: false,
+});
+
+/**
+ * @param {keyof FEATURE_FLAGS} name
+ * @returns {boolean}
+ */
+export function isFeatureEnabled(name) {
+  return FEATURE_FLAGS[name] === true;
+}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,6 +6,7 @@ export {
   FORMSPREE_ENDPOINT,
 } from './constants.js';
 export { SITE } from './site.js';
+export { FEATURE_FLAGS, isFeatureEnabled } from './feature-flags.js';
 export { KARATS } from './karats.js';
 export { COUNTRIES } from './countries.js';
 export { TRANSLATIONS } from './translations.js';

--- a/src/lib/quote-providers/cross-validation.js
+++ b/src/lib/quote-providers/cross-validation.js
@@ -1,0 +1,67 @@
+/**
+ * cross-validation.js — pure secondary-provider divergence detection (Phase 8, feature-flagged).
+ *
+ * Compares the primary and secondary provider spot prices (XAU/USD) and classifies whether they
+ * agree or diverge enough to warrant an "under review" trust signal. This module is:
+ *   • pure — math only; no fetching, no DOM, no timers, no side effects;
+ *   • non-authoritative — it never changes the peg/troy math or the displayed price, it only
+ *     produces a review status a consumer may surface;
+ *   • dormant by default — gated by FEATURE_FLAGS.CROSS_VALIDATION_ENABLED (OFF). Enabling it live
+ *     is an owner decision (see reports/data/phase8-cross-validation-2026-07-07.md).
+ *
+ * The repo already carries the plumbing this hooks into: `secondary-provider.js` and the
+ * `secondaryHealth` snapshot in `realtime-pricing-engine.js`. This adds only the comparison logic.
+ */
+import { isFeatureEnabled } from '../../config/feature-flags.js';
+
+/** Divergence (percent) beyond which two provider prices are flagged "under review". */
+export const DEFAULT_DIVERGENCE_THRESHOLD_PCT = 0.75;
+
+/** @returns {boolean} whether cross-validation is enabled by the build flag. */
+export function isCrossValidationEnabled() {
+  return isFeatureEnabled('CROSS_VALIDATION_ENABLED');
+}
+
+/**
+ * Symmetric percentage divergence between two positive prices (relative to their mean), or `null`
+ * when either input is not a valid positive number.
+ * @param {number} primaryUsd
+ * @param {number} secondaryUsd
+ * @returns {number|null}
+ */
+export function computeDivergencePct(primaryUsd, secondaryUsd) {
+  const a = Number(primaryUsd);
+  const b = Number(secondaryUsd);
+  if (!Number.isFinite(a) || !Number.isFinite(b) || a <= 0 || b <= 0) return null;
+  const mid = (a + b) / 2;
+  return (Math.abs(a - b) / mid) * 100;
+}
+
+/**
+ * Classify the primary vs secondary spot prices.
+ *
+ * @param {object}  [opts]
+ * @param {number}  [opts.primaryUsd]     Primary provider XAU/USD spot.
+ * @param {number}  [opts.secondaryUsd]   Secondary provider XAU/USD spot.
+ * @param {number}  [opts.thresholdPct]   Divergence threshold (%). Defaults to 0.75%.
+ * @param {boolean} [opts.enabled]        Override the flag (mainly for tests).
+ * @returns {{ status:'disabled'|'insufficient-data'|'agree'|'under-review', divergencePct:number|null, underReview:boolean }}
+ */
+export function evaluateCrossValidation({
+  primaryUsd,
+  secondaryUsd,
+  thresholdPct = DEFAULT_DIVERGENCE_THRESHOLD_PCT,
+  enabled = isCrossValidationEnabled(),
+} = {}) {
+  if (!enabled) return { status: 'disabled', divergencePct: null, underReview: false };
+  const divergencePct = computeDivergencePct(primaryUsd, secondaryUsd);
+  if (divergencePct == null) {
+    return { status: 'insufficient-data', divergencePct: null, underReview: false };
+  }
+  const threshold =
+    Number.isFinite(thresholdPct) && thresholdPct > 0
+      ? thresholdPct
+      : DEFAULT_DIVERGENCE_THRESHOLD_PCT;
+  const underReview = divergencePct > threshold;
+  return { status: underReview ? 'under-review' : 'agree', divergencePct, underReview };
+}

--- a/tests/cross-validation.test.js
+++ b/tests/cross-validation.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+// ES modules — load dynamically.
+let mod;
+async function load() {
+  if (!mod) mod = await import('../src/lib/quote-providers/cross-validation.js');
+  return mod;
+}
+
+test('defaults to disabled (feature flag OFF) — dormant in production', async () => {
+  const { evaluateCrossValidation } = await load();
+  const r = evaluateCrossValidation({ primaryUsd: 4000, secondaryUsd: 4500 });
+  assert.equal(r.status, 'disabled');
+  assert.equal(r.underReview, false);
+  assert.equal(r.divergencePct, null);
+});
+
+test('computeDivergencePct: symmetric percentage vs the mean', async () => {
+  const { computeDivergencePct } = await load();
+  assert.equal(computeDivergencePct(4000, 4000), 0);
+  // 4000 vs 4040 → |40| / 4020 * 100 ≈ 0.995%
+  assert.ok(Math.abs(computeDivergencePct(4000, 4040) - 0.995) < 0.01);
+});
+
+test('computeDivergencePct: invalid inputs → null', async () => {
+  const { computeDivergencePct } = await load();
+  assert.equal(computeDivergencePct(0, 4000), null);
+  assert.equal(computeDivergencePct(4000, -1), null);
+  assert.equal(computeDivergencePct(NaN, 4000), null);
+  assert.equal(computeDivergencePct(undefined, 4000), null);
+});
+
+test('enabled + within threshold → agree', async () => {
+  const { evaluateCrossValidation } = await load();
+  const r = evaluateCrossValidation({ primaryUsd: 4000, secondaryUsd: 4010, enabled: true });
+  assert.equal(r.status, 'agree');
+  assert.equal(r.underReview, false);
+  assert.ok(r.divergencePct > 0 && r.divergencePct < 0.75);
+});
+
+test('enabled + beyond threshold → under-review', async () => {
+  const { evaluateCrossValidation } = await load();
+  const r = evaluateCrossValidation({ primaryUsd: 4000, secondaryUsd: 4100, enabled: true });
+  assert.equal(r.status, 'under-review');
+  assert.equal(r.underReview, true);
+  assert.ok(r.divergencePct > 0.75);
+});
+
+test('enabled + missing/invalid secondary → insufficient-data (never false-positive)', async () => {
+  const { evaluateCrossValidation } = await load();
+  assert.equal(
+    evaluateCrossValidation({ primaryUsd: 4000, enabled: true }).status,
+    'insufficient-data'
+  );
+  assert.equal(
+    evaluateCrossValidation({ primaryUsd: 4000, secondaryUsd: 0, enabled: true }).status,
+    'insufficient-data'
+  );
+});
+
+test('custom threshold is honoured; invalid threshold falls back to default', async () => {
+  const { evaluateCrossValidation, DEFAULT_DIVERGENCE_THRESHOLD_PCT } = await load();
+  // ~0.995% divergence: under-review at 0.5% threshold, agree at 2%.
+  assert.equal(
+    evaluateCrossValidation({
+      primaryUsd: 4000,
+      secondaryUsd: 4040,
+      thresholdPct: 0.5,
+      enabled: true,
+    }).status,
+    'under-review'
+  );
+  assert.equal(
+    evaluateCrossValidation({
+      primaryUsd: 4000,
+      secondaryUsd: 4040,
+      thresholdPct: 2,
+      enabled: true,
+    }).status,
+    'agree'
+  );
+  // Invalid threshold → default (0.75%).
+  const r = evaluateCrossValidation({
+    primaryUsd: 4000,
+    secondaryUsd: 4040,
+    thresholdPct: -1,
+    enabled: true,
+  });
+  assert.equal(r.status, 'under-review');
+  assert.equal(DEFAULT_DIVERGENCE_THRESHOLD_PCT, 0.75);
+});
+
+test('isCrossValidationEnabled reflects the (default OFF) flag', async () => {
+  const { isCrossValidationEnabled } = await load();
+  assert.equal(isCrossValidationEnabled(), false);
+});


### PR DESCRIPTION
## What

Phase 8 (Track B · 🟡). Adds **divergence detection** between the primary and secondary gold providers, **dormant behind a build feature flag** (`CROSS_VALIDATION_ENABLED`, default **OFF**). Enabling it live is explicitly an **owner decision**.

## Why

Cross-validating two independent sources catches a bad provider before it misleads users — but surfacing an "under review" state changes what the site tells users about price trust, so it must be owner-approved and must never alter the price itself.

## How

- **`src/config/feature-flags.js`** — new flags module, kept **separate from the owner-gated `constants.js`** so a flag toggle never touches the peg/troy constants.
- **`src/lib/quote-providers/cross-validation.js`** — pure logic: `computeDivergencePct` (symmetric, vs mean) + `evaluateCrossValidation` → `disabled` / `insufficient-data` / `agree` / `under-review` (default threshold 0.75%). No false positives when the secondary is missing.
- **`tests/cross-validation.test.js`** — 8 unit tests.
- Builds on the repo's existing `secondary-provider.js` + `secondaryHealth` plumbing.

## Owner gate (documented in the report, **not done here**)

Flip the flag → wire `evaluateCrossValidation` into `realtime-pricing-engine.js`'s flag computation → optional "under review" chip. Populating the secondary provider in production needs the owner-gated `gold-price-fetch.yml` — untouched.

## Files touched

`src/config/feature-flags.js` (new), `src/config/index.js` (export), `src/lib/quote-providers/cross-validation.js` (new), `tests/cross-validation.test.js` (new), report. **`constants.js`, peg, troy — untouched.**

## Tests run

`npm run validate` (0), `npm test` (**1294/1294**, +8), `npm run build` (0).

## Risk

**Low** — dormant behind a default-OFF flag; pure/tested; no runtime, UI, or price change until the owner enables it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default-OFF flag and pure, untested-in-production comparison module with no runtime or UI integration until an owner enables and wires it.
> 
> **Overview**
> Introduces **Phase 8 secondary-provider cross-validation** as **dormant infrastructure**: a new `feature-flags.js` module (separate from owner-gated `constants.js`) with `CROSS_VALIDATION_ENABLED: false`, re-exported from `src/config/index.js`.
> 
> Adds **`cross-validation.js`** with symmetric mean-based `computeDivergencePct` and `evaluateCrossValidation`, returning `disabled` (flag off), `insufficient-data`, `agree`, or `under-review` at a **0.75%** default threshold—status only, **no change to displayed prices or peg/troy math**. Eight unit tests cover the flag default, thresholds, and invalid secondary inputs.
> 
> A **phase report** documents owner steps to enable the flag and wire into `realtime-pricing-engine.js` / optional UI chips; **this PR does not** integrate the evaluator into the live pricing path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc27ddfb0bae29feb4ba298a32f0b49a941f1bd9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->