### PR TITLE
feat(phase-29): client-side $0 growth-experiment registry (flags only)

### DIFF
--- a/reports/growth/PHASE-29-growth-flags.md
+++ b/reports/growth/PHASE-29-growth-flags.md
@@ -1,0 +1,56 @@
+# Phase 29 — Additive growth (flags only) (Track G · Yellow)
+
+Establishes a **client-side, $0 growth-experiment registry** — flags only, everything OFF, nothing
+wired into the live UI. It gives future growth work a safe, no-cost place to land behind a flag, and
+a guard test so nothing ships on by accident.
+
+## Why a new registry (and not the existing flags)
+
+The site already has a feature-flag system in `src/lib/site-settings.js`, but it is
+**Supabase-backed and owner-controlled** (admin panel `features`: `darkMode`, `newsletter:false`,
+`portfolioTracker`, `orderGold`, `priceAlerts`). That is owner-gated — this phase does **not** touch
+Supabase, the admin, or those flags. Instead it adds a separate, purely client-side layer for **$0
+growth experiments** that need no backend, account, or recurring cost.
+
+## `src/config/growth-experiments.js`
+
+- `GROWTH_EXPERIMENTS` — a documented registry; each entry has `enabled` (default **false**),
+  `summary`, `rationale`, and `readiness` (what building it would touch when turned on).
+- `isGrowthExperimentEnabled(key)` — live default is always the registry value (false for everything
+  today). A `?growth=<key>` URL param can force one on **for local testing only** — it never
+  persists and is ignored for unknown keys, so it can't accidentally ship anything.
+- The module is **not imported anywhere**, so the bundler tree-shakes it out — zero bytes and zero
+  behaviour change on the live site. This is literally "flags only".
+
+Registered experiments (all OFF; each is a considered, ready-to-build $0 lever):
+
+| Key                  | What it would add                                              | $0 lever                                                                                 |
+| -------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `shareNudge`         | Dismissible "share this tool" prompt on result surfaces        | Word-of-mouth; reuses the native Web Share path from Phase 23                            |
+| `relatedToolsRail`   | Cross-tool recommendation rail                                 | Session depth via internal links only                                                    |
+| `priceMoveBadge`     | Subtle "▲ x% today" badge on landing surfaces                  | Retention; reuses the tracker's existing move engine (same reference-estimate labelling) |
+| `saveComparisonLink` | One-tap "save this comparison" copying the URL-state deep link | Return visits; reuses existing deep-link serialisation + copy toast                      |
+
+## Guard test — `tests/growth-experiments.test.js`
+
+Five assertions that make the "flags only, $0" contract enforceable in CI:
+
+1. The registry is a non-empty object.
+2. **Every experiment defaults to `enabled:false`** — the build fails if any flips to `true`.
+3. Each experiment carries the documented `summary`/`rationale`/`readiness` fields.
+4. **No experiment references a forbidden monetization/cost surface** (regex guard against
+   `newsletter` / `whatsapp business` / `stripe` / `payment` / `subscription billing`) — protects
+   the $0 / no-resurrected-monetization guardrail.
+5. `isGrowthExperimentEnabled()` returns `false` for every key (and unknown keys) with no URL
+   override.
+
+## Constraints honoured
+
+- $0 / no new recurring cost — every experiment is client-side only.
+- No newsletter automation, WhatsApp Business API, or payments — the guard test blocks them.
+- No Supabase / admin / owner-gated changes.
+- No live UI change — the registry is unwired and tree-shaken out.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (1291 pass, +5) + `npm run lint` — all green.

--- a/src/config/growth-experiments.js
+++ b/src/config/growth-experiments.js
@@ -1,0 +1,101 @@
+/**
+ * config/growth-experiments.js
+ *
+ * Client-side, $0 registry of **additive growth experiments** — all OFF by default.
+ *
+ * This is deliberately separate from the Supabase-backed feature flags in `src/lib/site-settings.js`
+ * (which the owner controls via the admin panel). Those toggle owner-gated product features;
+ * *these* are purely client-side, no-cost growth ideas that a future phase can build behind the flag
+ * and enable without any backend, account, or recurring cost.
+ *
+ * Rules for anything added here:
+ *   1. Default MUST be `false` — nothing here changes the live site until deliberately enabled. The
+ *      `growth-experiments.test.js` guard fails the build if any default flips to `true`.
+ *   2. $0 only — no newsletter automation, no WhatsApp Business API, no payments, no new recurring
+ *      cost. Local/client-side behaviour only (localStorage, Web Share, DOM nudges).
+ *   3. Every price/trust surface stays honest — a growth nudge may never overstate data or imply
+ *      endorsement.
+ *
+ * Enabling for local testing only: append `?growth=<key>` (or a comma list) to the URL. This never
+ * persists and is ignored unless the key exists below, so it can't accidentally ship anything on.
+ */
+
+/**
+ * @typedef {Object} GrowthExperiment
+ * @property {boolean} enabled      Live default — MUST be false.
+ * @property {string}  summary      One line: what shipping it would add.
+ * @property {string}  rationale    Why it's a $0-safe growth lever.
+ * @property {string}  readiness    What building it would touch when enabled.
+ */
+
+/** @type {Record<string, GrowthExperiment>} */
+export const GROWTH_EXPERIMENTS = {
+  shareNudge: {
+    enabled: false,
+    summary: 'Dismissible "share this tool" prompt on the calculator/tracker result surfaces.',
+    rationale:
+      'Word-of-mouth is the only $0 acquisition channel available; reuses the existing native Web Share path (Phase 23), no dependency.',
+    readiness:
+      'Add a gated, dismissible prompt near the result actions; persists dismissal in localStorage.',
+  },
+  relatedToolsRail: {
+    enabled: false,
+    summary: 'Cross-tool recommendation rail ("people comparing prices also use the calculator").',
+    rationale:
+      'Increases session depth across the free tools with purely internal links — no data, no cost.',
+    readiness: 'Render a gated rail from a static internal-links map already present in the shell.',
+  },
+  priceMoveBadge: {
+    enabled: false,
+    summary: 'A subtle "▲ x% today" badge on landing surfaces to pull returning visitors back.',
+    rationale:
+      'Uses data already computed for the tracker (session move vs. baseline); retention lever at $0.',
+    readiness:
+      'Reuse the freshness/move engine; must carry the same reference-estimate labelling as every price surface.',
+  },
+  saveComparisonLink: {
+    enabled: false,
+    summary: 'One-tap "save this comparison" that copies the URL-state deep link with a toast.',
+    rationale:
+      'Encourages return visits and sharing of a specific comparison; the deep-link state already exists.',
+    readiness:
+      'Gated button on compare/calculator; reuses existing URL-state serialisation + copy toast.',
+  },
+};
+
+/** Keys that may be force-enabled via `?growth=` for local testing (all of them). */
+const OVERRIDABLE = new Set(Object.keys(GROWTH_EXPERIMENTS));
+
+function urlOverrides() {
+  try {
+    if (typeof location === 'undefined' || !location.search) return new Set();
+    const raw = new URLSearchParams(location.search).get('growth');
+    if (!raw) return new Set();
+    return new Set(
+      raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => OVERRIDABLE.has(s))
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Is a growth experiment active for this page load? Live default is always the registry's `enabled`
+ * (false for everything today); a `?growth=<key>` URL param can force it on for local testing only.
+ * @param {string} key
+ * @returns {boolean}
+ */
+export function isGrowthExperimentEnabled(key) {
+  const exp = GROWTH_EXPERIMENTS[key];
+  if (!exp) return false;
+  if (exp.enabled) return true;
+  return urlOverrides().has(key);
+}
+
+/** All registry keys (for tooling/tests). */
+export function growthExperimentKeys() {
+  return Object.keys(GROWTH_EXPERIMENTS);
+}

--- a/tests/growth-experiments.test.js
+++ b/tests/growth-experiments.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * Guard test for the client-side growth-experiment registry.
+ *
+ * The whole point of `src/config/growth-experiments.js` is "flags only" — nothing there may change
+ * the live site until deliberately enabled. This test fails the build if any experiment's default
+ * flips to `true`, drifts from its documented shape, or references a forbidden monetization surface,
+ * so growth can never ship on by accident.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const MODULE = new URL('../src/config/growth-experiments.js', `file://${__filename}`).href;
+
+test('growth-experiments: registry is a non-empty object', async () => {
+  const { GROWTH_EXPERIMENTS } = await import(MODULE);
+  assert.equal(typeof GROWTH_EXPERIMENTS, 'object');
+  assert.ok(Object.keys(GROWTH_EXPERIMENTS).length > 0, 'expected at least one growth experiment');
+});
+
+test('growth-experiments: every experiment defaults to enabled:false (flags only)', async () => {
+  const { GROWTH_EXPERIMENTS } = await import(MODULE);
+  for (const [key, exp] of Object.entries(GROWTH_EXPERIMENTS)) {
+    assert.equal(
+      exp.enabled,
+      false,
+      `growth experiment "${key}" must default to enabled:false — nothing ships on by default`
+    );
+  }
+});
+
+test('growth-experiments: each experiment carries required documentation fields', async () => {
+  const { GROWTH_EXPERIMENTS } = await import(MODULE);
+  for (const [key, exp] of Object.entries(GROWTH_EXPERIMENTS)) {
+    for (const field of ['summary', 'rationale', 'readiness']) {
+      assert.equal(typeof exp[field], 'string', `growth experiment "${key}" missing "${field}"`);
+      assert.ok(exp[field].length > 0, `growth experiment "${key}" has an empty "${field}"`);
+    }
+  }
+});
+
+test('growth-experiments: no forbidden monetization/cost surfaces are referenced', async () => {
+  // Guardrail: additive growth here is $0 only — no newsletter automation, WhatsApp Business API, or
+  // payments. Catch any experiment that tries to (re)introduce them by keyword.
+  const { GROWTH_EXPERIMENTS } = await import(MODULE);
+  const forbidden = /newsletter|whatsapp business|stripe|payment|subscription billing/i;
+  for (const [key, exp] of Object.entries(GROWTH_EXPERIMENTS)) {
+    const blob = `${exp.summary} ${exp.rationale} ${exp.readiness}`;
+    assert.equal(
+      forbidden.test(blob),
+      false,
+      `growth experiment "${key}" references a forbidden monetization/cost surface`
+    );
+  }
+});
+
+test('growth-experiments: isGrowthExperimentEnabled is false for all + unknown keys by default', async () => {
+  const { GROWTH_EXPERIMENTS, isGrowthExperimentEnabled } = await import(MODULE);
+  for (const key of Object.keys(GROWTH_EXPERIMENTS)) {
+    assert.equal(
+      isGrowthExperimentEnabled(key),
+      false,
+      `"${key}" must be off with no URL override`
+    );
+  }
+  assert.equal(isGrowthExperimentEnabled('does-not-exist'), false);
+});


### PR DESCRIPTION
## Phase 29 — Additive growth (flags only) (Track G · Yellow)

Establishes a **client-side, $0 growth-experiment registry** — flags only, everything OFF, nothing wired into the live UI. Gives future growth work a safe, no-cost place to land behind a flag, with a guard test so nothing ships on by accident.

### Why a new registry
The site's existing feature flags (`src/lib/site-settings.js`) are **Supabase-backed and owner-controlled** (owner-gated). This phase does **not** touch Supabase/admin/those flags. It adds a separate, purely client-side layer for **$0 growth experiments**.

### `src/config/growth-experiments.js`
- `GROWTH_EXPERIMENTS` — documented registry; each entry `enabled:false` + `summary`/`rationale`/`readiness`.
- `isGrowthExperimentEnabled(key)` — always the registry default (false for all today); `?growth=<key>` force-enables one **for local testing only** (never persists, ignores unknown keys).
- **Unimported → tree-shaken out**: zero bytes, zero live behaviour change. Literally "flags only".

| Key | Would add | $0 lever |
| --- | --- | --- |
| `shareNudge` | "share this tool" prompt | native Web Share (Phase 23) |
| `relatedToolsRail` | cross-tool rail | internal links |
| `priceMoveBadge` | "▲ x% today" badge | existing move engine |
| `saveComparisonLink` | copy deep-link | existing URL-state |

### Guard test — `tests/growth-experiments.test.js`
5 assertions enforcing the contract: every experiment defaults `false` (build fails if flipped), carries doc fields, references **no forbidden monetization surface** (`newsletter`/`whatsapp business`/`stripe`/`payment`), and the accessor is off for all + unknown keys.

### Constraints honoured
$0 / no recurring cost; no newsletter/WhatsApp/payments (guard-tested); no Supabase/admin; no live UI change.

### Verification
`npm run build` + `npm run validate` + `npm test` (1291 pass / 0 fail, +5) + `npm run lint` — all green.

Full write-up: `reports/growth/PHASE-29-growth-flags.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive config, tests, and docs only; nothing is wired into production UI or backend flags.
> 
> **Overview**
> Adds a **separate client-side growth flag layer** from Supabase owner flags: `src/config/growth-experiments.js` documents four experiments (`shareNudge`, `relatedToolsRail`, `priceMoveBadge`, `saveComparisonLink`) with **`enabled: false`**, plus `isGrowthExperimentEnabled()` and optional **`?growth=<key>`** overrides for local testing only.
> 
> **No live behaviour change** — the module is not imported elsewhere (intended tree-shake). CI guard **`tests/growth-experiments.test.js`** enforces defaults stay off, required doc fields, no forbidden monetization keywords, and the accessor stays false without URL overrides. Phase write-up: `reports/growth/PHASE-29-growth-flags.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05113563a15aa8bc20de9e171c847e572e32c1c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->