### PR TITLE
Phase 10 — hreflang &amp; bilingual SEO audit (Track C)

### DIFF
--- a/reports/seo/phase10-hreflang-2026-07-07.md
+++ b/reports/seo/phase10-hreflang-2026-07-07.md
@@ -1,0 +1,47 @@
+# Phase 10 — hreflang & bilingual SEO audit (Track C)
+
+Audit of reciprocal hreflang, `x-default`, and `lang`/`dir` attributes across every indexable page.
+**Result: the hreflang layer is complete and correct — no code change warranted.** The deeper
+"distinct Arabic titles/URLs" problem (audit P0-1) is a separate, in-progress workstream and is
+documented here, not attempted in this phase.
+
+## Findings
+
+Scanned all 32 tracked HTML files; 14 are indexable (have a `canonical`, not `noindex`).
+
+| Check                                                                                 | Result                                                                                              |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Indexable pages with reciprocal `hreflang` (`en` + `ar` + `x-default`)                | **14 / 14** ✅                                                                                      |
+| hreflang model                                                                        | `?lang=ar` (e.g. `…/calculator.html` ↔ `…/calculator.html?lang=ar`) — **matches in-flight PR #536** |
+| Self-referencing hreflang present                                                     | ✅ (`en` and `x-default` both point to the page's own EN URL)                                       |
+| `x-default` target                                                                    | ✅ the EN URL (correct default)                                                                     |
+| `<html lang="en" dir="ltr">` default; AR toggle sets `lang="ar" dir="rtl"` at runtime | ✅ (RTL verified in the live audit)                                                                 |
+| `404.html` / `offline.html` without hreflang                                          | ✅ **correct** — both are `noindex` with no canonical, so they must not carry hreflang              |
+
+No missing, non-reciprocal, or mismatched hreflang was found. This is consistent with the metadata
+audit in Phase 9 (canonicals self-consistent).
+
+## Reconciliation with PR #536
+
+PR #536 standardises hreflang alternates on the `?lang=ar` form (same canonical URL) rather than
+separate `/ar/...` locs. The pages already emit exactly that form, so **Phase 10 introduces no
+conflicting hreflang change** — it confirms the model #536 formalises.
+
+## Deferred — the real Arabic-indexability limitation (audit P0-1)
+
+The `?lang=ar` URLs serve the **same static HTML** with an English `<title>`/`<meta description>`
+and `<html lang="en">`; the Arabic layer is applied by client JS. A JS-rendering crawler sees
+Arabic, but the pre-render limitation (no distinct Arabic `<title>`/URL in the served HTML) is real.
+Fixing it properly means **pre-rendering distinct Arabic pages** — a large static-generation change
+that:
+
+- is already **in progress** (`scripts/node/generate-ar-homepage.mjs` exists for the homepage),
+- overlaps **PR #536** and the 50-phase plan's SEO phases 6–9,
+
+so it is intentionally **out of this phase's safe green scope**. Tracked in the master tracker /
+Owner-Gated & follow-up notes; not attempted here to avoid colliding with #536 and the AR-pre-render
+generator.
+
+## Verification
+
+`npm run validate` (0), `npm test` — green. No files changed except this report.


### PR DESCRIPTION
## What

Phase 10 (Track C). Audited reciprocal hreflang, `x-default`, and `lang`/`dir` across every indexable page. **Result: complete and correct — no code change needed.** Adds `reports/seo/phase10-hreflang-2026-07-07.md`.

## Findings

- **14 / 14 indexable pages** carry reciprocal `en` + `ar` + `x-default` hreflang, self-referencing, `x-default` → EN.
- hreflang uses the **`?lang=ar`** model — **matches in-flight PR #536**, so this introduces no conflicting change.
- `404.html` / `offline.html` correctly `noindex` with **no** hreflang.
- `<html lang="en" dir="ltr">` default; AR toggle sets `lang="ar" dir="rtl"` at runtime.

## Deferred (documented)

The real Arabic-indexability limitation (audit P0-1 — `?lang=ar` serves English `<title>` in the static HTML) needs **distinct Arabic pre-rendered pages**. That's already **in progress** (`scripts/node/generate-ar-homepage.mjs`) and overlaps **PR #536** + the 50-phase plan's SEO phases — intentionally out of this phase's safe scope to avoid a collision.

## Files touched

`reports/seo/phase10-hreflang-2026-07-07.md` only.

## Tests run

`npm run validate` (0), `npm test` (**1286/1286**).

## Risk

**None** — audit report only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime, SEO markup, or build changes.
> 
> **Overview**
> Adds **`reports/seo/phase10-hreflang-2026-07-07.md`** for Track C Phase 10 — an hreflang/bilingual SEO audit with **no production code changes**.
> 
> The report records that **14/14 indexable pages** already have reciprocal `en`/`ar`/`x-default` hreflang (including self-reference and `x-default` → EN), the **`?lang=ar`** alternate model aligns with **PR #536**, and `404`/`offline` correctly omit hreflang as `noindex`. It also documents **deferred** work on audit **P0-1** (distinct Arabic `<title>`/pre-rendered AR pages) to avoid overlapping #536 and the AR homepage generator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00ee0cecb73089700aa5e4acb5a6354cc3196203. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->