### PR TITLE
Phase 18 — Global shell &amp; nav verification (Track E)

### DIFF
--- a/reports/design/phase18-shell-nav-2026-07-07.md
+++ b/reports/design/phase18-shell-nav-2026-07-07.md
@@ -1,0 +1,46 @@
+# Phase 18 — Global shell & navigation (Track E)
+
+Verified the shared shell: nav search, header/footer, skip-links, and the internal-linking surfacing
+Phase 13 routed here (L-2). **All already implemented and working — verified behaviorally, no change
+needed.**
+
+## Nav search icon → bilingual search — wired & working ✅
+
+`src/components/nav.js` renders `#nav-search-btn` → `#nav-search-overlay` / `#nav-search-input` /
+`#nav-search-dropdown`, lazy-imports `src/search/searchEngine.js`, queries on input, and renders
+results. Behavioral proof (headless Chromium against the built `dist/`):
+
+| Query        | Locale          | Overlay opened | Results |
+| ------------ | --------------- | -------------- | ------: |
+| `calculator` | EN              | ✅             |       1 |
+| `ذهب` (gold) | AR (`?lang=ar`) | ✅             |      10 |
+
+So the search icon is wired to the existing **bilingual** search (Arabic query returns
+Arabic-indexed results). Also triggerable by `/` and `Ctrl/Cmd+K` (per `nav.js`).
+
+## Header / footer / skip-link consistency ✅
+
+- **Skip-link** present on every page (verified `#tracker-app` on tracker; `#main-content`
+  elsewhere); `npm run validate`'s shell-guard confirms 16 top-level pages share one nav/footer with
+  no duplicate shell markup and 7-surface nav coverage.
+- **Footer** is rendered once from `NAV_DATA.groups` (same source as the nav — no divergence).
+
+## Phase 13 L-2 — resolved (portfolio/heatmap are footer-surfaced) ✅
+
+The Phase-13 audit flagged portfolio/heatmap as thin on **static-HTML** inbound links. Behavioral
+check shows the JS-injected footer on tracker carries **4 portfolio** and **4 heatmap** links — they
+are the 3rd item in their nav-data groups, so the footer's 3-per-section rail includes them, and
+they are linked from **every** page's footer + nav. The Phase-13 count undercounted because
+nav/footer are injected at runtime, not present in the static HTML. **L-2 needs no code change.**
+
+## Phase 13 L-3 (market.html inbound) — minor, deferred
+
+`market.html` ("How Gold Is Priced", 4 inbound) is in the nav mega-menu but below the footer's
+3-per-section cut. Surfacing it would mean reordering `nav-data` (which also reorders the visible
+nav) or raising the footer cap (more links everywhere) — a nav-IA design choice, not a bug, so it's
+left for an intentional nav-IA pass rather than changed blindly here.
+
+## Verification
+
+`npm run validate` (shell-guard + a11y gates) / `npm test` green; Playwright confirms nav search
+EN+AR, footer links, and skip-link. No code changed.


### PR DESCRIPTION
## What

Phase 18 (Track E). Verified the shared shell (nav search, header/footer, skip-links) and the Phase-13 L-2 routing. **All already implemented — verified behaviorally, no change needed.** Adds `reports/design/phase18-shell-nav-2026-07-07.md`.

## Nav search — wired & working (behavioral proof)

`nav.js` lazy-imports `searchEngine.js` and renders results. Headless Chromium against built `dist/`:

| Query | Locale | Overlay | Results |
|---|---|---|--:|
| `calculator` | EN | ✅ | 1 |
| `ذهب` (gold) | AR | ✅ | 10 |

Bilingual search confirmed (Arabic query → Arabic results); also `/` and `Ctrl/Cmd+K`.

## Consistency + L-2

- Skip-link on every page; validate's shell-guard confirms one nav/footer across 16 pages.
- **Phase-13 L-2 resolved:** the JS-injected footer carries **4 portfolio + 4 heatmap** links per page (they're the 3rd nav-data item → within the footer's 3/section rail). The earlier "thin inbound" was a static-HTML undercount.
- L-3 (market.html) left as an intentional nav-IA choice, not a blind change.

## Files touched

`reports/design/phase18-shell-nav-2026-07-07.md` only.

## Tests run

`npm run validate` (0), `npm test` (**1286/1286**), Playwright nav-search EN+AR.

## Risk

**None** — verification report.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only PR with no runtime or config changes.
> 
> **Overview**
> Adds **`reports/design/phase18-shell-nav-2026-07-07.md`** documenting Phase 18 (Track E) verification of the global shell and navigation. **No application code changes.**
> 
> The report records behavioral checks (Playwright/headless Chromium on built `dist/`, plus `npm run validate` / `npm test`) for nav search (EN + AR via `nav.js` → `searchEngine.js`), skip-links, and shared header/footer from `NAV_DATA`. It closes **Phase 13 L-2** as a static-HTML undercount—portfolio/heatmap links are present via runtime-injected footer/nav—and defers **L-3** (`market.html` footer surfacing) to a future nav-IA pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6c7a241a5a32b364adab1372d3b1b916e9dfb74. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->