### PR TITLE
feat(phase-23): native Web Share on calculator + copy-image fallback fix

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -450,6 +450,7 @@
             </p>
             <div class="calc-result-note" id="val-nisab-indicator" role="status" aria-live="polite"></div>
             <div class="calc-result-actions">
+              <button class="calc-copy-btn calc-share-native-btn" id="calc-share-btn" type="button" hidden><svg class="calc-btn-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true" focusable="false"><use href="#i-share"/></svg> Share</button>
               <button class="calc-copy-btn" id="calc-copy-link-btn" type="button">Copy Link</button>
               <button class="calc-copy-btn" id="calc-copy-image-btn" type="button"><svg class="calc-btn-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true" focusable="false"><use href="#i-camera"/></svg> Copy as image</button>
             </div>

--- a/reports/calculator/PHASE-23-calculator-share.md
+++ b/reports/calculator/PHASE-23-calculator-share.md
@@ -1,0 +1,48 @@
+# Phase 23 — Calculator UX + export/share (Track F · Green)
+
+The calculator already ships a solid export/share surface — a shareable result card, **Copy Link**
+(deep-links via URL state), and **Copy as image** (html2canvas → clipboard). This phase fills the
+two real gaps in that surface: no native mobile share, and a copy-image path that could no-op on
+some browsers. Additive and zero-dependency (respects the $0 constraint — no new library, no
+network).
+
+## Fixes shipped
+
+1. **Native Web Share (new)** — added a **Share** button to the calculator result actions. It uses
+   the platform share sheet (`navigator.share`), the same pattern already used on the shops page
+   (`src/pages/shops.js`), so on mobile users can share straight to WhatsApp / Messages / etc.
+   instead of only copying a link.
+   - **Feature-detected & graceful:** the button ships `hidden` and is only revealed when
+     `typeof navigator.share === 'function'`. Where the API is absent (most desktops), it stays
+     hidden and the existing Copy Link / Copy as image buttons remain the fallback.
+   - Shares the canonical deep-link (`location … + search`, i.e. the URL-state permalink) plus a
+     short text built from the share card (weight · karat · currency · estimated value), omitting
+     the text when no result is computed yet.
+   - **Bilingual:** label is `Share` / `مشاركة`, set in `applyLang()` alongside the sibling buttons.
+   - No dependency, no CDN, no tracking on share.
+2. **Copy-as-image fallback gap (bug fix)** — the previous handler only ran inside
+   `if (navigator.clipboard?.write) { … }`, so browsers without clipboard **image** write (Firefox,
+   insecure contexts, older Safari) got **nothing** — not even a download. Restructured so the PNG
+   is copied to the clipboard where supported and **always falls back to a file download** otherwise
+   (and on a failed/empty blob). Every browser now gets the image one way or another.
+
+## Verification
+
+End-to-end headless smoke test (Playwright, stubbed `navigator.share`):
+
+| Scenario                  | Result                                                                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `navigator.share` present | Share button revealed (`hidden=false`), labeled `Share`; click fires `navigator.share({title, url: …?k=22&c=AED&mode=value})` |
+| `navigator.share` absent  | Share button stays `hidden` — copy buttons remain the fallback                                                                |
+
+Gate: `npm run build` + `npm run validate` + `npm test` (1286 pass) + `npm run lint` — all green.
+
+## Registered follow-up (not changed here)
+
+- **`Copy as image` loads html2canvas from a CDN** (`cdn.jsdelivr.net/npm/html2canvas@1.4.1`,
+  `src/pages/calculator.js`), lazily on click. This is the same external-CDN pattern the shops map
+  uses for Leaflet (accepted, lazy). For a fully self-contained / CSP-tightenable build it would be
+  better to bundle html2canvas as an on-demand dynamic-import chunk, but that adds a ~200 KB
+  dependency and needs a `gh-advisory-database` check + `npm run build` size review — out of scope
+  for this Green phase. Recommended as a dedicated dependency-review change. (The Share and Copy
+  Link paths have no such dependency.)

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -1178,7 +1178,11 @@ function applyLang() {
   renderCalculatorTrustAddons();
   set('calc-country-link', t('country_link'));
   document.querySelectorAll('.calc-copy-btn').forEach((btn) => {
-    if (btn.id === 'calc-copy-link-btn' || btn.id === 'calc-copy-image-btn') {
+    if (
+      btn.id === 'calc-copy-link-btn' ||
+      btn.id === 'calc-copy-image-btn' ||
+      btn.id === 'calc-share-btn'
+    ) {
       return;
     }
     const isSave = btn.classList.contains('calc-save-btn');
@@ -1186,6 +1190,13 @@ function applyLang() {
     btn.textContent = label;
     btn.setAttribute('aria-label', label);
   });
+  const shareBtn = document.getElementById('calc-share-btn');
+  if (shareBtn) {
+    shareBtn.replaceChildren(
+      iconUseElement('i-share', 'calc-btn-ico'),
+      ` ${STATE.lang === 'ar' ? 'مشاركة' : 'Share'}`
+    );
+  }
   set('calc-copy-link-btn', STATE.lang === 'ar' ? 'نسخ الرابط' : 'Copy Link');
   const copyImageBtn = document.getElementById('calc-copy-image-btn');
   if (copyImageBtn) {
@@ -1719,22 +1730,53 @@ function initCopyBtn() {
       }
       if (!window.html2canvas) return;
       const canvas = await window.html2canvas(card, { backgroundColor: '#ffffff', scale: 2 });
-      if (navigator.clipboard?.write) {
+      const downloadImage = () => {
+        const link = document.createElement('a');
+        link.href = canvas.toDataURL('image/png');
+        link.download = 'gold-calculator-result.png';
+        link.click();
+      };
+      // Prefer copying the image to the clipboard where supported; otherwise always fall back to a
+      // download so every browser (Firefox, insecure contexts, older Safari) still gets the image.
+      if (navigator.clipboard?.write && window.ClipboardItem) {
         canvas.toBlob(async (blob) => {
-          if (!blob) return;
+          if (!blob) {
+            downloadImage();
+            return;
+          }
           try {
-            if (window.ClipboardItem) {
-              await navigator.clipboard.write([new window.ClipboardItem({ [blob.type]: blob })]);
-              return;
-            }
-            throw new Error('Clipboard image API unavailable');
+            await navigator.clipboard.write([new window.ClipboardItem({ [blob.type]: blob })]);
           } catch {
-            const link = document.createElement('a');
-            link.href = canvas.toDataURL('image/png');
-            link.download = 'gold-calculator-result.png';
-            link.click();
+            downloadImage();
           }
         });
+      } else {
+        downloadImage();
+      }
+    });
+  }
+
+  const shareBtn = document.getElementById('calc-share-btn');
+  if (shareBtn && typeof navigator.share === 'function') {
+    // Native share sheet (mobile). Only surfaced when the Web Share API exists — the copy-link /
+    // copy-image buttons remain the fallback everywhere else. No dependency, no network.
+    shareBtn.hidden = false;
+    shareBtn.addEventListener('click', async () => {
+      const link = `${location.origin}${location.pathname}${location.search}`;
+      const main = document.getElementById('calc-share-card-main')?.textContent?.trim() || '';
+      const value = document.getElementById('calc-share-card-meta')?.textContent?.trim() || '';
+      const text = [main, value].filter((s) => s && s !== '—').join(' · ');
+      try {
+        await navigator.share({
+          title:
+            STATE.lang === 'ar'
+              ? 'حاسبة الذهب — Gold Ticker Live'
+              : 'Gold Ticker Live — gold calculator',
+          text: text || undefined,
+          url: link,
+        });
+      } catch {
+        // User canceled the share sheet, or share failed — no-op (copy buttons remain available).
       }
     });
   }


### PR DESCRIPTION
## Phase 23 — Calculator UX + export/share (Track F · Green)

The calculator already ships a solid export/share surface — a shareable result card, **Copy Link** (URL-state deep link), and **Copy as image**. This PR fills the two real gaps: no native mobile share, and a copy-image path that could no-op on some browsers. Additive, **zero-dependency** ($0 — no new library, no network).

### Fixes
1. **Native Web Share (new)** — added a **Share** button to the result actions using `navigator.share` (the same pattern already used on the shops page). On mobile, users share straight to the native sheet (WhatsApp / Messages / …) instead of only copying a link.
   - **Feature-detected & graceful:** ships `hidden`, revealed only when `typeof navigator.share === 'function'`. Absent on most desktops → stays hidden, existing copy buttons remain the fallback.
   - Shares the canonical URL-state permalink + a short card-derived text (weight · karat · currency · value), omitted when no result is computed.
   - **Bilingual** (`Share` / `مشاركة`). No dependency, no CDN, no share tracking.
2. **Copy-as-image fallback bug** — the handler only ran inside `if (navigator.clipboard?.write)`, so browsers without clipboard **image** write (Firefox, insecure contexts, older Safari) got **nothing**. Restructured to copy where supported and **always fall back to a file download** otherwise.

### Verification
End-to-end headless smoke test (Playwright, stubbed `navigator.share`):

| Scenario | Result |
| --- | --- |
| `navigator.share` present | Share button revealed, labeled `Share`; click fires `navigator.share({title, url: …?k=22&c=AED&mode=value})` |
| `navigator.share` absent | Button stays `hidden`; copy buttons remain the fallback |

Gate: `npm run build` + `npm run validate` + `npm test` (1286 pass / 0 fail) + `npm run lint` — all green.

### Registered follow-up
`Copy as image` still lazy-loads html2canvas from a CDN (same accepted pattern as Leaflet on the shops map). Bundling it as an on-demand dynamic-import chunk is a dependency-review change (~200 KB dep + advisory + size review) — out of scope for this Green phase; the Share and Copy Link paths have no such dependency.

Full write-up: `reports/calculator/PHASE-23-calculator-share.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only calculator UX with feature detection and graceful fallbacks; no auth, data, or API changes.
> 
> **Overview**
> Adds a **Share** control to gold value result actions that uses **`navigator.share`** (same approach as shops) when the API exists, sharing the URL-state permalink plus optional card text; the button stays **`hidden`** on unsupported browsers so **Copy Link** / **Copy as image** remain unchanged.
> 
> **Copy as image** now always delivers a PNG: clipboard copy when `ClipboardItem` is available, otherwise an automatic **`gold-calculator-result.png`** download (including empty blob or write failures). Share labeling is wired in **`applyLang()`** as **Share** / **مشاركة**.
> 
> Phase 23 notes are documented in `reports/calculator/PHASE-23-calculator-share.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cdc34d5faa850f8807e5c67f139121b60934d0f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->