### PR TITLE
fix(phase-24): compare table off-by-one colspan on unavailable rows

### DIFF
--- a/reports/compare/PHASE-24-compare-polish.md
+++ b/reports/compare/PHASE-24-compare-polish.md
@@ -1,0 +1,70 @@
+# Phase 24 — Compare tool polish, in-place (Track F · Green)
+
+Audited the country comparison tool (`compare.html`, `src/pages/compare.js`,
+`styles/pages/compare.css`). The tool is already well-built — but the audit found one **live
+table-structure bug** that misaligns the comparison table on every initial load. Fixed and verified,
+plus one CSS correctness cleanup.
+
+## Bug fixed — off-by-one colspan on "unavailable" rows (WCAG 1.3.1)
+
+The comparison table has **8 columns** (`COLUMNS`: country, currency, local, USD, VAT, making,
+retail, vs-UAE). When a country's data is unavailable, the row is rendered as:
+
+- `<th scope="row">` (country) — 1 column
+- `<td>` (currency) — 1 column
+- `<td colspan="COLUMNS.length - 1">` (the "unavailable" message)
+
+That is `1 + 1 + 7 = 9` columns in an **8-column** table — the "unavailable" cell overran the table
+by one column, breaking row/column alignment and the table's semantic structure (screen readers get
+misaligned column associations; visually the cell overhangs). The colspan must be
+`COLUMNS.length - 2` (country `<th>` and currency `<td>` already occupy the first two columns), i.e.
+**6**.
+
+This is not an edge case: in the **offline / pre-data-fetch state the entire table renders as
+unavailable rows**, so the misalignment was visible on every initial page load until live data
+resolved.
+
+**Fix:** `colspan: String(COLUMNS.length - 1)` → `String(COLUMNS.length - 2)` in `renderTable()`
+(`src/pages/compare.js`).
+
+**Verified** with a headless render (Playwright) that sums every body row's `colspan` and compares
+to the header column count:
+
+| Metric              | Before (implied)     | After (measured)                       |
+| ------------------- | -------------------- | -------------------------------------- |
+| Header columns      | 8                    | 8                                      |
+| Rows rendered       | 4                    | 4 (all "unavailable" in offline state) |
+| Rows whose span ≠ 8 | 4 (all overran by 1) | **0**                                  |
+
+## Correctness cleanup
+
+- `styles/pages/compare.css` `.compare-chart-key::before` used
+  `border-radius: var(--radius-xs, 3px)`, but `--radius-xs` is defined as **4px** — the `3px`
+  fallback was both dead (the token always wins) and mismatched (a trap if the token were ever
+  removed). Changed to `var(--radius-xs)`.
+
+## Verified clean — no change needed
+
+The interactive compare tool is otherwise solid: the table is a real `<table>` with
+`<th scope="col">` column headers, `<th scope="row">` country headers, **dynamic `aria-sort`**
+(recomputed per render from sort state) driven by proper `<button>` sort controls; the karat group
+and country picker carry correct `role`/`aria-label`/`<label>`; no duplicate ids; no empty
+interactive elements; the swipe hint is i18n-managed with correctly-mirrored RTL arrows (verified in
+Phase 20). `--weight-normal` and `--radius-xs` are both defined tokens (no undefined-token bugs like
+the homepage/tracker had).
+
+## Registered follow-up — edu-hub colour-contrast (not fixed here)
+
+Phase 19 flagged the **static educational hub** at the bottom of the compare page (`.edu-table` /
+`.edu-card-title`, styled by the shared `styles/components/edu.css`) at ~4.36:1 vs the 4.5:1 AA
+target. This is the shared `edu-*` component (also on the portfolio page) and the affected colour
+resolves through shared brand tokens (`--color-warning` `#a0671c`, `--color-gold-dark`) used in
+**both themes** — exactly the token-level, both-theme change deferred in Phase 19. Precise data for
+the eventual remediation: on the edu tinted surface `#fef5e7`, a text colour of ≈`#946017` reaches
+4.93:1 (and 5.32:1 on white) while staying visually close. Left for the dedicated contrast pass, not
+rushed into this Green in-place phase.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (1286 pass, incl. `compare-core.test.js`) +
+`npm run lint` — all green. Headless render confirms the table column structure is now consistent.

--- a/src/pages/compare.js
+++ b/src/pages/compare.js
@@ -495,9 +495,12 @@ function renderTable(rows) {
       ])
     );
     if (!row.available) {
+      // Country <th> and the currency <td> already occupy the first two columns, so the
+      // "unavailable" cell spans the remaining COLUMNS.length - 2 (was - 1, which overran the
+      // table by one column and broke row/column alignment — WCAG 1.3.1).
       const td = el(
         'td',
-        { class: 'compare-td compare-td--unavailable', colspan: String(COLUMNS.length - 1) },
+        { class: 'compare-td compare-td--unavailable', colspan: String(COLUMNS.length - 2) },
         t().unavailable
       );
       tr.append(el('td', { class: 'compare-td' }, row.currency), td);

--- a/styles/pages/compare.css
+++ b/styles/pages/compare.css
@@ -627,7 +627,9 @@
   content: '';
   inline-size: 0.75rem;
   block-size: 0.75rem;
-  border-radius: var(--radius-xs, 3px);
+
+  /* --radius-xs is defined (4px); the old `, 3px` fallback was dead and mismatched the token. */
+  border-radius: var(--radius-xs);
 }
 
 .compare-chart-key--a::before {


### PR DESCRIPTION
## Phase 24 — Compare tool polish, in-place (Track F · Green)

Audited the country comparison tool. It's already well-built, but the audit found one **live table-structure bug** that misaligns the table on every initial load. Fixed + verified, plus a CSS correctness cleanup.

### Bug fixed — off-by-one colspan on "unavailable" rows (WCAG 1.3.1)
The table has **8 columns**. An unavailable-country row renders `<th>`(country) + `<td>`(currency) + `<td colspan="COLUMNS.length - 1">` = `1 + 1 + 7 = 9` columns in an 8-column table — the "unavailable" cell overran by one column, breaking row/column alignment and table semantics. Colspan must be `COLUMNS.length - 2` (the country `<th>` and currency `<td>` already take the first two columns).

**Not an edge case:** in the offline / pre-data-fetch state the **entire table renders as unavailable rows**, so the misalignment showed on every initial load.

**Verified** (headless Playwright, summing each row's colspan vs the header):

| Metric | Before | After |
| --- | --- | --- |
| Header columns | 8 | 8 |
| Rows with span ≠ 8 | 4 (all overran by 1) | **0** |

### Correctness cleanup
`.compare-chart-key::before` used `var(--radius-xs, 3px)`, but `--radius-xs` is **4px** — the `3px` fallback was dead and mismatched → `var(--radius-xs)`.

### Verified clean (no change)
Real `<table>` with `<th scope="col/row">`, **dynamic `aria-sort`** via proper sort buttons, labeled controls, no dup ids / empty elements, RTL-correct swipe hint. Both referenced tokens are defined (no undefined-token bug).

### Registered follow-up
The shared **edu-hub** colour-contrast (`.edu-table`/`.edu-card-title`, ~4.36:1 vs 4.5:1) resolves through shared brand tokens used in both themes — the Phase-19-deferred token-level contrast pass. Precise target recorded (≈`#946017` → 4.93:1 on the edu surface). Not rushed into this Green phase.

### Verification
`npm run build` + `npm run validate` + `npm test` (1286 pass / 0 fail, incl. `compare-core.test.js`) + `npm run lint` — all green.

Full write-up: `reports/compare/PHASE-24-compare-polish.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized compare UI fix (table markup + cosmetic CSS) with no auth, data, or API changes.
> 
> **Overview**
> Fixes a **live table-structure bug** on the compare page: unavailable-country rows used `colspan={COLUMNS.length - 1}` even though the country `<th>` and currency `<td>` already fill two of eight columns, so every such row spanned nine columns and misaligned the grid (including the common offline/pre-fetch state where all rows are unavailable). **`renderTable()`** now uses `COLUMNS.length - 2` with an inline WCAG 1.3.1 note.
> 
> **`.compare-chart-key::before`** drops the dead `3px` fallback on `var(--radius-xs)` and uses the defined **4px** token only.
> 
> Adds **`reports/compare/PHASE-24-compare-polish.md`** documenting the fix, verification, and a deferred edu-hub contrast follow-up (unchanged in code).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c342fb254f28e87b7055f5a7654024513199214d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->