### PR TITLE
Phase 12 — Sitemap audit + clear stale seo-governance (Track C)

### DIFF
--- a/reports/seo/governance.json
+++ b/reports/seo/governance.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-07-04T22:11:26.561Z",
+  "generatedAt": "2026-07-07T11:37:26.516Z",
   "summary": {
     "groups": {
       "core": 48,
@@ -399,7 +399,7 @@
         "ar"
       ],
       "hasSchema": true,
-      "wordCount": 1871,
+      "wordCount": 1882,
       "thinRisk": false,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -475,7 +475,7 @@
         "ar"
       ],
       "hasSchema": true,
-      "wordCount": 1666,
+      "wordCount": 1702,
       "thinRisk": false,
       "missingCanonical": false,
       "missingHreflang": false,
@@ -566,7 +566,7 @@
         "ar"
       ],
       "hasSchema": true,
-      "wordCount": 506,
+      "wordCount": 505,
       "thinRisk": false,
       "missingCanonical": false,
       "missingHreflang": false,

--- a/reports/seo/phase12-sitemap-2026-07-07.md
+++ b/reports/seo/phase12-sitemap-2026-07-07.md
@@ -1,0 +1,39 @@
+# Phase 12 — Sitemap gap closure (Track C, reconciled with PR #536)
+
+Audited the sitemap, robots.txt, and noindex coverage. **The sitemap is complete and correct — no
+generation change made** (that pipeline is owned by in-flight **PR #536**; this phase does not
+duplicate it). One concrete SEO-governance hygiene fix landed alongside.
+
+## Sitemap audit — complete & clean
+
+| Check                               | Result                                                                                                                                                                                          |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `robots.txt` references the sitemap | ✅ `Sitemap: https://goldtickerlive.com/sitemap.xml`                                                                                                                                            |
+| Committed source                    | ✅ `public/sitemap.xml` is the git-tracked one; root `/sitemap.xml` is a gitignored build artifact — matches PR #536's model                                                                    |
+| Coverage                            | ✅ **14 `<loc>` = 14 indexable pages** exactly (homepage `/` + calculator, compare, dubai-gold-price, glossary, heatmap, learn, market, methodology, portfolio, privacy, shops, terms, tracker) |
+| noindex leaks                       | ✅ **none** — `404.html`, `offline.html`, and all `admin/*` (noindex) are absent from the sitemap                                                                                               |
+| hreflang alternates                 | ✅ present — 42 `xhtml:link` entries (14 URLs × en/ar/x-default, `?lang=ar` model)                                                                                                              |
+
+Coverage was cross-checked by listing every tracked HTML with a `canonical` and no `noindex` — the
+set equals the sitemap's URL set exactly. The historical "sitemap gaps (28)" item predates the
+country-URL consolidation; the current indexable surface is 14 pages, all covered.
+
+## Reconciliation with PR #536
+
+PR #536 migrates sitemap generation to the committed `public/sitemap.xml` (single generator
+`scripts/node/generate-sitemap.js`, `--out public/sitemap.xml`, coverage enforcement in CI) and the
+`?lang=ar` hreflang model. Main already reflects that end-state (only `public/sitemap.xml` is
+tracked; hreflang alternates present). **Phase 12 therefore changes no sitemap file or generator** —
+it confirms correctness and defers all generation ownership to #536.
+
+## Concrete fix — cleared the stale SEO-governance report
+
+`reports/seo/governance.json` had been stale since the Phase-1 baseline (a non-fatal
+`npm run validate` warning). Regenerated it (`node scripts/node/seo-governance.js`): now
+`check ok — 48 pages, thinRisk=0, dupClusters=0`, clearing the warning. Small diff (4±4 lines), pure
+report artifact.
+
+## Verification
+
+`npm run validate` (now with `seo-governance --check` **ok**, no stale warning) / `npm test` /
+`npm run build` green.


### PR DESCRIPTION
## What

Phase 12 (Track C), reconciled with in-flight **PR #536** (which owns sitemap generation). Audited sitemap/robots/noindex — **complete and correct, no generation change** — and cleared a long-standing stale SEO-governance report.

## Sitemap audit — clean

- `robots.txt` references the sitemap ✅
- **14 `<loc>` = exactly the 14 indexable pages** (cross-checked against every canonical, non-noindex HTML) — no gaps
- **Zero noindex leaks** — `404`, `offline`, all `admin/*` correctly excluded
- hreflang alternates present (42 `xhtml:link`, `?lang=ar` model)
- `public/sitemap.xml` is the committed source (root gitignored) — **main already reflects #536's end-state**, so no sitemap file/generator is touched here.

## Concrete fix

Regenerated `reports/seo/governance.json` (stale since the Phase-1 baseline). `seo-governance --check` now **ok** (48 pages, thinRisk=0, dupClusters=0), clearing the non-fatal `npm run validate` warning. Small diff, pure report artifact.

## Files touched

`reports/seo/governance.json`, report. **No sitemap file or generator changed** (deferred to #536).

## Tests run

`npm run validate` (0, governance warning gone), `npm test` (**1286/1286**).

## Risk

**Very low** — a regenerated report + an audit doc.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Report-only changes with no runtime, auth, or sitemap generation logic touched.
> 
> **Overview**
> **Phase 12 (Track C)** documents a sitemap/robots/noindex audit and refreshes a stale SEO governance artifact. **No sitemap XML or generator changes** — generation stays with PR #536.
> 
> Adds `reports/seo/phase12-sitemap-2026-07-07.md` recording that coverage matches **14 indexable pages**, `robots.txt` points at the sitemap, no noindex URLs leak in, and hreflang alternates look correct. The write-up explicitly defers any pipeline work to #536.
> 
> Regenerates `reports/seo/governance.json` via `seo-governance.js` so `npm run validate` / `seo-governance --check` passes again (48 pages, thinRisk=0, dupClusters=0). The diff is mostly a new `generatedAt` and small per-page `wordCount` tweaks on glossary, market, and shops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f91d6f4428ac6611b4ab1c070bf41e078c6fb1a3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->