### PR TITLE
Phase 15 — Image-pipeline audit + size-delta evidence (Track D)

### DIFF
--- a/reports/perf/phase15-image-pipeline-2026-07-07.md
+++ b/reports/perf/phase15-image-pipeline-2026-07-07.md
@@ -1,0 +1,46 @@
+# Phase 15 — Asset & image pipeline audit (Track D)
+
+Audited every raster image's format, responsive delivery, CLS safety, and lazy-loading. **The image
+pipeline is already best-practice — no change warranted.** Documents the size-delta the pipeline
+delivers and the two non-improvements (with reasons).
+
+## Audit result
+
+| Check                         | Result                                                                                                                                                                            |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Modern formats (avif/webp)    | ✅ **every** referenced raster image ships avif + webp + jpg via `<picture>` (33 avif + 40 webp assets). A scan found **0** referenced `.jpg`/`.png` without an avif/webp sibling |
+| `<picture>` source order      | ✅ avif → webp → jpg, so browsers pick the smallest they support                                                                                                                  |
+| Responsive `srcset`           | ✅ large market cards carry `480w / 768w / 960w` + `sizes`; small strip tiles use a single 480 (appropriate for a ~150–240px thumbnail)                                           |
+| CLS safety (`width`/`height`) | ✅ every `<img>` has explicit `width` + `height` (matches the Phase 14 finding: CLS ≤ 0.016 everywhere)                                                                           |
+| Lazy-loading + async decode   | ✅ every content image is `loading="lazy" decoding="async"`                                                                                                                       |
+| Hero                          | webp CSS background (`assets/hero/gold-bullion-band.webp`, 35.5 KB)                                                                                                               |
+
+## Size-delta the pipeline already delivers (avif vs jpg, 768w market images)
+
+| Image             |     jpg |    avif |            saved |
+| ----------------- | ------: | ------: | ---------------: |
+| qatar-souq-waqif  | 39.2 KB | 16.9 KB |         **−56%** |
+| jordan-amman      | 58.9 KB | 33.6 KB |             −43% |
+| dubai-gold-souk   | 73.8 KB | 46.1 KB |             −37% |
+| riyadh-dirah      | 82.0 KB | 50.9 KB |             −37% |
+| india-manek-chowk | 78.9 KB | 52.0 KB |             −34% |
+| … (11 images)     |         |         | 5–56%, most ~30% |
+
+Because avif is the first `<picture>` source, supporting browsers download these smaller files
+automatically. This is why the Phase-14 CWV run shows image weight at ~2–18 KB per page in the lab
+(the visible market thumbnails load lazily and in avif).
+
+## Non-improvements (with reasons — not done)
+
+- **Hero avif.** The hero is webp-only in CSS (`background-image`). An `image-set()` avif upgrade
+  would save ~15%, but **no avif hero asset exists** and no image encoder (sharp/cwebp/avifenc) is
+  installed in this environment, so it can't be produced at $0. The webp hero is already well-
+  compressed (35.5 KB). Recommend generating a hero avif + `image-set()` when tooling is available.
+- **Strip-tile 768w.** The small market-strip thumbnails use a single 480 source; the 768 assets
+  exist, but 480 already covers a ~150–240px thumbnail at 2×. Adding 768w is marginal and would
+  touch `index.html` (Phase 21's surface) — deferred as not worth the cross-phase edit.
+
+## Verification
+
+`npm run validate` / `npm test` green (no code changed — audit + evidence report). Re-run
+`npm run perf` (Phase 14) after any future image change for a before/after weight delta.


### PR DESCRIPTION
## What

Phase 15 (Track D). Audited the asset/image pipeline. **Already best-practice — no change warranted.** Adds `reports/perf/phase15-image-pipeline-2026-07-07.md` with size-delta evidence.

## Audit result

- Every referenced raster image ships **avif + webp + jpg via `<picture>`** (avif first); a scan found **0** `.jpg`/`.png` without an avif/webp sibling.
- Large market cards carry `480/768/960` srcset + `sizes`; strip tiles use a single 480 (fine for small thumbnails).
- Every `<img>` has explicit **width/height** (CLS-safe — matches Phase 14's CLS ≤ 0.016) and `loading="lazy" decoding="async"`.
- avif delivers **5–56% (most ~30%)** savings vs jpg on the market images.

## Non-improvements (documented, not done)

- **Hero avif** — needs an avif asset + an image encoder (sharp/cwebp/avifenc) not available at $0; webp hero is already 35.5 KB.
- **Strip-tile 768w** — marginal and would touch `index.html` (Phase 21).

## Files touched

`reports/perf/phase15-image-pipeline-2026-07-07.md` only.

## Tests run

`npm run validate` (0), `npm test` (**1286/1286**).

## Risk

**None** — audit + evidence report.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only PR with no runtime, asset, or markup changes.
> 
> **Overview**
> Adds **`reports/perf/phase15-image-pipeline-2026-07-07.md`** as the only change — a Phase 15 (Track D) audit write-up with **no application or asset edits**.
> 
> The report records that the current raster pipeline is already in good shape (avif/webp/jpg `<picture>` order, responsive srcset on market cards, width/height for CLS, lazy + async decode) and includes **avif vs jpg size tables** (~5–56% savings on sample 768w market images). It also documents **deferred** follow-ups: hero avif via `image-set()` (no encoder/asset today) and optional 768w on strip tiles (marginal, would touch `index.html` in a later phase). Verification notes: validate/tests unchanged; suggest re-running `npm run perf` after any future image work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16e4c58f474062e8930300f289ee513b43f6a7e2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->