### PR TITLE
Phase 11 — Structured data: methodology FAQPage schema (Track C)

### DIFF
--- a/methodology.html
+++ b/methodology.html
@@ -108,6 +108,38 @@
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Why does my shop quote differ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Retail prices add making charges, VAT, design premiums, and dealer margins. Our numbers are spot-linked reference metal value — use the spot vs retail guide and calculator to compare transparently."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How fresh is the data?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Gold spot is committed hourly during market hours to data/gold_price.json ; the browser re-fetches about every 90 seconds. FX updates roughly daily. Check the freshness chip on each surface."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why is AED pricing special?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "We hardcode the official 3.6725 AED/USD peg — never a floating FX quote — so UAE gram prices move deterministically with XAU/USD."
+      }
+    }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Data Sources & Methodology | Gold Ticker Live",
   "description": "How Gold Ticker Live calculates gold prices, sources data, and handles AED fixed peg, karat conversions, and data freshness.",

--- a/reports/seo/inventory.json
+++ b/reports/seo/inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAtDate": "2026-07-04",
+  "generatedAtDate": "2026-07-07",
   "summary": {
     "totalHtmlFiles": 16,
     "withCanonical": 14,
@@ -360,7 +360,8 @@
       ],
       "jsonLdTypes": [
         "Article",
-        "BreadcrumbList"
+        "BreadcrumbList",
+        "FAQPage"
       ],
       "hasStructuredData": true,
       "jsonLdParseFailures": null

--- a/reports/seo/phase11-structured-data-2026-07-07.md
+++ b/reports/seo/phase11-structured-data-2026-07-07.md
@@ -1,0 +1,48 @@
+# Phase 11 — Structured data completion (Track C)
+
+Audited JSON-LD across the tool + content pages and closed the one real gap.
+
+## Audit — coverage is already broad
+
+| Type                                 | Where                                                            | Status                        |
+| ------------------------------------ | ---------------------------------------------------------------- | ----------------------------- |
+| `Organization` + `WebSite`           | homepage                                                         | ✅                            |
+| `BreadcrumbList`                     | every tool + content page (via `inject-schema.js`, non-homepage) | ✅                            |
+| `WebApplication` (+ `Offer` price 0) | tracker, calculator, compare, heatmap, portfolio                 | ✅                            |
+| `ItemList` + `JewelryStore`          | shops                                                            | ✅ already present            |
+| `Article`                            | learn, methodology                                               | ✅                            |
+| `FAQPage`                            | country pages (Dubai etc.), built from visible Q&A               | ✅                            |
+| `Dataset` (+ `FAQPage`)              | reference/price pages                                            | ✅ (non-commercial, no Offer) |
+
+The build's `inject-schema.js` already governs breadcrumbs, Article, Dataset, and country-page
+FAQPage, and `inject-schema --check` is enforced in `npm run validate`.
+
+## Gap fixed — methodology FAQPage
+
+`methodology.html` renders a visible **"Frequently asked questions"** section, but it uses a
+`<dl class="method-faq-list">` (`<dt>` question / `<dd>` answer) — while `inject-schema.js` only
+detected the `<details class="dubai-faq-item">` form. So the site's strongest trust page had **no
+`FAQPage` schema** and was ineligible for the FAQ rich result.
+
+Fix (build-managed, so it stays in sync):
+
+- Added `extractDlFaq(content, sectionId)` to `inject-schema.js` — extracts `<dt>/<dd>` pairs
+  constrained to a section id, canonical-English only (same Arabic-skip rule as the details
+  extractor).
+- For any page containing `id="method-faq"`, it now pushes a `FAQPage` schema.
+- Ran the injector: `methodology.html` gained a valid `FAQPage` with its 3 real Q&A ("Why does my
+  shop quote differ?", "How fresh is the data?", "Why is AED pricing special?").
+  `inject-schema --check` is **idempotent** (0 re-modifications).
+
+## Deferred (owned by other phases)
+
+- **Glossary `DefinedTermSet`/`DefinedTerm`** — `glossary.html` has ~50 terms but no term schema; it
+  is Phase 28's surface (learn hub & glossary), so the schema is best added there alongside the
+  glossary rework.
+- **Homepage `WebSite` `SearchAction`** (sitelinks searchbox) — touches `index.html`/homepage
+  schema, Phase 21's surface; deferred to avoid collision.
+
+## Verification
+
+`npm run validate` (incl. `inject-schema --check`) / `npm test` / `npm run build` green. FAQPage
+JSON is well-formed (produced by `getFAQPageSchema`, `--check` clean).

--- a/scripts/node/inject-schema.js
+++ b/scripts/node/inject-schema.js
@@ -220,6 +220,37 @@ function extractDetailsFaq(content, itemClass) {
 }
 
 /**
+ * Extract Q&A pairs from a visible `<dl>` FAQ inside a section (e.g. the methodology
+ * "Frequently asked questions": `<dt>` = question, `<dd>` = answer). Constrained to the
+ * given section id so unrelated `<dl>`s on the page aren't captured. Keeps only the
+ * canonical-English items (skips any question containing Arabic characters).
+ * @param {string} content
+ * @param {string} sectionId - id of the wrapping `<section>` (e.g. 'method-faq')
+ */
+function extractDlFaq(content, sectionId) {
+  const secMatch = content.match(
+    new RegExp(`<section[^>]*id="${sectionId}"[^>]*>([\\s\\S]*?)<\\/section>`, 'i')
+  );
+  if (!secMatch) return [];
+  const strip = (s) =>
+    s
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  const re = /<dt[^>]*>([\s\S]*?)<\/dt>\s*<dd[^>]*>([\s\S]*?)<\/dd>/gi;
+  const faqItems = [];
+  let match = re.exec(secMatch[1]);
+  while (match) {
+    const q = strip(match[1]);
+    if (q && !/[؀-ۿ]/.test(q)) {
+      faqItems.push({ q, a: strip(match[2]) });
+    }
+    match = re.exec(secMatch[1]);
+  }
+  return faqItems;
+}
+
+/**
  * Dataset schema for price data pages.
  * @param {Object} options
  */
@@ -479,6 +510,16 @@ function generateSchemasForPage(filePath, content) {
   // (English) twin only.
   if (content.includes('dubai-faq-item')) {
     const faqItems = extractDetailsFaq(content, 'dubai-faq-item');
+    if (faqItems.length > 0) {
+      schemas.push(getFAQPageSchema(faqItems));
+    }
+  }
+
+  // Methodology's <dl>-based "Frequently asked questions" (id=method-faq) also gets
+  // FAQPage schema built from its visible Q&A (canonical English), so the strongest
+  // trust page is eligible for the FAQ rich result like the country pages are.
+  if (content.includes('id="method-faq"')) {
+    const faqItems = extractDlFaq(content, 'method-faq');
     if (faqItems.length > 0) {
       schemas.push(getFAQPageSchema(faqItems));
     }


### PR DESCRIPTION
## What

Phase 11 (Track C). Audited JSON-LD coverage and closed the one real gap: **methodology.html had no `FAQPage` schema** despite a visible FAQ.

## Audit — already broad

`BreadcrumbList` on every tool, `ItemList` + `JewelryStore` on shops, `Article` on learn/methodology, `FAQPage` on country pages, `Dataset` on price pages, `Organization`/`WebSite` on home — all present.

## Gap fixed

methodology's "Frequently asked questions" uses a `<dl class="method-faq-list">` (`<dt>`/`<dd>`), but `inject-schema.js` only detected the `<details class="dubai-faq-item">` form — so the strongest trust page was ineligible for the FAQ rich result.

- Added `extractDlFaq(content, sectionId)` to `inject-schema.js` (dt/dd pairs, section-scoped, canonical-English only).
- Wired `FAQPage` for pages containing `id="method-faq"`; ran the injector → methodology gained a valid `FAQPage` with its 3 real Q&A. `inject-schema --check` is idempotent.
- Regenerated `reports/seo/inventory.json` (validate requires it after a JSON-LD change).

## Deferred (owning phases)

Glossary `DefinedTermSet` → Phase 28; homepage `WebSite` `SearchAction` → Phase 21.

## Files touched

`scripts/node/inject-schema.js`, `methodology.html` (injected schema), `reports/seo/inventory.json`, report.

## Tests run

`npm run validate` (0, incl. `inject-schema --check` + `inventory-seo --check`), `npm test` (**1286/1286**), `npm run build` (0).

## Risk

**Low** — additive schema built from existing visible content (schema-honest); build-managed so it stays in sync.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, build-managed JSON-LD derived from existing visible copy; no pricing or runtime behavior changes.
> 
> **Overview**
> **methodology.html** now emits **`FAQPage` JSON-LD** for its visible “Frequently asked questions” section (`id="method-faq"`), matching the three on-page Q&A pairs so the page can qualify for FAQ rich results like the country landings.
> 
> **`inject-schema.js`** gains **`extractDlFaq`** to read `<dt>`/`<dd>` pairs inside a scoped section (not only `<details class="dubai-faq-item">`), with the same canonical-English-only rule as the existing details extractor. The injector was run so the HTML carries the new block; **`reports/seo/inventory.json`** lists `FAQPage` for methodology, and a Phase 11 audit note documents deferred glossary/homepage schema work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f2e61110781cd39859ccf65437513c51640aad2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->