### PR TITLE
feat(phase-32): metals data-layer foundation (silver pilot)

### DIFF
--- a/reports/metals/PHASE-32-metals-foundation.md
+++ b/reports/metals/PHASE-32-metals-foundation.md
@@ -1,0 +1,57 @@
+# Phase 32 — Metals data-layer foundation, silver pilot (Yellow)
+
+Lays the client-side data-layer so a future phase can add **silver** (then platinum/palladium) to
+the tools, **without changing anything about gold**. Foundation only — not wired into any live page
+(Phase 33 does the silver UI), and gold's numbers are guaranteed byte-identical.
+
+## `src/config/metals.js`
+
+A single metals registry + one shared pricing formula:
+
+| Metal          | `key`       | Spot symbol | Purities                                  |
+| -------------- | ----------- | ----------- | ----------------------------------------- |
+| Gold (primary) | `gold`      | **XAU**     | the existing karat table, reused verbatim |
+| Silver         | `silver`    | **XAG**     | fine .999, sterling .925, coin .900       |
+| Platinum       | `platinum`  | **XPT**     | fine .999, jewellery .950                 |
+| Palladium      | `palladium` | **XPD**     | fine .999, jewellery .950                 |
+
+- `metalUsdPerGram(spot, purity)` — the **same expression the gold code already uses**,
+  `(spot × purity) ÷ CONSTANTS.TROY_OZ_GRAMS` (31.1035), so gold is byte-identical and every metal
+  shares one formula. `usdToAedPerGram()` applies the fixed peg 3.6725.
+- Gold's `purities` **are** `KARATS` (mapped, not re-declared) — gold config can't drift.
+- Only gold is `primary`; the others are pilots. Helpers: `metalKeys()`, `getMetal()`,
+  `PRIMARY_METAL`.
+- The module is **not imported anywhere**, so the bundler tree-shakes it out — zero live behaviour
+  change. Silver/platinum/palladium exist only as data until a UI phase opts in.
+
+## Byte-identical gold guarantee — `tests/metals.test.js` (8 cases)
+
+The safety property of this phase, made a test:
+
+1. Registry exposes the four metals with the correct spot symbols (XAU/XAG/XPT/XPD).
+2. Only gold is `primary`.
+3. **Gold purities equal the karat table verbatim** (no drift).
+4. **`metalUsdPerGram` is byte-identical** to `(spot × purity) / TROY` across 8 spots × 8 purities.
+5. Gold 24K via the registry equals the direct gold gram value.
+6. **Immutable constants untouched** — AED peg 3.6725, troy-oz 31.1035.
+7. `usdToAedPerGram` applies the peg; rejects non-finite input.
+8. `metalUsdPerGram` rejects non-finite input.
+
+## Data-source note (recommend-only — owner-gated)
+
+The plan calls to "verify gold-api.com XAG/XPT/XPD". The registry uses the **standard** spot symbols
+(`XAU`/`XAG`/`XPT`/`XPD`) that gold-api.com and the LBMA/LME conventions use. **Actually fetching**
+silver/platinum/palladium spot into the site requires the **owner-gated** `gold-price-fetch.yml`
+workflow to write additional `data/*_price.json` files (mirroring `gold_price.json`) — that is
+untouched here and recommended as an owner change when the silver pilot is greenlit. No external API
+was called from this environment, and no owner-gated file was modified.
+
+## Constraints honoured
+
+- Gold maths byte-identical (test-proven); AED peg and troy-oz immutable.
+- $0 / no new dependency; module tree-shaken out (no live change).
+- No owner-gated files touched (`gold-price-fetch.yml`, etc.).
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (1294 pass, +8) + `npm run lint` — all green.

--- a/src/config/metals.js
+++ b/src/config/metals.js
@@ -1,0 +1,143 @@
+/**
+ * config/metals.js — precious-metals data-layer foundation.
+ *
+ * A single registry that generalises the site's gold maths to silver, platinum and palladium so a
+ * future phase can add them to the tools **without changing anything about gold**. This module is
+ * foundation only: it is not wired into any live page yet (Phase 33+ does that), and gold's numbers
+ * are guaranteed byte-identical to the existing path (see `tests/metals.test.js`).
+ *
+ * Design rules:
+ *   1. Gold is the primary metal. Its purities ARE the existing `KARATS` — reused, not re-declared —
+ *      so nothing about gold can drift.
+ *   2. Every metal prices with the **same** formula the gold code already uses:
+ *      `(spot per troy ounce × purity) ÷ grams per troy ounce`, using the shared
+ *      `CONSTANTS.TROY_OZ_GRAMS` (31.1035) and, for AED, the fixed peg 3.6725 — both immutable.
+ *   3. Non-gold metals use fineness grades (fine / sterling / coin), not karats.
+ */
+
+import { CONSTANTS } from './constants.js';
+import { KARATS } from './karats.js';
+
+/** The one live metal today; everything else is a pilot behind a future toggle. */
+export const PRIMARY_METAL = 'gold';
+
+/**
+ * @typedef {Object} MetalPurity
+ * @property {string} code       Short grade code (karat number, or fineness like '999').
+ * @property {number} purity     Fraction of pure metal (0–1).
+ * @property {string} labelEn
+ * @property {string} labelAr
+ */
+
+/**
+ * @typedef {Object} Metal
+ * @property {string} key        'gold' | 'silver' | 'platinum' | 'palladium'
+ * @property {string} symbol     Spot symbol used by gold-api.com etc. (XAU/XAG/XPT/XPD).
+ * @property {string} nameEn
+ * @property {string} nameAr
+ * @property {boolean} primary   True only for gold.
+ * @property {MetalPurity[]} purities  Available fineness grades, richest first.
+ * @property {string} defaultPurity    Default grade `code`.
+ */
+
+/** @type {Record<string, Metal>} */
+export const METALS = {
+  gold: {
+    key: 'gold',
+    symbol: 'XAU',
+    nameEn: 'Gold',
+    nameAr: 'الذهب',
+    primary: true,
+    // Gold's grades are the existing karat table verbatim — never re-declared here.
+    purities: KARATS.map((k) => ({
+      code: k.code,
+      purity: k.purity,
+      labelEn: k.labelEn,
+      labelAr: k.labelAr,
+    })),
+    defaultPurity: '24',
+  },
+  silver: {
+    key: 'silver',
+    symbol: 'XAG',
+    nameEn: 'Silver',
+    nameAr: 'الفضة',
+    primary: false,
+    purities: [
+      { code: '999', purity: 0.999, labelEn: 'Fine silver (.999)', labelAr: 'فضة نقية (.999)' },
+      { code: '925', purity: 0.925, labelEn: 'Sterling (.925)', labelAr: 'إسترليني (.925)' },
+      { code: '900', purity: 0.9, labelEn: 'Coin silver (.900)', labelAr: 'فضة عملات (.900)' },
+    ],
+    defaultPurity: '999',
+  },
+  platinum: {
+    key: 'platinum',
+    symbol: 'XPT',
+    nameEn: 'Platinum',
+    nameAr: 'البلاتين',
+    primary: false,
+    purities: [
+      { code: '999', purity: 0.999, labelEn: 'Fine platinum (.999)', labelAr: 'بلاتين نقي (.999)' },
+      { code: '950', purity: 0.95, labelEn: 'Jewellery (.950)', labelAr: 'مجوهرات (.950)' },
+    ],
+    defaultPurity: '999',
+  },
+  palladium: {
+    key: 'palladium',
+    symbol: 'XPD',
+    nameEn: 'Palladium',
+    nameAr: 'البلاديوم',
+    primary: false,
+    purities: [
+      {
+        code: '999',
+        purity: 0.999,
+        labelEn: 'Fine palladium (.999)',
+        labelAr: 'بلاديوم نقي (.999)',
+      },
+      { code: '950', purity: 0.95, labelEn: 'Jewellery (.950)', labelAr: 'مجوهرات (.950)' },
+    ],
+    defaultPurity: '999',
+  },
+};
+
+/** All metal keys, primary (gold) first. */
+export function metalKeys() {
+  return Object.keys(METALS).sort((a, b) =>
+    a === PRIMARY_METAL ? -1 : b === PRIMARY_METAL ? 1 : 0
+  );
+}
+
+/** Look up a metal by key; falls back to gold for any unknown key. */
+export function getMetal(key) {
+  return METALS[key] || METALS[PRIMARY_METAL];
+}
+
+/**
+ * Spot-linked value of one gram of a metal at a given purity, in USD.
+ *
+ * This is the SAME expression the gold code already uses — `(spot × purity) ÷ troyOzGrams` — so gold
+ * is byte-identical and every other metal shares one formula. Returns `null` on non-finite input.
+ *
+ * @param {number} spotUsdPerOz  Spot price per troy ounce, USD.
+ * @param {number} purity        Fraction of pure metal (0–1).
+ * @param {number} [troyOzGrams] Grams per troy ounce (defaults to the immutable constant).
+ * @returns {number|null}
+ */
+export function metalUsdPerGram(spotUsdPerOz, purity, troyOzGrams = CONSTANTS.TROY_OZ_GRAMS) {
+  if (!Number.isFinite(spotUsdPerOz) || !Number.isFinite(purity) || !Number.isFinite(troyOzGrams)) {
+    return null;
+  }
+  return (spotUsdPerOz * purity) / troyOzGrams;
+}
+
+/**
+ * Convert a USD/gram value to AED/gram using the fixed peg (3.6725). Kept here so metals share the
+ * one immutable peg rather than re-deriving it.
+ * @param {number} usdPerGram
+ * @returns {number|null}
+ */
+export function usdToAedPerGram(usdPerGram) {
+  if (!Number.isFinite(usdPerGram)) return null;
+  return usdPerGram * CONSTANTS.AED_PEG;
+}

--- a/tests/metals.test.js
+++ b/tests/metals.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+/**
+ * Metals data-layer foundation — guards the "gold math stays byte-identical" invariant.
+ *
+ * The metals registry generalises pricing to silver/platinum/palladium. This test proves that doing
+ * so changes NOTHING about gold: the generalised formula reproduces the existing gold expression
+ * exactly, gold's purities are the karat table verbatim, and the shared constants are untouched.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const METALS_MOD = new URL('../src/config/metals.js', `file://${__filename}`).href;
+const KARATS_MOD = new URL('../src/config/karats.js', `file://${__filename}`).href;
+const CONST_MOD = new URL('../src/config/constants.js', `file://${__filename}`).href;
+
+test('metals: registry exposes gold/silver/platinum/palladium with correct spot symbols', async () => {
+  const { METALS } = await import(METALS_MOD);
+  assert.deepEqual(Object.fromEntries(Object.values(METALS).map((m) => [m.key, m.symbol])), {
+    gold: 'XAU',
+    silver: 'XAG',
+    platinum: 'XPT',
+    palladium: 'XPD',
+  });
+  for (const m of Object.values(METALS)) {
+    assert.equal(typeof m.nameEn, 'string');
+    assert.equal(typeof m.nameAr, 'string');
+    assert.ok(Array.isArray(m.purities) && m.purities.length > 0, `${m.key} needs purities`);
+    assert.ok(
+      m.purities.some((p) => p.code === m.defaultPurity),
+      `${m.key} defaultPurity must exist in purities`
+    );
+  }
+});
+
+test('metals: only gold is primary', async () => {
+  const { METALS, PRIMARY_METAL } = await import(METALS_MOD);
+  assert.equal(PRIMARY_METAL, 'gold');
+  const primaries = Object.values(METALS).filter((m) => m.primary);
+  assert.deepEqual(
+    primaries.map((m) => m.key),
+    ['gold']
+  );
+});
+
+test('metals: gold purities are the karat table verbatim (no drift)', async () => {
+  const { METALS } = await import(METALS_MOD);
+  const { KARATS } = await import(KARATS_MOD);
+  assert.deepEqual(
+    METALS.gold.purities.map((p) => [p.code, p.purity]),
+    KARATS.map((k) => [k.code, k.purity])
+  );
+});
+
+test('metals: metalUsdPerGram is byte-identical to the existing gold formula', async () => {
+  const { metalUsdPerGram } = await import(METALS_MOD);
+  const { CONSTANTS } = await import(CONST_MOD);
+  const TROY = CONSTANTS.TROY_OZ_GRAMS;
+  // The exact expression used across the gold code (e.g. src/lib/export.js): (spot * purity) / TROY.
+  const goldFormula = (spot, purity) => (spot * purity) / TROY;
+  const spots = [0.5, 1, 25.4, 1980.75, 2500, 3333.33, 4149.0, 99999.99];
+  const purities = [1.0, 22 / 24, 21 / 24, 18 / 24, 0.999, 0.925, 0.95, 0.9];
+  for (const spot of spots) {
+    for (const purity of purities) {
+      assert.equal(
+        metalUsdPerGram(spot, purity),
+        goldFormula(spot, purity),
+        `mismatch at spot=${spot} purity=${purity}`
+      );
+    }
+  }
+});
+
+test('metals: gold 24K via the registry equals the direct gold gram value', async () => {
+  const { METALS, metalUsdPerGram } = await import(METALS_MOD);
+  const { CONSTANTS } = await import(CONST_MOD);
+  const spot = 4149.0; // matches a committed data/gold_price.json snapshot
+  const k24 = METALS.gold.purities.find((p) => p.code === '24');
+  assert.equal(metalUsdPerGram(spot, k24.purity), (spot * 1.0) / CONSTANTS.TROY_OZ_GRAMS);
+});
+
+test('metals: immutable constants are untouched', async () => {
+  const { CONSTANTS } = await import(CONST_MOD);
+  assert.equal(CONSTANTS.AED_PEG, 3.6725);
+  assert.equal(CONSTANTS.TROY_OZ_GRAMS, 31.1035);
+});
+
+test('metals: usdToAedPerGram applies the fixed peg', async () => {
+  const { usdToAedPerGram } = await import(METALS_MOD);
+  const { CONSTANTS } = await import(CONST_MOD);
+  assert.equal(usdToAedPerGram(100), 100 * CONSTANTS.AED_PEG);
+  assert.equal(usdToAedPerGram(Number.NaN), null);
+});
+
+test('metals: metalUsdPerGram rejects non-finite input', async () => {
+  const { metalUsdPerGram } = await import(METALS_MOD);
+  assert.equal(metalUsdPerGram(Number.NaN, 1), null);
+  assert.equal(metalUsdPerGram(2000, Number.NaN), null);
+  assert.equal(metalUsdPerGram(Infinity, 1), null);
+});


### PR DESCRIPTION
## Phase 32 — Metals data-layer foundation, silver pilot (Yellow)

Foundation only — a client-side registry generalising the site's gold maths to silver/platinum/palladium so a future phase can add them **without changing anything about gold**. Not wired into any live page (Phase 33 does the silver UI); gold numbers guaranteed byte-identical.

### `src/config/metals.js`
| Metal | key | Symbol | Purities |
| --- | --- | --- | --- |
| Gold (primary) | `gold` | **XAU** | the karat table, reused verbatim |
| Silver | `silver` | **XAG** | fine .999, sterling .925, coin .900 |
| Platinum | `platinum` | **XPT** | .999, .950 |
| Palladium | `palladium` | **XPD** | .999, .950 |

- `metalUsdPerGram(spot, purity)` = the **same expression the gold code already uses**, `(spot × purity) ÷ 31.1035`, so gold is byte-identical and every metal shares one formula. `usdToAedPerGram()` applies the fixed 3.6725 peg.
- Gold's purities **are** `KARATS` (reused, not re-declared) — can't drift. Only gold is `primary`.
- **Unimported → tree-shaken out**: zero live behaviour change.

### Byte-identical gold guarantee — `tests/metals.test.js` (8 cases)
Proves gold purities == karat table verbatim; `metalUsdPerGram` byte-identical to `(spot×purity)/TROY` across 8×8 inputs; gold 24K matches the direct value; AED peg 3.6725 + troy-oz 31.1035 untouched.

### Data-source note (recommend-only)
Registry uses the standard XAG/XPT/XPD spot symbols. **Actually fetching** them needs the **owner-gated** `gold-price-fetch.yml` to write additional data files — untouched here, recommended when the silver pilot is greenlit. No external API called; no owner-gated file modified.

### Verification
`npm run build` + `npm run validate` + `npm test` (1294 pass / 0 fail, +8) + `npm run lint` — all green.

Full write-up: `reports/metals/PHASE-32-metals-foundation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive config and tests only; nothing imports the new module, so runtime pricing and data pipelines are unchanged.
> 
> **Overview**
> Adds an **unwired** `src/config/metals.js` data layer so silver, platinum, and palladium can plug in later **without touching live gold behaviour**. The module defines a four-metal registry (XAU/XAG/XPT/XPD), reuses **`KARATS` verbatim** for gold purities, and centralises **`metalUsdPerGram`** / **`usdToAedPerGram`** on the same `(spot × purity) ÷ troy oz` and AED peg constants the gold path already uses.
> 
> **Eight new tests** in `tests/metals.test.js` lock the byte-identical gold guarantee (formula parity, karat table equality, constants). A Phase 32 write-up is added under `reports/metals/`. No pages, fetch workflows, or owner-gated price files are changed — the new module should tree-shake until a later UI phase imports it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb312300c671599dd7e71576ad6d5557e3cd9c45. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->