### PR TITLE
feat(phase-21): homepage visual-regression gate + concrete a11y/hygiene fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ docs/plans/_artifacts/2026-06-26-overhaul-qa/
 # Tracker visual-harness output (regenerable via scripts/node/tracker-shots.mjs).
 docs/plans/_artifacts/tracker-shots/
 .image-src/
+
+# Visual-regression screenshots (regenerated on demand; signature JSON is the committed baseline)
+reports/visual/home/

--- a/index.html
+++ b/index.html
@@ -661,7 +661,7 @@
                 22K per gram in local currency · freshness shown live
               </p>
             </div>
-            <a href="tracker.html" class="section-link" id="gcc-see-all"></a>
+            <a href="tracker.html" class="section-link" id="gcc-see-all">See all countries →</a>
           </div>
           <!-- Region tabs for filtering prices -->
           <div class="gcc-region-tabs" role="tablist" aria-label="Filter gold prices by region">
@@ -699,7 +699,14 @@
               Global (24+)
             </button>
           </div>
-            <div class="gcc-grid" id="gcc-quick-grid" role="tabpanel" aria-live="polite">
+            <div
+              class="gcc-grid"
+              id="gcc-quick-grid"
+              role="tabpanel"
+              aria-labelledby="gcc-tab-gcc"
+              tabindex="0"
+              aria-live="polite"
+            >
             <!-- Filled by home.js -->
             <div class="gcc-card skeleton-card">
               <div class="skeleton-flag"></div>
@@ -877,20 +884,20 @@
               </p>
             </div>
           </div>
-          <div class="home-stats-grid" aria-label="Gold Ticker Live stats">
-            <article class="home-stat-card">
+          <div class="home-stats-grid" role="list" aria-label="Gold Ticker Live stats">
+            <article class="home-stat-card" role="listitem">
               <strong class="home-stat-value" id="home-stat-1-value">24+</strong>
               <span class="home-stat-label" id="home-stat-1-label">Countries</span>
             </article>
-            <article class="home-stat-card">
+            <article class="home-stat-card" role="listitem">
               <strong class="home-stat-value" id="home-stat-2-value">7</strong>
               <span class="home-stat-label" id="home-stat-2-label">Karats</span>
             </article>
-            <article class="home-stat-card">
+            <article class="home-stat-card" role="listitem">
               <strong class="home-stat-value" id="home-stat-3-value">EN / AR</strong>
               <span class="home-stat-label" id="home-stat-3-label">Bilingual</span>
             </article>
-            <article class="home-stat-card">
+            <article class="home-stat-card" role="listitem">
               <strong class="home-stat-value" id="home-stat-4-value">Free</strong>
               <span class="home-stat-label" id="home-stat-4-label">Forever</span>
             </article>
@@ -1334,7 +1341,12 @@
         </div>
       </section>
 
-      <section id="methodology" class="home-section home-section--methodology" data-reveal>
+      <section
+        id="methodology"
+        class="home-section home-section--methodology"
+        aria-labelledby="home-methodology-title"
+        data-reveal
+      >
         <div class="home-section-inner">
           <div class="section-intro">
             <div>
@@ -1351,7 +1363,12 @@
         </div>
       </section>
 
-      <section id="location-guides" class="home-section home-section--location-guides" data-reveal>
+      <section
+        id="location-guides"
+        class="home-section home-section--location-guides"
+        aria-labelledby="home-location-guides-title"
+        data-reveal
+      >
         <div class="home-section-inner">
           <div class="section-intro">
             <div>

--- a/reports/visual/PHASE-21-homepage.md
+++ b/reports/visual/PHASE-21-homepage.md
@@ -1,0 +1,80 @@
+# Phase 21 — Homepage overhaul (Track F · Yellow — visual-regression gated)
+
+The homepage is the flagship surface and has already been through many visual revamps, so a
+speculative redesign would be high-risk and low-value. This phase instead (1) builds the
+**visual-regression gate** the phase name references — which did not exist — and (2) ships a set of
+**concrete, objectively-verifiable** homepage fixes surfaced by a full structured audit of
+`index.html` / `src/pages/home.js` / `styles/pages/home.css`. No speculative aesthetic churn.
+
+## 1. Visual-regression gate — `scripts/qa/home-visual-baseline.mjs`
+
+Fully local, **$0** (no hosted visual-diff service — respects the cost constraint):
+
+- Renders the built `dist/index.html` in headless Chromium across **3 viewports × {light, dark}**
+  (mobile 390, tablet 768, desktop 1280) and writes two artefacts under `reports/visual/`:
+  - **`home/*.png`** — full-page screenshots for human pixel review (git-ignored; regenerated on
+    demand so the repo stays lean).
+  - **`home-signature.json`** — a **committed, diffable** structural + dimensional digest: section
+    id list, full heading outline, landmark/img/button/link counts, and the authoritative rendered
+    full-page height per viewport (read from each screenshot's PNG IHDR — robust to the homepage's
+    inner-scroll-container architecture, where `documentElement.scrollHeight` reports only the
+    viewport).
+- `--check` mode fails (exit 1) when the structure changes at all, or any viewport's rendered height
+  drifts >12% from the committed baseline — the gate future homepage phases run.
+- CodeQL-safe: constant out dir + in-memory-Map file server (`req.url` never reaches an `fs` call),
+  matching the console/perf/axe harnesses.
+- Handles headless scroll-reveal: forces `[data-reveal]` sections to their settled `.is-in-view`
+  state before capture (the IntersectionObserver never fires during a fullPage screenshot).
+
+Baseline captured this phase: 1 `h1`, 21 sections, clean h1→h6 outline (no skipped levels), 1 nav /
+1 main / 1 footer, rendered heights 10903 (mobile) / 9592 (tablet) / 8131 (desktop) px.
+
+**Proof the gate works:** after applying the fixes below, `--check` still passes against the
+pre-edit baseline — confirming every change is structurally and dimensionally non-regressing.
+
+## 2. Concrete fixes shipped
+
+**Accessibility (objective WCAG defects):**
+
+1. **Empty link with no discernible text** — `index.html` `#gcc-see-all` was `<a …></a>` (text only
+   injected by JS). Fails WCAG 2.4.4 / 4.1.2 if JS defers/fails. Added the fallback text
+   (`See all countries →`, matching the runtime `tx('seeAll')`) — consistent with its sibling
+   section links, which already ship fallback text.
+2. **Two top-level `<section>`s missing accessible names** — `#methodology` and `#location-guides`
+   had no `aria-labelledby`, so they weren't exposed as named landmarks like every sibling section.
+   Pointed each at its existing `<h2>` id.
+3. **Tabpanel incomplete (ARIA tabs pattern)** — `#gcc-quick-grid` (`role="tabpanel"`) had no
+   `aria-labelledby` and no `tabindex`. Added `aria-labelledby="gcc-tab-gcc"` + `tabindex="0"`, and
+   the region-tab click handler in `home.js` now repoints `aria-labelledby` at the active tab on
+   switch.
+4. **Ignored `aria-label` + weak KPI semantics** — `.home-stats-grid` carried an `aria-label` that
+   AT ignores on a role-less `<div>`, and its four KPI tiles were `<article>` (implies
+   self-contained headed content). Gave the grid `role="list"` (so the label is now announced) and
+   the tiles `role="listitem"`.
+
+**Correctness / hygiene:**
+
+5. **Undefined design token** — `styles/pages/home.css` karat tooltip used
+   `background: var(--color-gray-900, #1a1a1a)`, but `--color-gray-900` is defined nowhere, so it
+   silently relied on the literal. This tooltip is intentionally dark in both themes (paired with
+   fixed white text), so made the intent explicit: `background: #1a1a1a` with a comment (matching
+   the file's existing documented theme-invariant-literal pattern).
+6. **Dead duplicate statement** — `src/pages/home.js` removed a doubled
+   `priceEl.classList.remove('hlc-price--loading')`.
+
+## 3. Registered follow-ups (deliberately not touched)
+
+- **Trust-banner `<h3>` heading level** (`index.html` `#trust-banner-title`) reads as a subsection
+  rather than a section peer (WCAG 1.3.1). Not a strict skipped level, and its styling is coupled to
+  the `.trust-banner-content h3` selector — promoting the tag risks a visual regression, so it needs
+  a coordinated CSS+visual pass. Left for a dedicated change.
+- **Residual `var(--token, <literal>)` fallbacks** in `home.css` where the token name differs from
+  the compared token (e.g. `--color-up`, `--surface-secondary`) — several of these tokens may be
+  undefined-and-relying-on-the-fallback (as `--color-gray-900` was), so blind fallback removal is
+  unsafe. Belongs with a token-definition audit (Phase 17 territory), not a homepage edit.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (1286 pass) + `npm run lint` — all green.
+`node scripts/qa/home-visual-baseline.mjs --check` passes against the committed baseline. Homepage
+axe (A + AA) shows no new violations from the added ARIA semantics.

--- a/reports/visual/home-signature.json
+++ b/reports/visual/home-signature.json
@@ -1,0 +1,262 @@
+{
+  "structure": {
+    "h1Count": 1,
+    "sections": [
+      "hero-headline",
+      "home-chart-title",
+      "home-trend-title",
+      "home-tools-title",
+      "home-quick-convert-title",
+      "karat-strip-title",
+      "trust-strip",
+      "trust-banner-title",
+      "gcc-section-title",
+      "tools-title",
+      "home-stats-section",
+      "next-step-title",
+      "countries-quick",
+      "markets-title",
+      "home-section",
+      "how-it-works",
+      "methodology",
+      "methodology-reference",
+      "location-guides",
+      "location-guides-title",
+      "faq"
+    ],
+    "headingOutline": [
+      {
+        "level": 1,
+        "text": "Gold Prices Today UAE, GCC & Arab World"
+      },
+      {
+        "level": 2,
+        "text": "Gold Price Chart"
+      },
+      {
+        "level": 2,
+        "text": "Price History"
+      },
+      {
+        "level": 2,
+        "text": "Start from what you need"
+      },
+      {
+        "level": 3,
+        "text": "Quick convert"
+      },
+      {
+        "level": 2,
+        "text": "Live reference prices by karat"
+      },
+      {
+        "level": 3,
+        "text": "About Our Prices"
+      },
+      {
+        "level": 2,
+        "text": "Live Gold Prices"
+      },
+      {
+        "level": 2,
+        "text": "Everything You Need"
+      },
+      {
+        "level": 3,
+        "text": "Live Tracker"
+      },
+      {
+        "level": 3,
+        "text": "Gold Calculator"
+      },
+      {
+        "level": 3,
+        "text": "UAE Gold Prices"
+      },
+      {
+        "level": 3,
+        "text": "Find Gold Shops"
+      },
+      {
+        "level": 3,
+        "text": "Browse Countries"
+      },
+      {
+        "level": 3,
+        "text": "World Gold Map"
+      },
+      {
+        "level": 3,
+        "text": "Portfolio Tracker"
+      },
+      {
+        "level": 3,
+        "text": "Learn & Glossary"
+      },
+      {
+        "level": 3,
+        "text": "Gold Insights"
+      },
+      {
+        "level": 3,
+        "text": "Methodology"
+      },
+      {
+        "level": 3,
+        "text": "Gold Investing Guide"
+      },
+      {
+        "level": 2,
+        "text": "Gold Ticker Live by the numbers"
+      },
+      {
+        "level": 2,
+        "text": "What should I check next?"
+      },
+      {
+        "level": 3,
+        "text": "UAE buying guide"
+      },
+      {
+        "level": 3,
+        "text": "Dubai gold rate guide"
+      },
+      {
+        "level": 3,
+        "text": "GCC comparison"
+      },
+      {
+        "level": 3,
+        "text": "Spot vs retail"
+      },
+      {
+        "level": 2,
+        "text": "Browse by Country"
+      },
+      {
+        "level": 2,
+        "text": "Major Gold Markets"
+      },
+      {
+        "level": 3,
+        "text": "Dubai Gold Souk"
+      },
+      {
+        "level": 3,
+        "text": "Riyadh Gold Market"
+      },
+      {
+        "level": 3,
+        "text": "Kuwait Gold Souk"
+      },
+      {
+        "level": 3,
+        "text": "Khan el-Khalili"
+      },
+      {
+        "level": 3,
+        "text": "From the markets"
+      },
+      {
+        "level": 2,
+        "text": "Methodology at a glance"
+      },
+      {
+        "level": 2,
+        "text": "Reference methodology"
+      },
+      {
+        "level": 3,
+        "text": "How to compare with a shop quote"
+      },
+      {
+        "level": 2,
+        "text": "City buying guides"
+      },
+      {
+        "level": 2,
+        "text": "Location guide starter set"
+      },
+      {
+        "level": 3,
+        "text": "Dubai"
+      },
+      {
+        "level": 4,
+        "text": "Dubai — Quote verification checklist"
+      },
+      {
+        "level": 3,
+        "text": "Riyadh"
+      },
+      {
+        "level": 4,
+        "text": "Riyadh — Quote verification checklist"
+      },
+      {
+        "level": 3,
+        "text": "Kuwait City"
+      },
+      {
+        "level": 4,
+        "text": "Kuwait City — Quote verification checklist"
+      },
+      {
+        "level": 2,
+        "text": "Common Questions"
+      },
+      {
+        "level": 2,
+        "text": "Explore"
+      },
+      {
+        "level": 3,
+        "text": "Price tools"
+      },
+      {
+        "level": 3,
+        "text": "Markets"
+      },
+      {
+        "level": 3,
+        "text": "Learn & trust"
+      }
+    ],
+    "landmarks": {
+      "nav": 1,
+      "main": 1,
+      "footer": 1
+    },
+    "counts": {
+      "img": 12,
+      "buttons": 25,
+      "links": 145
+    }
+  },
+  "viewports": {
+    "mobile-light": {
+      "pageHeight": 10903,
+      "screenshotBytes": 113470
+    },
+    "mobile-dark": {
+      "pageHeight": 10903,
+      "screenshotBytes": 119595
+    },
+    "tablet-light": {
+      "pageHeight": 9592,
+      "screenshotBytes": 180910
+    },
+    "tablet-dark": {
+      "pageHeight": 9592,
+      "screenshotBytes": 300347
+    },
+    "desktop-light": {
+      "pageHeight": 8131,
+      "screenshotBytes": 243379
+    },
+    "desktop-dark": {
+      "pageHeight": 8131,
+      "screenshotBytes": 278350
+    }
+  }
+}

--- a/scripts/qa/home-visual-baseline.mjs
+++ b/scripts/qa/home-visual-baseline.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+/**
+ * home-visual-baseline.mjs — visual-regression signal for the homepage, fully local ($0, no hosted
+ * visual-diff service).
+ *
+ * Renders the built `dist/index.html` in headless Chromium across three viewports × {light, dark}
+ * and produces two artefacts under `reports/visual/`:
+ *   1. PNG screenshots (`reports/visual/home/*.png`) — for human pixel review. Git-ignored so the
+ *      repo stays lean; regenerate on demand.
+ *   2. `home-signature.json` — a committed, diffable structural + dimensional digest (section ids,
+ *      heading outline, landmark/img/button counts, full-page pixel height per viewport, screenshot
+ *      byte size). A regression that adds/drops a section, breaks the heading order, or blows up page
+ *      height shows as a JSON diff in review, and `--check` fails CI when it drifts from the
+ *      committed baseline.
+ *
+ * Usage:
+ *   npm run build && cp -r assets/. dist/assets/ && cp -r data/. dist/data/ && cp -f favicon.svg manifest.json dist/
+ *   node scripts/qa/home-visual-baseline.mjs            # write baseline (signature + screenshots)
+ *   node scripts/qa/home-visual-baseline.mjs --check    # compare signature to committed baseline, exit 1 on drift
+ *
+ * Security: the out dir is constant, and the local server resolves requests against an in-memory file
+ * map (req.url never reaches an fs call), matching the console/perf/axe harnesses.
+ */
+import { chromium } from 'playwright';
+import http from 'node:http';
+import {
+  createReadStream,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  mkdirSync,
+  writeFileSync,
+} from 'node:fs';
+import { extname, join, resolve, sep, relative } from 'node:path';
+
+const CHECK = process.argv.includes('--check');
+const SERVE_DIR = 'dist';
+const OUT_DIR = 'reports/visual';
+const SHOT_DIR = join(OUT_DIR, 'home');
+const SIGNATURE_PATH = join(OUT_DIR, 'home-signature.json');
+const PORT = 8302;
+
+const VIEWPORTS = [
+  { name: 'mobile', width: 390, height: 844 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'desktop', width: 1280, height: 900 },
+];
+const THEMES = ['light', 'dark'];
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.avif': 'image/avif',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+  '.xml': 'application/xml',
+  '.txt': 'text/plain',
+  '.map': 'application/json',
+  '.webmanifest': 'application/manifest+json',
+};
+
+function resolveChromium() {
+  if (process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE) return process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE;
+  const root = process.env.PLAYWRIGHT_BROWSERS_PATH || '/opt/pw-browsers';
+  try {
+    const dir = readdirSync(root).find((d) => d.startsWith('chromium-'));
+    if (dir) {
+      const p = join(root, dir, 'chrome-linux', 'chrome');
+      if (existsSync(p)) return p;
+    }
+  } catch {
+    /* fall through to default */
+  }
+  return undefined;
+}
+
+function loadTree(dir) {
+  const root = resolve(dir);
+  const map = new Map();
+  const walk = (d) => {
+    for (const n of readdirSync(d)) {
+      const f = join(d, n);
+      if (statSync(f).isDirectory()) walk(f);
+      else map.set('/' + relative(root, f).split(sep).join('/'), f);
+    }
+  };
+  walk(root);
+  return map;
+}
+
+function startServer(tree) {
+  const server = http.createServer((req, res) => {
+    let u = decodeURIComponent((req.url || '/').split('?')[0]);
+    if (u.endsWith('/')) u += 'index.html';
+    const f = tree.get(u);
+    if (!f) {
+      res.writeHead(404);
+      res.end('not found');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': MIME[extname(f)] || 'application/octet-stream' });
+    createReadStream(f).pipe(res);
+  });
+  return new Promise((r) => server.listen(PORT, () => r(server)));
+}
+
+/** Structural digest of the rendered homepage — stable across cosmetic edits, sensitive to structure. */
+async function structuralDigest(page) {
+  return page.evaluate(() => {
+    const main = document.querySelector('main') || document.body;
+    const sections = Array.from(main.querySelectorAll('section')).map(
+      (s) => s.id || s.getAttribute('aria-labelledby') || s.className.split(' ')[0] || 'section'
+    );
+    const headings = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6')).map((h) => ({
+      level: Number(h.tagName[1]),
+      text: (h.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 60),
+    }));
+    return {
+      h1Count: document.querySelectorAll('h1').length,
+      sections,
+      headingOutline: headings,
+      landmarks: {
+        nav: document.querySelectorAll('nav').length,
+        main: document.querySelectorAll('main').length,
+        footer: document.querySelectorAll('footer').length,
+      },
+      counts: {
+        img: document.querySelectorAll('img').length,
+        buttons: document.querySelectorAll('button').length,
+        links: document.querySelectorAll('a[href]').length,
+      },
+    };
+  });
+}
+
+async function main() {
+  if (!existsSync(SERVE_DIR)) {
+    console.error(`serve dir not found: ${SERVE_DIR} (run npm run build first)`);
+    process.exit(2);
+  }
+  const tree = loadTree(SERVE_DIR);
+  const server = await startServer(tree);
+  const browser = await chromium.launch({
+    executablePath: resolveChromium(),
+    args: ['--no-sandbox'],
+  });
+
+  mkdirSync(SHOT_DIR, { recursive: true });
+  const viewportSig = {};
+  let sharedDigest = null;
+
+  for (const vp of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const page = await browser.newPage({
+        viewport: { width: vp.width, height: vp.height },
+        colorScheme: theme,
+      });
+      try {
+        await page.goto(`http://localhost:${PORT}/index.html`, {
+          waitUntil: 'load',
+          timeout: 25000,
+        });
+      } catch {
+        /* screenshot whatever rendered */
+      }
+      await page.evaluate((t) => {
+        document.documentElement.setAttribute('data-theme', t);
+        document.documentElement.setAttribute('data-theme-mode', t);
+      }, theme);
+      // Force scroll-reveal to its settled state. Headless Chromium never fires the reveal
+      // IntersectionObserver during a fullPage screenshot (no real scroll/paint), so [data-reveal]
+      // sections stay stranded at opacity:0. Real users see them fade in on scroll — capture that
+      // final state, not the transient hidden one.
+      await page.evaluate(() => {
+        document.querySelectorAll('[data-reveal]').forEach((n) => n.classList.add('is-in-view'));
+      });
+      await page.waitForTimeout(1400);
+
+      const shotPath = join(SHOT_DIR, `home-${vp.name}-${theme}.png`);
+      const buf = await page.screenshot({ fullPage: true });
+      writeFileSync(shotPath, buf);
+      // Authoritative rendered full-page height: the PNG's own pixel height (IHDR height field,
+      // big-endian at byte offset 20). This is exactly what Playwright's fullPage capture measured,
+      // and is robust to the page's inner-scroll-container architecture (documentElement.scrollHeight
+      // reports only the viewport there).
+      const renderedHeight = buf.readUInt32BE(20);
+
+      viewportSig[`${vp.name}-${theme}`] = { pageHeight: renderedHeight, screenshotBytes: buf.length };
+      // The structural digest is theme/viewport-invariant; capture once on desktop-light.
+      if (vp.name === 'desktop' && theme === 'light') sharedDigest = await structuralDigest(page);
+      await page.close();
+      process.stdout.write('.');
+    }
+  }
+  process.stdout.write('\n');
+  await browser.close();
+  server.close();
+
+  const signature = { structure: sharedDigest, viewports: viewportSig };
+
+  if (CHECK) {
+    if (!existsSync(SIGNATURE_PATH)) {
+      console.error(`no baseline at ${SIGNATURE_PATH}; run without --check to write one`);
+      process.exit(1);
+    }
+    const baseline = JSON.parse(readFileSync(SIGNATURE_PATH, 'utf8'));
+    // Structure must match exactly; page heights may drift within ±12% (fonts, live data).
+    const structDrift = JSON.stringify(baseline.structure) !== JSON.stringify(signature.structure);
+    const heightDrift = Object.entries(signature.viewports).filter(([k, v]) => {
+      const base = baseline.viewports[k];
+      return !base || Math.abs(v.pageHeight - base.pageHeight) / base.pageHeight > 0.12;
+    });
+    if (structDrift || heightDrift.length) {
+      console.error('Homepage visual signature drifted from baseline:');
+      if (structDrift) console.error('  · structure changed (sections/headings/landmarks/counts)');
+      for (const [k] of heightDrift) console.error(`  · ${k} page height drifted >12%`);
+      console.error('Review reports/visual/home/*.png, then re-baseline if intended.');
+      process.exit(1);
+    }
+    console.log('Homepage visual signature matches baseline.');
+    return;
+  }
+
+  writeFileSync(SIGNATURE_PATH, JSON.stringify(signature, null, 2) + '\n');
+  console.log(
+    `Wrote ${SIGNATURE_PATH} + ${VIEWPORTS.length * THEMES.length} screenshots under ${SHOT_DIR}/`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -432,8 +432,6 @@ function renderHeroCard() {
     });
 
     priceEl.classList.remove('hlc-price--loading');
-
-    priceEl.classList.remove('hlc-price--loading');
   }
 
   const directionEl = document.getElementById('hlc-direction');
@@ -1514,11 +1512,14 @@ async function init() {
       });
       tab.classList.add('is-active');
       tab.setAttribute('aria-selected', 'true');
+      // Keep the tabpanel's accessible name pointed at the active tab (ARIA tabs pattern).
+      document.getElementById('gcc-quick-grid')?.setAttribute('aria-labelledby', tab.id);
       renderGCCGrid();
     });
     if (tab.dataset.region === homeRegion) {
       tab.classList.add('is-active');
       tab.setAttribute('aria-selected', 'true');
+      document.getElementById('gcc-quick-grid')?.setAttribute('aria-labelledby', tab.id);
     }
   });
 

--- a/styles/pages/home.css
+++ b/styles/pages/home.css
@@ -965,7 +965,11 @@
   max-width: 220px;
   padding: 0.35rem 0.55rem;
   border-radius: var(--radius-sm);
-  background: var(--color-gray-900, #1a1a1a);
+
+  /* Intentional theme-invariant dark tooltip surface (paired with the fixed white text below);
+     stays dark in both themes. Was `var(--color-gray-900, #1a1a1a)` but --color-gray-900 is not
+     defined anywhere, so it silently relied on this literal — make the intent explicit. */
+  background: #1a1a1a;
   color: var(--color-white);
   font-size: var(--text-2xs);
   font-weight: var(--weight-semibold);


### PR DESCRIPTION
## Phase 21 — Homepage overhaul (Track F · Yellow — visual-regression gated)

The homepage is the flagship surface and already heavily revamped, so rather than a speculative redesign this PR (1) builds the **visual-regression gate** the phase references — which did not exist — and (2) ships **concrete, objectively-verifiable** fixes from a full structured audit of `index.html` / `src/pages/home.js` / `styles/pages/home.css`. No speculative aesthetic churn.

### 1. Visual-regression gate — `scripts/qa/home-visual-baseline.mjs`
Fully local, **$0** (no hosted visual-diff service):
- Renders built `dist/index.html` in headless Chromium across **3 viewports × {light, dark}**. Writes `reports/visual/home/*.png` (human review, git-ignored) + a committed **`home-signature.json`** — section ids, heading outline, landmark/img/button/link counts, and rendered full-page height per viewport (read from each PNG's IHDR — robust to the inner-scroll-container layout where `documentElement.scrollHeight` reports only the viewport).
- `--check` fails on any structural change or >12% height drift — the gate future homepage phases run.
- CodeQL-safe (in-memory-Map server); force-settles `[data-reveal]` before capture.

Baseline: 1 `h1`, 21 sections, clean heading outline, rendered heights 10903/9592/8131px.
**Proof it works:** after the fixes, `--check` still passes against the pre-edit baseline → every change is structurally/dimensionally non-regressing.

### 2. Concrete fixes
**Accessibility (objective WCAG):**
1. `#gcc-see-all` was an empty `<a>` (WCAG 2.4.4/4.1.2 if JS defers) → fallback text matching runtime `tx('seeAll')`.
2. `#methodology` / `#location-guides` sections had no accessible name → `aria-labelledby` to their existing `<h2>`.
3. `#gcc-quick-grid` tabpanel → `aria-labelledby` + `tabindex="0"`; region-tab handler repoints `aria-labelledby` to the active tab on switch (ARIA tabs pattern).
4. `.home-stats-grid` `aria-label` was ignored on a role-less `<div>` → `role="list"` + `role="listitem"` on the KPI tiles.

**Correctness / hygiene:**
5. Karat tooltip used `var(--color-gray-900, #1a1a1a)` but that token is **undefined** → explicit intentional theme-invariant `#1a1a1a` with a comment.
6. Removed a dead duplicate `priceEl.classList.remove('hlc-price--loading')` in `home.js`.

### 3. Registered follow-ups (deliberately untouched)
- Trust-banner `<h3>` heading level (WCAG 1.3.1) — styling-coupled, risks a visual regression; needs a coordinated CSS+visual pass.
- Residual `var(--token, <literal>)` fallbacks where the token may be undefined-and-relying-on-fallback — belongs with a token-definition audit (Phase 17 territory), not a homepage edit.

### Verification
`npm run build` + `npm run validate` + `npm test` (1286 pass / 0 fail) + `npm run lint` — all green. `home-visual-baseline.mjs --check` passes. Homepage axe (A+AA) shows no new violations from the added ARIA.

Full write-up: `reports/visual/PHASE-21-homepage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly QA tooling and additive ARIA/markup; homepage behavior and layout are explicitly baseline-gated, with no pricing or auth changes.
> 
> **Overview**
> Introduces a **local homepage visual-regression gate** via `scripts/qa/home-visual-baseline.mjs`: headless Chromium captures **3 viewports × light/dark**, git-ignores PNGs under `reports/visual/home/`, and commits **`reports/visual/home-signature.json`** (sections, heading outline, landmark/counts, per-viewport page height). **`--check`** fails on any structural drift or **>12%** height change; the harness settles `[data-reveal]` before screenshots and serves `dist/` from an in-memory map.
> 
> **Homepage fixes (no speculative redesign):** fallback link text on `#gcc-see-all`; `aria-labelledby` on `#methodology` and `#location-guides`; GCC tabpanel `aria-labelledby` / `tabindex="0"` with `home.js` repointing the label on region tab switch; stats grid `role="list"` / `role="listitem"`; explicit dark karat tooltip background in `home.css`; removed duplicate `hlc-price--loading` removal in `home.js`.
> 
> Docs: `reports/visual/PHASE-21-homepage.md`. `.gitignore` ignores regenerated screenshot output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 463e441ebee018810e5f3563376366b8d09af499. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->