### PR TITLE
Phase 9 — Metadata/canonical audit + twitter:site handle (Track C)

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -64,6 +64,8 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@GoldTickerLive" />
+    <meta name="twitter:creator" content="@GoldTickerLive" />
     <meta name="twitter:title" content="Gold Calculator — Value, Scrap, Zakat | Gold Ticker Live" />
     <meta
       name="twitter:description"

--- a/dubai-gold-price.html
+++ b/dubai-gold-price.html
@@ -62,6 +62,8 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@GoldTickerLive" />
+    <meta name="twitter:creator" content="@GoldTickerLive" />
     <meta name="twitter:title" content="Gold Rate in Dubai &amp; UAE — Price per Gram in AED" />
     <meta
       name="twitter:description"

--- a/index.html
+++ b/index.html
@@ -65,6 +65,8 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@GoldTickerLive" />
+    <meta name="twitter:creator" content="@GoldTickerLive" />
     <meta name="twitter:title" content="Gold Ticker Live — Reference Gold Prices for GCC &amp; the Arab World" />
     <meta
       name="twitter:description"

--- a/reports/seo/phase9-metadata-icons-2026-07-07.md
+++ b/reports/seo/phase9-metadata-icons-2026-07-07.md
@@ -1,0 +1,48 @@
+# Phase 9 — Metadata / canonical + favicon / app-icon / social-preview audit (Track C)
+
+Audit of metadata, canonicals, favicons/app-icons and OG/Twitter social previews across the flagship
+pages, plus the one concrete gap fixed.
+
+## Audit result — the layer is strong
+
+Scanned index / tracker / calculator / shops / compare / heatmap / portfolio / methodology / learn /
+market / glossary + a country sample (dubai-gold-price). **Every page** has: a self-referential
+`canonical`, `og:title/description/image/url/type/locale`, `og:image:width/height/alt`,
+`twitter:card/title/description/image`, `apple-touch-icon`, `manifest`, and `theme-color`.
+
+| Check                                                 | Result                                                                                                                                          |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Canonical present + equals `og:url` (self-consistent) | ✅ every page                                                                                                                                   |
+| OG image referenced exists on disk                    | ✅ all (`og-image.png`, `og/{tracker,calculator,shops,compare,learn,methodology}.png`, `og/countries/*`)                                        |
+| `og:image:width/height/alt`                           | ✅ present (1200×630 + alt)                                                                                                                     |
+| Manifest icons exist on disk                          | ✅ `favicon.svg`, `favicon-192/512/512-maskable` all present                                                                                    |
+| Audit P2-1 "`/assets/favicon.svg` 404"                | ✅ **not reproducible** — no page references `assets/favicon.svg`; the real favicon is `favicon.svg` at root (refreshed 2026-07-01, post-audit) |
+| Referenced OG images missing                          | ✅ none                                                                                                                                         |
+
+## The one real gap — fixed
+
+**`twitter:site` / `twitter:creator` were absent on every page**, even though the site runs an
+active `@GoldTickerLive` X account. Without `twitter:site`, X/Twitter cards don't attribute the
+site. Added to the flagship pages in this phase's scope (home, tracker, calculator, shops, country
+sample):
+
+```html
+<meta name="twitter:site" content="@GoldTickerLive" />
+<meta name="twitter:creator" content="@GoldTickerLive" />
+```
+
+## Deferred / recommended (not done here)
+
+- **Site-wide `twitter:site` rollout.** The five flagship pages are done; the remaining ~355 pages
+  would be best covered by a build-time meta injection (extend an existing head post-processor like
+  `inject-schema.js`) rather than hand-editing each. Recommended as a follow-up so all pages carry
+  the handle consistently.
+- **Canonical form (`.html` vs extensionless), audit P0-2.** The site's convention is `.html` URLs
+  (matching `_redirects` and the hreflang model in the in-flight **PR #536**). Migrating to
+  extensionless canonicals is a large, cross-cutting SEO change that would **collide with PR #536**
+  — deferred; not a correctness bug (each canonical already equals its own served URL).
+
+## Verification
+
+`npm run validate` (0), `npm test`, `npm run build` (0). All five pages now emit the Twitter handle;
+no other metadata changed.

--- a/shops.html
+++ b/shops.html
@@ -61,6 +61,8 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@GoldTickerLive" />
+    <meta name="twitter:creator" content="@GoldTickerLive" />
     <meta name="twitter:title" content="Gold Shops &amp; Markets Directory by Region | Gold Ticker Live" />
     <meta
       name="twitter:description"

--- a/tracker.html
+++ b/tracker.html
@@ -60,6 +60,8 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@GoldTickerLive" />
+    <meta name="twitter:creator" content="@GoldTickerLive" />
     <meta name="twitter:title" content="Gold Command Center — Gold Tracker for UAE, GCC &amp; Arab World | Gold Ticker Live" />
     <meta
       name="twitter:description"


### PR DESCRIPTION
## What

Phase 9 (Track C). Audited metadata / canonical / favicon / app-icon / OG-Twitter social previews across the flagship + country-sample pages, and fixed the one real gap.

## Audit — the layer is already strong

Every page scanned has a self-consistent `canonical` (== `og:url`), full OG + Twitter card tags, `og:image:width/height/alt`, `apple-touch-icon`, `manifest`, and `theme-color`. All referenced OG images and manifest icons exist on disk. The audit's **"`/assets/favicon.svg` 404" is not reproducible** — no page references that path; the real `favicon.svg` (root) was refreshed post-audit.

## The one real fix

**`twitter:site` / `twitter:creator` were missing site-wide** despite the active `@GoldTickerLive` account — so X/Twitter cards weren't attributed. Added the handle to this phase's scoped flagship pages (home, tracker, calculator, shops, country sample):

```html
<meta name="twitter:site" content="@GoldTickerLive" />
<meta name="twitter:creator" content="@GoldTickerLive" />
```

## Deferred (documented, not silently skipped)

- **Site-wide `twitter:site` rollout** → best done via a build-time head injection (recommended follow-up) rather than editing ~355 files.
- **`.html` vs extensionless canonical (audit P0-2)** → a large SEO migration that would **collide with in-flight PR #536**'s hreflang/sitemap model; not a correctness bug (each canonical already equals its served URL). Deferred.

## Files touched

`index.html`, `tracker.html`, `calculator.html`, `shops.html`, `dubai-gold-price.html` (one meta pair each) + report.

## Tests run

`npm run validate` (0), `npm test` (**1286/1286**), `npm run build` (0).

## Risk

**Very low** — additive `<meta>` tags on 5 pages; no canonical/URL/logic change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive static meta tags only; no URL, canonical, or application logic changes.
> 
> **Overview**
> Phase 9 (Track C) documents a metadata/social-preview audit and closes the only actionable gap: **Twitter/X cards were not attributed** because `twitter:site` and `twitter:creator` were missing despite an active `@GoldTickerLive` account.
> 
> **Change:** Each of five flagship HTML pages (`index`, `tracker`, `calculator`, `shops`, `dubai-gold-price`) now includes a pair of meta tags immediately after `twitter:card`, setting both to `@GoldTickerLive`. Canonicals, OG tags, and other head metadata are unchanged.
> 
> **Report:** `reports/seo/phase9-metadata-icons-2026-07-07.md` records that canonicals, OG/Twitter cards, favicons, and referenced OG assets already look solid on scanned pages, and notes follow-ups (site-wide handle via build-time injection like `inject-schema.js`, extensionless canonical migration deferred due to PR #536).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1189e106cf1509210ca8dcc172162691080bc127. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->