### PR TITLE
feat(phase-31): heatmap spot/retail lens toggle

### DIFF
--- a/heatmap.html
+++ b/heatmap.html
@@ -175,6 +175,7 @@
 
       <!-- Controls -->
       <section class="heatmap-controls" aria-label="Map controls">
+        <div class="heatmap-lens" id="heatmap-lens" role="group" aria-label="Colour map by"></div>
         <div class="heatmap-karat" id="heatmap-karat" role="group" aria-label="Karat"></div>
         <div class="heatmap-jump-block">
           <label class="heatmap-jump-label" id="heatmap-jump-label" for="heatmap-jump"

--- a/reports/heatmap/PHASE-31-lens-toggle.md
+++ b/reports/heatmap/PHASE-31-lens-toggle.md
@@ -1,0 +1,52 @@
+# Phase 31 — Heatmap spot/retail lens toggle (Green · optional)
+
+The one genuinely-new heatmap delta (the map itself shipped in Phase 25). Adds a **lens toggle**
+that switches the choropleth between the all-in **retail estimate** and the pure **spot value** —
+turning the map's core thesis into something the user can see.
+
+## What it does
+
+A segmented toggle above the map ("Colour map by: Retail estimate | Spot value"):
+
+- **Retail lens** (default, unchanged behaviour) — colours each market by its all-in retail estimate
+  (USD/g): spot-linked gold value + local VAT + typical making charges. A varied choropleth.
+- **Spot lens** (new) — colours by the pure spot-linked gold value (USD/g). Because gold's value per
+  gram is **identical worldwide in USD**, every market gets the **same** shade — which is exactly
+  the point the page has always made in prose, now shown visually. A caption states it plainly:
+  _"Every market shows the same shade: gold's spot-linked value per gram is identical worldwide in
+  USD. Switch to the retail lens to see where local VAT and making charges raise the price."_
+
+The legend title, the single-vs-gradient swatch, the caption, the tooltip value, and each region's
+`aria-label` all follow the active lens. Default stays **retail** (no change to the first view).
+
+## Implementation
+
+- `STATE.lens` (`'retail'` | `'spot'`), a `renderLens()` toggle (accessible `role="group"` +
+  `aria-pressed` buttons, bilingual EN/AR), wired into `render()`.
+- `paintMap()` is lens-aware: retail uses the existing equal-interval `computeDomain` buckets; spot
+  paints every market with data in one uniform bucket (`SPOT_UNIFORM_BUCKET`, since there is no
+  meaningful gradient) and reads `spotUsdPerGram` for the value/aria.
+- `renderLegend()` swaps the gradient for a single "identical worldwide" swatch + the lens caption.
+- No maths changed — both values come from the already-tested `buildComparisonRows` pipeline; the
+  AED peg (3.6725), troy-oz constant, and reference-estimate labelling are untouched.
+- `styles/pages/heatmap.css` adds `.heatmap-lens` / `.heatmap-lens-btn` (mirroring the karat toggle)
+  - `.heatmap-lens-note`.
+
+## Verification
+
+Headless render of the built page, with FX injected so the map colours:
+
+| Lens     | Bucket distribution                     | Interpretation                               |
+| -------- | --------------------------------------- | -------------------------------------------- |
+| Retail   | b0×4, b1×3, b2×2, b3×4, b4×3 (+ nodata) | Varied — VAT/making differences              |
+| **Spot** | **all 28 markets in one bucket (b3)**   | **Uniform — gold value identical worldwide** |
+
+Also confirmed: toggle buttons render with correct `aria-pressed` states; the legend title switches
+between "All-in retail estimate (USD per gram)" and "Spot-linked gold value (USD per gram)"; the
+lens caption renders. (The spot lens also lights up markets the retail lens leaves grey — spot USD
+value needs no FX, so all 28 tracked markets show.)
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (1286 pass) + `npm run lint` +
+`scripts/qa/parity-diff-scan.mjs` — all green.

--- a/src/pages/heatmap.js
+++ b/src/pages/heatmap.js
@@ -54,9 +54,18 @@ const T = {
     mapAria: 'World map of gold retail estimates by country',
     mapHint: 'Hover, tap or use the keyboard to explore countries. Full data in the table below.',
     legendTitle: 'All-in retail estimate (USD per gram)',
+    legendTitleSpot: 'Spot-linked gold value (USD per gram)',
     legendNoData: 'No data',
     legendLower: 'Lower',
     legendHigher: 'Higher',
+    lensLabel: 'Colour map by',
+    lensRetail: 'Retail estimate',
+    lensSpot: 'Spot value',
+    lensSpotLegend: 'Identical worldwide',
+    lensRetailCaption:
+      'Darker gold = a higher all-in retail estimate. The differences come from local VAT and typical making charges — the underlying gold is the same everywhere.',
+    lensSpotCaption:
+      'Every market shows the same shade: gold’s spot-linked value per gram is identical worldwide in USD. Switch to the retail lens to see where local VAT and making charges raise the price.',
     jumpLabel: 'Jump to a country',
     jumpPlaceholder: 'Pick a country…',
     groups: {
@@ -117,9 +126,18 @@ const T = {
     mapHint:
       'مرّر المؤشر أو انقر أو استخدم لوحة المفاتيح لاستكشاف الدول. البيانات الكاملة في الجدول أدناه.',
     legendTitle: 'التقدير الشامل للتجزئة (دولار لكل جرام)',
+    legendTitleSpot: 'قيمة الذهب المرتبطة بالسعر الفوري (دولار لكل جرام)',
     legendNoData: 'لا تتوفر بيانات',
     legendLower: 'أقل',
     legendHigher: 'أعلى',
+    lensLabel: 'تلوين الخريطة حسب',
+    lensRetail: 'تقدير التجزئة',
+    lensSpot: 'القيمة الفورية',
+    lensSpotLegend: 'متطابقة عالمياً',
+    lensRetailCaption:
+      'الذهبي الأغمق = تقدير تجزئة شامل أعلى. الفروق ناتجة عن الضريبة المحلية والمصنعية المعتادة — الذهب نفسه واحد في كل مكان.',
+    lensSpotCaption:
+      'كل الأسواق تظهر بنفس الدرجة: قيمة غرام الذهب المرتبطة بالسعر الفوري متطابقة عالمياً بالدولار. بدّل إلى عدسة التجزئة لترى أين ترفع الضريبة والمصنعية السعر.',
     jumpLabel: 'الانتقال إلى دولة',
     jumpPlaceholder: 'اختر دولة…',
     groups: {
@@ -183,6 +201,7 @@ const STATE = {
   status: { goldStale: false, fxStale: false },
   fxMeta: { lastUpdateUtc: null, nextUpdateUtc: 0 },
   karat: '22',
+  lens: 'retail', // 'retail' = all-in estimate (varies) | 'spot' = pure gold value (uniform worldwide)
   selected: null,
   goldPriceUsdPerOz: 0,
   mapData: null, // lazily imported world-map-data.js module
@@ -398,13 +417,19 @@ async function mountMap() {
 function paintMap() {
   if (!STATE.mapData) return;
   const rows = currentRows();
-  const domain = computeDomain(rows);
+  const spot = isSpotLens();
+  // Spot lens has no gradient (gold's USD value is identical worldwide) — every market with data
+  // gets the same uniform bucket; the retail lens keeps the equal-interval domain.
+  const domain = spot ? null : computeDomain(rows);
   const index = fillIndex(rows, domain);
   const dict = t();
+  const lensLabel = spot ? dict.spotRef : dict.retailEst;
 
   for (const [code, nodes] of STATE.mapNodes) {
     const entry = index.get(code);
-    const bucket = entry ? entry.bucket : null;
+    const value = entry ? (spot ? entry.row.spotUsdPerGram : entry.row.retailUsdPerGram) : null;
+    const hasData = value != null;
+    const bucket = !hasData ? null : spot ? SPOT_UNIFORM_BUCKET : entry.bucket;
     const primary = nodes[0];
     primary.classList.remove(
       'heatmap-b0',
@@ -417,11 +442,10 @@ function paintMap() {
     primary.classList.add(bucket == null ? 'heatmap-nodata' : `heatmap-b${bucket}`);
     const country = COUNTRIES.find((c) => c.code === code);
     const name = country ? countryName(country) : code;
-    const valueText =
-      entry && entry.row.retailUsdPerGram != null
-        ? `${fmtUsd(entry.row.retailUsdPerGram)} ${dict.perGram} (${STATE.karat}K)`
-        : dict.unavailable;
-    primary.setAttribute('aria-label', `${name} — ${dict.retailEst}: ${valueText}`);
+    const valueText = hasData
+      ? `${fmtUsd(value)} ${dict.perGram} (${STATE.karat}K)`
+      : dict.unavailable;
+    primary.setAttribute('aria-label', `${name} — ${lensLabel}: ${valueText}`);
     primary.setAttribute('aria-pressed', STATE.selected === code ? 'true' : 'false');
     for (const node of nodes) node.classList.toggle('heatmap-selected', STATE.selected === code);
   }
@@ -449,14 +473,17 @@ function showTooltipFor(target, pointerEvent) {
   const dict = t();
 
   clear(tip);
+  const spot = isSpotLens();
+  const primaryValue = row ? (spot ? row.spotUsdPerGram : row.retailUsdPerGram) : null;
   tip.appendChild(el('span', { class: 'heatmap-tip-name' }, [countryName(country)]));
-  if (row && row.retailUsdPerGram != null) {
+  if (primaryValue != null) {
     tip.appendChild(
       el('span', { class: 'heatmap-tip-value' }, [
-        `${fmtUsd(row.retailUsdPerGram)} ${dict.perGram} · ${STATE.karat}K`,
+        `${fmtUsd(primaryValue)} ${dict.perGram} · ${STATE.karat}K`,
       ])
     );
-    if (row.retailLocalPerGram != null && row.currency !== 'USD') {
+    // Local-currency line only makes sense for the retail lens (spot value is quoted in USD).
+    if (!spot && row.retailLocalPerGram != null && row.currency !== 'USD') {
       tip.appendChild(
         el('span', { class: 'heatmap-tip-local' }, [
           formatPrice(row.retailLocalPerGram, row.currency, row.decimals),
@@ -499,13 +526,29 @@ function renderLegend() {
   if (!host) return;
   const dict = t();
   const rows = currentRows();
-  const domain = computeDomain(rows);
+  const spot = isSpotLens();
+  const domain = spot ? null : computeDomain(rows);
   clear(host);
   host.appendChild(
-    el('span', { class: 'heatmap-legend-title', id: 'heatmap-legend-title' }, [dict.legendTitle])
+    el('span', { class: 'heatmap-legend-title', id: 'heatmap-legend-title' }, [
+      spot ? dict.legendTitleSpot : dict.legendTitle,
+    ])
   );
   const scale = el('div', { class: 'heatmap-legend-scale', role: 'list' });
-  if (!domain) {
+  if (spot) {
+    // One uniform swatch — the spot value is identical for every market.
+    scale.appendChild(
+      el('span', { class: 'heatmap-legend-stop', role: 'listitem' }, [
+        el('span', {
+          class: `heatmap-legend-swatch heatmap-b${SPOT_UNIFORM_BUCKET}`,
+          'aria-hidden': 'true',
+        }),
+        el('span', { class: 'heatmap-legend-range' }, [
+          `${fmtUsd(spotUsdPerGramNow(rows), 1)} ${dict.perGram} · ${dict.lensSpotLegend}`,
+        ]),
+      ])
+    );
+  } else if (!domain) {
     scale.appendChild(el('span', { class: 'heatmap-legend-waiting' }, [dict.waiting]));
   } else {
     const stops = legendStops(domain);
@@ -527,6 +570,16 @@ function renderLegend() {
     ])
   );
   host.appendChild(scale);
+  // Lens explainer — states plainly why the map varies (retail) or is uniform (spot).
+  host.appendChild(
+    el('p', { class: 'heatmap-lens-note' }, [spot ? dict.lensSpotCaption : dict.lensRetailCaption])
+  );
+}
+
+/** The single spot-linked gold value per gram (USD) — identical across markets for the active karat. */
+function spotUsdPerGramNow(rows) {
+  const withSpot = (rows || []).find((r) => r.spotUsdPerGram != null);
+  return withSpot ? withSpot.spotUsdPerGram : 0;
 }
 
 // ── Karat switcher ────────────────────────────────────────────────────────────
@@ -550,6 +603,45 @@ function renderKarats() {
           },
         },
         [`${code}K`]
+      )
+    );
+  }
+}
+
+// Bucket the spot lens paints every market with — a single mid-high gold shade, since gold's
+// spot-linked value per gram is identical worldwide in USD (there is no meaningful gradient).
+const SPOT_UNIFORM_BUCKET = 3;
+
+/** True when the map is coloured by pure spot value (uniform) rather than the all-in retail estimate. */
+function isSpotLens() {
+  return STATE.lens === 'spot';
+}
+
+// ── Lens switcher (colour map by retail estimate vs pure spot value) ───────────
+function renderLens() {
+  const host = document.getElementById('heatmap-lens');
+  if (!host) return;
+  const dict = t();
+  host.setAttribute('aria-label', dict.lensLabel);
+  clear(host);
+  for (const [code, labelKey] of [
+    ['retail', 'lensRetail'],
+    ['spot', 'lensSpot'],
+  ]) {
+    host.appendChild(
+      el(
+        'button',
+        {
+          type: 'button',
+          class: `heatmap-lens-btn${STATE.lens === code ? ' is-active' : ''}`,
+          'aria-pressed': STATE.lens === code ? 'true' : 'false',
+          onclick: () => {
+            if (STATE.lens === code) return;
+            STATE.lens = code;
+            render();
+          },
+        },
+        [dict[labelKey]]
       )
     );
   }
@@ -826,6 +918,7 @@ function applyLang() {
 function render() {
   renderSpotBadge();
   renderKarats();
+  renderLens();
   renderLegend();
   renderJumpSelect();
   renderDetail();

--- a/styles/pages/heatmap.css
+++ b/styles/pages/heatmap.css
@@ -141,13 +141,46 @@
   gap: var(--space-3);
 }
 
-.heatmap-karat {
+.heatmap-karat,
+.heatmap-lens {
   display: inline-flex;
   gap: var(--space-1);
   padding: var(--space-1);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-pill);
   background: var(--color-surface-1);
+}
+
+.heatmap-lens-btn {
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.heatmap-lens-btn:hover {
+  color: var(--color-text);
+}
+
+.heatmap-lens-btn.is-active {
+  background: var(--color-gold-dark);
+  color: var(--color-surface);
+}
+
+.heatmap-lens-note {
+  margin: var(--space-2) 0 0;
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--color-text-muted);
+  max-width: 60ch;
 }
 
 .heatmap-karat-btn {


### PR DESCRIPTION
## Phase 31 — Heatmap spot/retail lens toggle (Green · optional)

The one genuinely-new heatmap delta (the map shipped in Phase 25): a lens toggle switching the choropleth between the all-in **retail estimate** and the pure **spot value** — turning the page's core thesis into something you can see.

### What it does
Toggle above the map: **Retail estimate | Spot value**.
- **Retail lens** (default, unchanged): colours by all-in retail (USD/g) — a varied map driven by local VAT + making charges.
- **Spot lens** (new): colours by pure spot-linked gold value (USD/g). Gold's value per gram is **identical worldwide in USD**, so every market shows the **same** shade — the thesis, made visual. A caption explains it and points to the retail lens to see local premiums.

Legend title, swatch (gradient vs single), caption, tooltip, and each region's `aria-label` all follow the active lens. Default stays retail (no change to first view).

### Implementation
`STATE.lens` + accessible bilingual `renderLens()` toggle; `paintMap()` lens-aware (retail = existing `computeDomain` buckets; spot = one uniform `SPOT_UNIFORM_BUCKET`); `renderLegend()` swaps gradient for a single "identical worldwide" swatch + caption. **No pricing maths changed** — both values from the existing `buildComparisonRows` pipeline; AED peg / troy-oz / reference-estimate labels untouched.

### Verification (headless, FX injected)
| Lens | Buckets | Meaning |
| --- | --- | --- |
| Retail | b0×4, b1×3, b2×2, b3×4, b4×3 | Varied (VAT/making) |
| **Spot** | **all 28 in one bucket** | **Uniform (gold identical worldwide)** |

Toggle `aria-pressed`, legend-title switch, and caption all confirmed.

### Verification
`npm run build` + `npm run validate` + `npm test` (1286 pass / 0 fail) + `npm run lint` + `parity-diff-scan` — all green.

Full write-up: `reports/heatmap/PHASE-31-lens-toggle.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only UI on the heatmap page; no changes to pricing pipelines or shared APIs, with default behavior unchanged.
> 
> **Overview**
> Adds a **Retail estimate | Spot value** control on the gold price heatmap so users can switch what drives map coloring without changing pricing math.
> 
> **Retail** (default) keeps the existing equal-interval buckets on all-in retail USD/g. **Spot** colors every market with data using one uniform bucket and `spotUsdPerGram`, so the map looks flat and illustrates that spot-linked gold value per gram is the same worldwide in USD; legend, tooltips, region `aria-label`s, and captions follow the active lens (spot tooltips drop the local-currency line). Bilingual EN/AR strings and styles mirror the karat pill toggle; `STATE.lens` is wired through `render()` / `paintMap()` / `renderLegend()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8258e56ce16c9bb2416ee3b6950f366ab1c116f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->