### PR TITLE
Phase 16 — JS delivery &amp; service-worker audit (Track D)

### DIFF
--- a/reports/perf/phase16-js-sw-2026-07-07.md
+++ b/reports/perf/phase16-js-sw-2026-07-07.md
@@ -1,0 +1,56 @@
+# Phase 16 — JS delivery & service-worker caching (Track D · 🟡 sw.js recommend-only)
+
+Reviewed JS code-splitting/defer, the Leaflet load path, and the service-worker cache strategy.
+**The concrete asks are already satisfied and `sw.js` is best-practice** — `sw.js` is owner-gated,
+so it is audited read-only with recommendations, not edited.
+
+## Leaflet lazy-load — already done
+
+- **shops:** `src/components/shops-map.js` `loadLeaflet()` dynamically injects Leaflet CSS + JS **on
+  demand** (first Map-view open), with a cached load promise and graceful fallback to list-only if
+  the CDN fails. It is **not** on the shops page's initial load path. ✅
+- **heatmap:** uses a **generated inline-SVG** world map (`world-map-data-*.js`) — **no Leaflet at
+  all**, and that ~122 KB path-data chunk is itself lazy-loaded so the page paints first. ✅
+
+So "lazy-load Leaflet on shops/heatmap" needs no code change.
+
+## Code-splitting & defer — well-architected
+
+- `vite.config` uses a `manualChunks` function → a `vendor` chunk, a shared `utils` chunk, and
+  per-page chunks. The built `dist/` has 47 JS chunks; **each page loads only its own subset**,
+  which is why the Phase-14 CWV run shows per-page script weight comfortably under budget (home
+  393/600 KB, tracker 476/800 KB). The audit's "30+ chunks on first load" (P2-2) is **intentional
+  per-page splitting**, not a regression — a page does not download all 47.
+- Heaviest chunks: `vendor` (375 KB, cached across pages), `utils` (208 KB), `world-map-data` (122
+  KB, heatmap-only + lazy), `learn` (102 KB, learn-only), `shops` (82 KB, shops-only).
+- All page entry scripts are `<script type="module">` (deferred by spec); analytics is `defer`.
+
+## Service worker (`sw.js`) — read-only audit, **not edited (owner-gated)**
+
+`sw.js` (cache `goldtickerlive-v20`) is a correct, modern SW:
+
+| Aspect                           | Implementation                                  | Verdict                                   |
+| -------------------------------- | ----------------------------------------------- | ----------------------------------------- |
+| Install                          | precache `PRECACHE_URLS`, `skipWaiting()`       | ✅                                        |
+| Activate                         | delete old caches, `clients.claim()`            | ✅                                        |
+| HTML/navigation                  | `networkFirstWithFallback`                      | ✅ correct (fresh HTML, offline fallback) |
+| Static assets (css/js/fonts/img) | `cacheFirstWithUpdate` / `staleWhileRevalidate` | ✅ correct (fast + revalidated)           |
+| Data (`gold_price.json`)         | `staleWhileRevalidate` on RUNTIME cache         | ✅ correct (instant + fresh)              |
+| Unknown                          | plain fetch with 503 fallback                   | ✅ safe                                   |
+
+No change recommended — the strategy map already matches best practice. (And per the guardrails,
+`sw.js` is owner-gated: any edit needs owner approval.)
+
+## Recommendations (not applied — need owner/deps decision)
+
+1. **Self-host Leaflet** instead of `unpkg.com` (loaded by `shops-map.js`). This removes the
+   `cdn`/`unpkg` third-party `script-src`/`style-src` origin flagged in the Phase-3 CSP inventory,
+   removes a runtime dependency on unpkg's uptime, and is a $0 change — but it adds Leaflet to the
+   repo/deps, so it's an owner/deps decision. Vendoring `leaflet@1.9.4` (~150 KB, still lazy-loaded)
+   would let the CSP drop the CDN origin entirely.
+2. Keep the world-map-data chunk lazy (already is) as more countries are added.
+
+## Verification
+
+`npm run validate` / `npm test` green (no code changed — audit + recommendations; `sw.js`
+untouched).


### PR DESCRIPTION
## What

Phase 16 (Track D · 🟡). Reviewed JS delivery, the Leaflet load path, and the SW cache strategy. **Concrete asks already met; `sw.js` is best-practice (audited read-only — owner-gated).** Adds `reports/perf/phase16-js-sw-2026-07-07.md`.

## Findings

- **Leaflet lazy-load — already done.** shops loads Leaflet on demand (`shops-map.js` `loadLeaflet()`, first Map-view open, list-only fallback); heatmap uses inline-SVG (no Leaflet), with its ~122 KB path-data chunk lazy-loaded.
- **Code-splitting — well-architected.** Vite `manualChunks` (vendor/utils + per-page); each page loads only its subset → per-page script within budget. The audit's "30+ chunks" is intentional splitting.
- **`sw.js` (v20) — best-practice, not edited (owner-gated).** precache + `networkFirst` (HTML) / `staleWhileRevalidate` / `cacheFirstWithUpdate` router, correct per request type.

## Recommendation (not applied)

Self-host Leaflet to drop the `unpkg` third-party origin flagged in the Phase-3 CSP inventory — a $0 change but an owner/deps decision.

## Files touched

`reports/perf/phase16-js-sw-2026-07-07.md` only. **`sw.js` untouched.**

## Tests run

`npm run validate` (0), `npm test` (**1286/1286**).

## Risk

**None** — audit + recommendations.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, security, or dependency changes.
> 
> **Overview**
> Adds **`reports/perf/phase16-js-sw-2026-07-07.md`** for Phase 16 (Track D): a read-only performance audit of JS delivery, Leaflet loading, Vite chunking, and **`sw.js`** caching—**no application or `sw.js` code changes**.
> 
> The report records that **Leaflet is already lazy-loaded** on shops (`loadLeaflet()` in `shops-map.js`) and that heatmap uses lazy inline-SVG map data without Leaflet; **Vite `manualChunks`** yields per-page subsets within CWV script budgets; and **`sw.js` (v20)** strategies are judged best-practice and left **owner-gated / untouched**.
> 
> **Recommendations only (not implemented):** self-host Leaflet to remove the unpkg CSP origin, and keep world-map-data lazy as the map grows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d6a797d980a35a7436bfb6b6fff8bb8a2515958. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->