### PR TITLE
Phase 17 — Token-consolidation analysis + safe hex→token (Track E)

### DIFF
--- a/reports/design/phase17-token-consolidation-2026-07-07.md
+++ b/reports/design/phase17-token-consolidation-2026-07-07.md
@@ -1,0 +1,54 @@
+# Phase 17 — Design-token consolidation (Track E · 🟡)
+
+Analysed every hardcoded hex in the stylesheets against the token system. **Key finding: a blind
+hex→token mass-replace is _unsafe_ here** — it would silently break dark mode or re-colour
+intentional components. This phase applies the **one** provably-safe replacement and documents the
+safe methodology + the dual-theme visual-regression gate any real consolidation needs.
+
+## Hex inventory
+
+| Bucket                                     |   Count | Notes                                                             |
+| ------------------------------------------ | ------: | ----------------------------------------------------------------- |
+| Total hex literals in `styles/**`          |     478 |                                                                   |
+| In `styles/partials/tokens.css`            |     174 | **token definitions — the source of truth; must NOT be replaced** |
+| Usages elsewhere                           |    ~300 | the consolidation candidates                                      |
+| Tokens overridden in `[data-theme='dark']` | **276** | i.e. most tokens are **theme-variant**                            |
+
+## Why a mechanical replace is unsafe
+
+Cross-referencing every hex _usage_ (excluding `tokens.css`, and the intentionally off-canonical
+`invest.css` dark-premium identity and `admin/*`) against the `:root` token values:
+
+- **1** usage matches a **theme-invariant** token → provably safe (fixed below).
+- **10** usages match a **theme-variant** token → replacing them would **change the dark-mode
+  colour** (e.g. `--color-gold` is `#b07d1f` in light but `#ddb040` in dark). That's a re-theme, not
+  a refactor — it needs design intent + a visual-regression diff, not a blind swap.
+- The remaining ~290 are **intentional one-offs**: component-identity colours, hardcoded _dark_ card
+  blocks (e.g. `components.css` `#1a1a2e`/`#e0e0e0` — deliberately dark in both themes), brand
+  shades, and gradient stops. Tokenising these would either be a no-op-with-churn or an unwanted
+  recolour.
+
+So the backlog "565 hardcoded hex" is large-effort precisely because **each instance needs
+per-element judgment**; it cannot be safely mechanised.
+
+## Applied — the one provably-safe replacement
+
+`styles/components/alert-manager.css`: `border-color: #25d366` → `var(--brand-whatsapp)`. The token
+`--brand-whatsapp` is `#25d366` in **both** themes (theme-invariant), so the rendered colour is
+identical everywhere — a pure maintainability win, zero visual risk. (It's a WhatsApp **share-link**
+accent, unrelated to the parked WhatsApp Business API.)
+
+## Safe methodology for future consolidation (recommended, not mechanised here)
+
+1. **Exact-match to theme-invariant tokens only** → provable no-op (what was done above). A tiny
+   set.
+2. **Intentional re-theming** (mapping a hex to a theme-variant token so an element _starts_
+   adapting to dark mode): treat as a design change, one component at a time, **gated by a
+   dual-theme visual-regression screenshot diff** (light + dark, before/after). Requires design
+   sign-off because the dark-mode appearance genuinely changes.
+3. Never touch `tokens.css` definitions, `invest.css` (intentional identity), or `admin/*`.
+
+## Verification
+
+`npm run validate` / `npm test` / `npm run build` green; the single replacement resolves to an
+identical colour in both themes (token value == the former hex).

--- a/styles/components/alert-manager.css
+++ b/styles/components/alert-manager.css
@@ -428,7 +428,7 @@
 
 .alert-mgr-card-btn--wa:hover {
   background: #dcf8c6;
-  border-color: #25d366;
+  border-color: var(--brand-whatsapp); /* was #25d366 — identical value, theme-invariant token */
 }
 
 /* ─── Trigger dialog (native <dialog>) ───────────────────────────────── */


### PR DESCRIPTION
## What

Phase 17 (Track E · 🟡). Analysed the 478 hardcoded hex in `styles/` against the token system and applied the **one** provably-safe replacement. **Key finding: a blind hex→token mass-replace is unsafe here** — it would break dark mode or recolour intentional components.

## Why not a mass-replace

- **276 tokens are theme-variant** (overridden in `[data-theme='dark']`). Of ~300 hex *usages*, only **1** matches a **theme-invariant** token (safe); **10** match theme-variant tokens (would change dark-mode colour — e.g. `--color-gold` is `#b07d1f` light / `#ddb040` dark); the rest are **intentional one-offs** (component/dark-card identity, `invest.css` dark-premium identity, `admin/*`).
- So the "565 hex" backlog is large-effort because each needs per-element judgment — it can't be mechanised safely.

## Applied — the safe demonstrator

`alert-manager.css`: `border-color: #25d366` → `var(--brand-whatsapp)` (token is `#25d366` in **both** themes → identical render, zero visual risk; a share-link accent, not the parked WhatsApp Business API).

## Methodology documented for future work

Invariant exact-match only (provable no-op), or per-component intentional re-theming **gated by a dual-theme visual-regression diff** with design sign-off. Never touch token defs / `invest.css` / `admin`.

## Files touched

`styles/components/alert-manager.css` (1 line) + `reports/design/phase17-token-consolidation-2026-07-07.md`.

## Tests run

`npm run validate` (0), `npm test` (**1286/1286**), `npm run build` (0).

## Risk

**Very low** — one hex→token with an identical value in both themes; analysis + methodology otherwise.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS property points at an existing token with the same hex in both themes; remainder is documentation.
> 
> **Overview**
> Adds **Phase 17** design documentation explaining why a bulk hex→token pass over `styles/**` is unsafe (most tokens are dark-theme overrides; only one usage matched a theme-invariant token).
> 
> **Code change:** `.alert-mgr-card-btn--wa:hover` in `alert-manager.css` now uses `var(--brand-whatsapp)` instead of `#25d366` for the border — same colour in light and dark, no visual change.
> 
> The report also records a **safe future process**: invariant exact-match swaps only, or per-component re-theming behind dual-theme visual regression and design sign-off; exclude `tokens.css`, `invest.css`, and `admin/*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c05b86398371d4cbcb51d3b3bc327e5defc7896c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->