### PR TITLE
fix(phase-26): portfolio modal accessible name + fallback-token cleanup

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -670,7 +670,11 @@
     </main>
 
     <!-- Add/edit/confirm dialog (content rendered by portfolio.js) -->
-    <dialog class="portfolio-dialog" id="portfolio-dialog"></dialog>
+    <dialog
+      class="portfolio-dialog"
+      id="portfolio-dialog"
+      aria-labelledby="portfolio-dialog-title"
+    ></dialog>
 
     <script>
       if ('serviceWorker' in navigator) {

--- a/reports/portfolio/PHASE-26-portfolio-polish.md
+++ b/reports/portfolio/PHASE-26-portfolio-polish.md
@@ -1,0 +1,53 @@
+# Phase 26 — Portfolio tracker polish, in-place (Track F · Green)
+
+Audited the portfolio tracker (`portfolio.html`, `src/pages/portfolio.js`,
+`styles/pages/portfolio.css`). The tool is well-built (local-only holdings, labeled inputs, correct
+value formula), but the audit found one real modal-accessibility gap. Fixed and verified, plus the
+recurring fallback-token cleanup.
+
+## Bug fixed — modal dialog had no accessible name (ARIA / WCAG 4.1.2)
+
+The add/edit-holding and confirm-delete flows both use the shared `<dialog id="portfolio-dialog">`
+opened with `showModal()`. Each builder injects an `<h2>` title ("Add holding" / "Edit holding" /
+the confirm prompt), but the dialog had **no `aria-labelledby`**, so screen readers announced the
+modal with no name — the user hears "dialog" with no indication of what it's for.
+
+**Fix:** declared `aria-labelledby="portfolio-dialog-title"` on the static `<dialog>`
+(`portfolio.html`) and gave the title `<h2>` that id in **both** builders — `openHoldingDialog()`
+and `confirmDialog()` (`src/pages/portfolio.js`). Only one dialog is open at a time and content is
+rebuilt on each open, so the single shared id is correct.
+
+**Verified** (headless Playwright): clicking "Add holding" opens the dialog with
+`aria-labelledby="portfolio-dialog-title"` resolving to the title text **"Add holding"** — a real
+accessible name where there was none.
+
+## Correctness cleanup
+
+- `styles/pages/portfolio.css` had the recurring dead+mismatched fallback
+  `letter-spacing: var(--tracking-wide, 0.04em)` in **two** places — `--tracking-wide` is defined as
+  **0.025em**, so the `0.04em` literal was dead and misleading. Removed the fallback (same cleanup
+  as Phases 24/25).
+
+## Verified well-built — no change needed
+
+- **Add/edit form:** every input (`pf-label`, `pf-weight`, `pf-karat`, `pf-date`, `pf-cost`,
+  `pf-cost-currency`) is paired with a `<label for>` via the shared `field()` helper (ids match);
+  inputs use correct `type` (number/date/text), `inputmode`, `min`/`step`, and `required`.
+- **Holdings table:** real `<table>` with `<th scope="col">` for all seven columns; edit/remove
+  buttons carry value-bearing `aria-label`s (`"<edit/remove>: <holding label>"`).
+- **Value formula:** `weight × (karat/24) × (spot ÷ troy-oz) × FX` with the immutable
+  `CONSTANTS.AED_PEG` (3.6725) and troy-oz constant — invariants intact; every figure labeled a
+  spot-linked reference estimate.
+- **Privacy / $0:** holdings persist to `localStorage` only — no backend, no account, no cost.
+- No duplicate ids, no empty interactive elements.
+
+## Registered follow-up
+
+- The portfolio page's **shared edu-hub** section carries the same colour-contrast the compare page
+  does (`.edu-card-title`, ~4.36:1 vs 4.5:1) — the Phase-19-deferred shared-token, both-theme
+  contrast pass (target data recorded in the Phase 24 report). Not rushed into this Green phase.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (1286 pass) + `npm run lint` — all green. Headless
+render confirms the dialog now exposes its accessible name on open.

--- a/src/pages/portfolio.js
+++ b/src/pages/portfolio.js
@@ -729,7 +729,7 @@ function openForm(editId = null) {
   if (!dialog) return;
   clear(dialog);
 
-  const title = el('h2', { class: 'portfolio-dialog-title' }, [
+  const title = el('h2', { id: 'portfolio-dialog-title', class: 'portfolio-dialog-title' }, [
     editing ? dict.editHolding : dict.addHolding,
   ]);
 
@@ -882,7 +882,9 @@ function confirmDialog({ title, body, onConfirm }) {
   const dialog = document.getElementById('portfolio-dialog');
   if (!dialog) return;
   clear(dialog);
-  dialog.appendChild(el('h2', { class: 'portfolio-dialog-title' }, [title]));
+  dialog.appendChild(
+    el('h2', { id: 'portfolio-dialog-title', class: 'portfolio-dialog-title' }, [title])
+  );
   if (body) dialog.appendChild(el('p', { class: 'portfolio-dialog-body' }, [body]));
   dialog.appendChild(
     el('div', { class: 'portfolio-form-actions' }, [

--- a/styles/pages/portfolio.css
+++ b/styles/pages/portfolio.css
@@ -203,7 +203,9 @@
   font-weight: var(--weight-semibold);
   color: var(--color-text-muted);
   text-transform: uppercase;
-  letter-spacing: var(--tracking-wide, 0.04em);
+  letter-spacing: var(
+    --tracking-wide
+  ); /* token is 0.025em; dead+mismatched 0.04em fallback removed */
 }
 
 .portfolio-card-value {
@@ -347,7 +349,9 @@
   font-size: var(--text-xs);
   font-weight: var(--weight-semibold);
   text-transform: uppercase;
-  letter-spacing: var(--tracking-wide, 0.04em);
+  letter-spacing: var(
+    --tracking-wide
+  ); /* token is 0.025em; dead+mismatched 0.04em fallback removed */
 }
 
 .portfolio-table-label {


### PR DESCRIPTION
## Phase 26 — Portfolio tracker polish, in-place (Track F · Green)

Audited the portfolio tracker. It's well-built (local-only holdings, labeled inputs, correct value formula), but the audit found one real modal-accessibility gap.

### Bug fixed — modal dialog had no accessible name (WCAG 4.1.2 / ARIA)
The add/edit-holding and confirm-delete flows share `<dialog id="portfolio-dialog">` opened via `showModal()`. Each builder injects an `<h2>` title, but the dialog had **no `aria-labelledby`**, so screen readers announced the modal with no name.

**Fix:** declared `aria-labelledby="portfolio-dialog-title"` on the static `<dialog>` and gave the title `<h2>` that id in **both** `openHoldingDialog()` and `confirmDialog()`.

**Verified** (headless Playwright): opening "Add holding" exposes `aria-labelledby="portfolio-dialog-title"` → title text **"Add holding"** — an accessible name where there was none.

### Correctness cleanup
Removed the recurring dead+mismatched `letter-spacing: var(--tracking-wide, 0.04em)` fallback in two places (`--tracking-wide` is 0.025em) — same as Phases 24/25.

### Verified well-built (no change)
- Every add/edit input paired with `<label for>` (ids match), correct input types/validation.
- Holdings `<table>` with `<th scope="col">`; edit/remove buttons carry value-bearing `aria-label`s.
- Value formula uses the immutable AED peg (3.6725) + troy-oz; every figure labeled a reference estimate.
- Holdings persist to `localStorage` only — no backend, no account, **$0**.

### Registered follow-up
The shared **edu-hub** section carries the same colour-contrast as the compare page (Phase-19-deferred shared-token, both-theme pass).

### Verification
`npm run build` + `npm run validate` + `npm test` (1286 pass / 0 fail) + `npm run lint` — all green.

Full write-up: `reports/portfolio/PHASE-26-portfolio-polish.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small a11y and styling-token fixes only; no changes to valuation, storage, or API behavior.
> 
> **Overview**
> Gives the portfolio **add/edit** and **confirm-delete** modals a proper accessible name (WCAG 4.1.2): `#portfolio-dialog` now has `aria-labelledby="portfolio-dialog-title"`, and both dialog builders set that id on the injected title `<h2>` so screen readers announce the modal purpose instead of an unnamed “dialog”.
> 
> Also drops the misleading `letter-spacing: var(--tracking-wide, 0.04em)` fallback in two portfolio CSS rules (token is 0.025em), matching prior phase cleanups. Phase 26 audit notes are in `reports/portfolio/PHASE-26-portfolio-polish.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ab0a6ef1249bba348248bda8f5a9cb80d1d7ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->