### PR TITLE
rtl(phase-20): fix inverted AR pagination arrows + shops logical-inset gaps

### DIFF
--- a/reports/rtl/PHASE-20-rtl-bilingual.md
+++ b/reports/rtl/PHASE-20-rtl-bilingual.md
@@ -1,0 +1,66 @@
+# Phase 20 — RTL & bilingual polish (Track E · Green)
+
+Audited the Arabic (`?lang=ar`, `dir="rtl"`) rendering path across the translation dictionary, the
+CSS direction handling, and the directional-glyph/icon plumbing. The RTL implementation is already
+**mature** — 299 logical-property uses vs ~50 physical, 243 `[dir='rtl']` override blocks, every CSS
+pseudo-element arrow already dir-guarded, and complete EN↔AR arrow-twin coverage in the dictionary.
+This phase fixes the one genuine directional **bug** plus a small number of clear physical-property
+gaps, and records the verification of everything that was already correct.
+
+## Fixes shipped
+
+1. **Inverted Arabic pagination arrows (real bug)** — `src/config/translations.js`
+   (`tracker.pagination.prev` / `.next`). The author had mirrored the arrow's _position_ from
+   English but kept the English _glyph direction_, so both arrows pointed backwards for an RTL
+   reader. In RTL, "previous/back" must point **→** and "next/forward" must point **←** (readers
+   advance leftward).
+   - `prev`: `'السابق ←'` → `'السابق →'`
+   - `next`: `'→ التالي'` → `'← التالي'`
+   - Rendered live on the tracker archive pager (`src/tracker/archive.js:138,159`). Single-glyph
+     edits inside existing values — no key added/removed, so the EN/AR parity guard
+     (`tests/i18n-sitewide-guard.test.js`) stays green.
+
+2. **`text-align: left` → `text-align: start`** — `styles/pages/shops.css`, `.shops-nearme-status`
+   and `.shops-nearme-results` (the "near me" geolocation status/results copy). These were pinned to
+   the physical left edge, so Arabic text mis-aligned; `start` follows the writing direction.
+
+3. **Shops modal close button → logical inset** — `styles/pages/shops.css`, `.shops-modal-close`.
+   Converted `right: 1.2rem` → `inset-inline-end: 1.2rem` and the small-viewport `@media` variant
+   `right: 0.8rem` → `inset-inline-end: 0.8rem`, then **removed** the now-redundant
+   `[dir='rtl'] .shops-modal-close { right: auto; left: 1.2rem }` override. This also fixes a latent
+   bug: the small-viewport variant had no RTL override, so on narrow screens the close button kept a
+   1.2rem (not 0.8rem) inset in Arabic. One self-contained component, converted in isolation.
+
+## Verified correct — no change needed
+
+- **Directional icons.** Only two direction-bearing sprite symbols exist (`i-exchange`,
+  `i-external`). `i-exchange` is already registered in the RTL-mirror set
+  (`src/components/icon-sprite.js:378`, `DIRECTIONAL`), and external-link icons are conventionally
+  left un-mirrored. No back/next/chevron sprite id is rendered un-mirrored. No gap.
+- **Swipe scroll-hints.** Both the karat strip (`home.karatStripScrollHint`) and the compare table
+  (`compare.js swipeHint`) are i18n-managed and ship correctly-flipped Arabic arrows (`… ←` /
+  `← … →`). No gap.
+- **Arrow-bearing CTAs.** The site's convention is EN strings embed `→` and the AR dictionary ships
+  hand-flipped `←` twins (65× `→` / 61× `←` in `translations.js`). Bound CTAs (`data-i18n` / id →
+  `page-hydrator` / page module) therefore resolve to the flipped Arabic glyph at runtime.
+- **CSS pseudo-element arrows & breadcrumb chevrons** are all `[dir='rtl']`-guarded already
+  (learn/home/market/dubai page CSS, `components.css` breadcrumb `›`→`‹`).
+
+## Registered follow-ups (out of scope for this polish phase)
+
+- **Untranslated static first-paint copy** — a few tracker body links (e.g. the data-trust banner's
+  `<a href="methodology.html">Methodology →</a>`, `tracker.html:174`) are static English in the
+  markup. They are the JS-hydrated first-paint fallback (the tracker shell re-renders translated
+  copy via `src/pages/tracker-pro.js`), so this is a **content-translation** concern (Phase 41
+  territory), not an RTL directional bug. Left as-is.
+- **`styles/admin.css`** carries the most physical-direction properties (32) but the admin surface
+  is English-only / non-bilingual — deliberately skipped.
+- **Eastern-Arabic numerals + `tabular-nums`.** Eastern-Arabic glyphs aren't guaranteed equal-width,
+  so tabular alignment can be marginally imperfect in AR. Cosmetic, not directional. Noted only.
+
+## Gate
+
+`npm run build` (translations + CSS touched) + `npm run validate` + `npm test` (incl. the i18n
+parity/coverage suite) + `npm run lint` — all green. `scripts/qa/parity-diff-scan.mjs` confirms the
+edited AR values remain distinct from their EN counterparts (no accidental identical-string
+regression).

--- a/src/config/translations.js
+++ b/src/config/translations.js
@@ -1993,8 +1993,8 @@ export const TRANSLATIONS = {
     'tracker.briefHeadline': 'الذهب عند {spot} لكل أوقية تروي — {source}',
     'tracker.briefBody':
       'عيار 24 في الإمارات: {aed24} درهم/غ. العرض المحدد: {karat} قيراط بعملة {currency} لكل {unit}. مصدر الصرف: open.er-api.com (مع ربط الدرهم الثابت 3.6725). السجل: متوسطات LBMA الشهرية من 2019 حتى {lastMonth} مع لقطات الجلسة.',
-    'tracker.pagination.prev': 'السابق ←',
-    'tracker.pagination.next': '→ التالي',
+    'tracker.pagination.prev': 'السابق →',
+    'tracker.pagination.next': '← التالي',
     'tracker.pagination.prevLabel': 'الصفحة السابقة',
     'tracker.pagination.nextLabel': 'الصفحة التالية',
     'tracker.pagination.page': 'صفحة {page} / {total}',

--- a/styles/pages/shops.css
+++ b/styles/pages/shops.css
@@ -1295,7 +1295,7 @@
 
   .shops-modal-close {
     top: 0.8rem;
-    right: 0.8rem;
+    inset-inline-end: 0.8rem;
     font-size: var(--text-2xl);
   }
 
@@ -1397,7 +1397,9 @@
 .shops-modal-close {
   position: absolute;
   top: 1.2rem;
-  right: 1.2rem;
+
+  /* Logical inset — flips to the inline-start automatically under [dir='rtl']. */
+  inset-inline-end: 1.2rem;
   background: none;
   border: none;
   font-size: 1.8rem;
@@ -1414,11 +1416,6 @@
 
 .shops-modal-close:hover {
   color: var(--text-primary);
-}
-
-[dir='rtl'] .shops-modal-close {
-  right: auto;
-  left: 1.2rem;
 }
 
 #shops-modal-title {
@@ -2249,7 +2246,7 @@
   font-size: 0.85rem;
   padding: 0.5rem 1rem;
   border-radius: 6px;
-  text-align: left;
+  text-align: start;
 }
 
 .shops-nearme-status--info {
@@ -2264,7 +2261,7 @@
 
 .shops-nearme-results {
   margin-top: 1.25rem;
-  text-align: left;
+  text-align: start;
 }
 
 .nearme-intro {


### PR DESCRIPTION
## Phase 20 — RTL & bilingual polish (Track E · Green)

Audited the Arabic (`?lang=ar`, `dir="rtl"`) rendering path across the translation dictionary, CSS direction handling, and directional-glyph/icon plumbing. The RTL implementation is already **mature** — 299 logical-property uses vs ~50 physical, 243 `[dir='rtl']` override blocks, every CSS pseudo-element arrow dir-guarded, complete EN↔AR arrow-twin coverage. This PR fixes the one genuine directional **bug** plus a few clear physical-property gaps, and records verification of what was already correct.

### Fixes
1. **Inverted Arabic pagination arrows (real bug)** — `tracker.pagination.prev` / `.next` in `src/config/translations.js`. The English *glyph direction* was kept while only the *position* was mirrored, so both arrows pointed backwards for an RTL reader. In RTL, "previous/back" must point **→** and "next/forward" **←**.
   - `prev`: `السابق ←` → `السابق →`
   - `next`: `→ التالي` → `← التالي`
   - Rendered live on the tracker archive pager (`src/tracker/archive.js`). Glyph-only edits inside existing values — no key change, so the EN/AR parity guard stays green.
2. **`text-align: left` → `start`** — `styles/pages/shops.css`, `.shops-nearme-status` / `.shops-nearme-results` (geolocation "near me" copy), so Arabic text aligns to the writing direction.
3. **Shops modal close → logical inset** — `.shops-modal-close` `right` → `inset-inline-end` (base + `@media` variant); removed the now-redundant `[dir='rtl']` override. Also fixes a latent bug where the narrow-screen variant kept an LTR inset in Arabic.

### Verified already-correct (no change)
- Directional icons: only `i-exchange` / `i-external`; `i-exchange` already in the RTL-mirror set, external-link icons conventionally un-mirrored.
- Swipe scroll-hints (karat strip + compare table): i18n-managed with flipped AR arrows.
- Arrow CTAs: bound elements resolve to the AR dictionary's hand-flipped `←` twins at runtime.
- CSS pseudo-element arrows + breadcrumb chevrons: all `[dir='rtl']`-guarded.

### Registered follow-ups (out of scope)
- A few static first-paint tracker links are English in markup but JS-hydrated to translated copy via `tracker-pro.js` — a content-translation concern (Phase 41), not an RTL bug.
- `styles/admin.css` has the most physical props but is English-only — skipped.

Full write-up: `reports/rtl/PHASE-20-rtl-bilingual.md`.

### Verification
`npm run build` + `npm run validate` + `npm test` (1286 pass / 0 fail) + `npm run lint` + `scripts/qa/parity-diff-scan.mjs` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small translation glyph fixes and CSS logical-property updates on shops/tracker UI; no auth, data, or API changes.
> 
> **Overview**
> Phase 20 RTL polish: fixes Arabic directional UX and documents the audit in `reports/rtl/PHASE-20-rtl-bilingual.md`.
> 
> **Arabic tracker archive pager** — `tracker.pagination.prev` / `.next` in `src/config/translations.js` had arrow glyphs pointing the wrong way for RTL (English glyph direction with mirrored label layout). **Prev** now uses **→** and **next** uses **←**, matching how readers move through pages in Arabic.
> 
> **Shops page CSS** (`styles/pages/shops.css`) — `.shops-nearme-status` and `.shops-nearme-results` use `text-align: start` instead of `left`. `.shops-modal-close` uses `inset-inline-end` for base and narrow viewport rules; the manual `[dir='rtl']` override is removed, which also fixes narrow-screen Arabic close-button inset on small viewports.
> 
> No new i18n keys; existing parity tests stay valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95229e322b5335482d5f0f2bd337554280bc69bc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->