### PR TITLE
feat(phase-33): metals pricing-resolution layer + pilot flag (silver gated OFF)

### DIFF
--- a/reports/metals/PHASE-32-metals-foundation.md
+++ b/reports/metals/PHASE-32-metals-foundation.md
@@ -1,0 +1,57 @@
+# Phase 32 — Metals data-layer foundation, silver pilot (Yellow)
+
+Lays the client-side data-layer so a future phase can add **silver** (then platinum/palladium) to
+the tools, **without changing anything about gold**. Foundation only — not wired into any live page
+(Phase 33 does the silver UI), and gold's numbers are guaranteed byte-identical.
+
+## `src/config/metals.js`
+
+A single metals registry + one shared pricing formula:
+
+| Metal          | `key`       | Spot symbol | Purities                                  |
+| -------------- | ----------- | ----------- | ----------------------------------------- |
+| Gold (primary) | `gold`      | **XAU**     | the existing karat table, reused verbatim |
+| Silver         | `silver`    | **XAG**     | fine .999, sterling .925, coin .900       |
+| Platinum       | `platinum`  | **XPT**     | fine .999, jewellery .950                 |
+| Palladium      | `palladium` | **XPD**     | fine .999, jewellery .950                 |
+
+- `metalUsdPerGram(spot, purity)` — the **same expression the gold code already uses**,
+  `(spot × purity) ÷ CONSTANTS.TROY_OZ_GRAMS` (31.1035), so gold is byte-identical and every metal
+  shares one formula. `usdToAedPerGram()` applies the fixed peg 3.6725.
+- Gold's `purities` **are** `KARATS` (mapped, not re-declared) — gold config can't drift.
+- Only gold is `primary`; the others are pilots. Helpers: `metalKeys()`, `getMetal()`,
+  `PRIMARY_METAL`.
+- The module is **not imported anywhere**, so the bundler tree-shakes it out — zero live behaviour
+  change. Silver/platinum/palladium exist only as data until a UI phase opts in.
+
+## Byte-identical gold guarantee — `tests/metals.test.js` (8 cases)
+
+The safety property of this phase, made a test:
+
+1. Registry exposes the four metals with the correct spot symbols (XAU/XAG/XPT/XPD).
+2. Only gold is `primary`.
+3. **Gold purities equal the karat table verbatim** (no drift).
+4. **`metalUsdPerGram` is byte-identical** to `(spot × purity) / TROY` across 8 spots × 8 purities.
+5. Gold 24K via the registry equals the direct gold gram value.
+6. **Immutable constants untouched** — AED peg 3.6725, troy-oz 31.1035.
+7. `usdToAedPerGram` applies the peg; rejects non-finite input.
+8. `metalUsdPerGram` rejects non-finite input.
+
+## Data-source note (recommend-only — owner-gated)
+
+The plan calls to "verify gold-api.com XAG/XPT/XPD". The registry uses the **standard** spot symbols
+(`XAU`/`XAG`/`XPT`/`XPD`) that gold-api.com and the LBMA/LME conventions use. **Actually fetching**
+silver/platinum/palladium spot into the site requires the **owner-gated** `gold-price-fetch.yml`
+workflow to write additional `data/*_price.json` files (mirroring `gold_price.json`) — that is
+untouched here and recommended as an owner change when the silver pilot is greenlit. No external API
+was called from this environment, and no owner-gated file was modified.
+
+## Constraints honoured
+
+- Gold maths byte-identical (test-proven); AED peg and troy-oz immutable.
+- $0 / no new dependency; module tree-shaken out (no live change).
+- No owner-gated files touched (`gold-price-fetch.yml`, etc.).
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (1294 pass, +8) + `npm run lint` — all green.

--- a/reports/metals/PHASE-33-silver-ui-plan.md
+++ b/reports/metals/PHASE-33-silver-ui-plan.md
@@ -1,0 +1,59 @@
+# Phase 33 — Silver on tracker + calculator (Yellow)
+
+Silver-on-the-tools is genuinely blocked on two things this session cannot safely do: live **silver
+spot data** (owner-gated — it must come from `gold-price-fetch.yml`, which we never touch), and a
+risky rewrite of the flagship calculator/tracker pricing paths for a feature that can't work yet.
+Per the operating guardrails, this phase ships the **safe, tested resolution layer + a default-OFF
+pilot flag** that make the eventual wiring trivial, and documents that wiring — without changing
+gold or advertising a dead feature.
+
+> Depends on the Phase 32 metals foundation (PR #569); this branch is based on it.
+
+## Shipped (safe, no live change)
+
+- **`src/config/metals-flags.js`** — `METALS_PILOT_ENABLED = false`. The single switch for the
+  non-gold metals UI. Gold is never gated by it.
+- **`src/lib/metal-pricing.js`** — `resolveMetalGramPrice(metalKey, purityCode, spotByMetal, opts)`,
+  pure and side-effect-free, returning one honest tagged result:
+  - `{ state: 'ok', usdPerGram, aedPerGram, … }` — priced (gold today; other metals once enabled),
+    using the byte-identical `metalUsdPerGram` from the registry so **gold's numbers can't move**;
+  - `{ state: 'pending-data' }` — an enabled metal with no spot feed yet (never a fake price);
+  - `{ state: 'disabled' }` — a non-gold metal while the pilot is off. Plus `availableMetalKeys()` →
+    `['gold']` today, all four when enabled.
+- **`tests/metal-pricing.test.js`** (8) — pilot ships OFF; only gold offered while off; gold prices
+  identically to the registry formula and 24K matches the direct value; silver is `disabled` while
+  off, prices when on + data present, and is `pending-data` (not fake) when enabled without data.
+- Neither module is imported by a live page — the bundler tree-shakes them out; **zero behaviour
+  change** on the calculator, tracker, or anywhere else.
+
+## Wiring design (for when the pilot is greenlit)
+
+Once the owner adds silver spot (below) and flips `METALS_PILOT_ENABLED`:
+
+1. **Metal switcher** (default **gold**) on the calculator and tracker — a segmented control built
+   from `availableMetalKeys()`; when it returns only `['gold']` the control simply doesn't render,
+   so the tools stay exactly as today.
+2. **Pricing** — the calculator/tracker call `resolveMetalGramPrice(metal, grade, spotByMetal)`
+   instead of the inline gold expression. For gold the result is byte-identical (proven), so the
+   switch is a no-op for the default path.
+3. **Honest states** — `pending-data` renders a "Silver pricing is being added" note (no number);
+   `disabled` never appears in the UI (the metal isn't offered). No metal ever shows a fabricated
+   price.
+4. **Purity labels** — the switcher swaps the karat list for the metal's fineness grades (silver
+   .999/.925/.900, etc.) from the registry.
+
+## Owner-gated dependency (recommend-only — not done here)
+
+Live silver needs `data/silver_price.json` (mirroring `gold_price.json`) written by the owner-gated
+`gold-price-fetch.yml`, fetching the `XAG` spot symbol already registered in `metals.js`. That
+workflow is **not modified**. Until it exists, `spotByMetal.silver` is absent and the resolver
+correctly reports `pending-data`.
+
+## Constraints honoured
+
+Gold byte-identical (test-proven); AED peg / troy-oz immutable; pilot default OFF (no live change,
+no dead feature advertised); no owner-gated files touched; $0.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (1302 pass, +8) + `npm run lint` — all green.

--- a/src/config/metals-flags.js
+++ b/src/config/metals-flags.js
@@ -1,0 +1,13 @@
+/**
+ * config/metals-flags.js — pilot gate for the non-gold metals UI.
+ *
+ * Silver/platinum/palladium are OFF until (a) the owner adds their spot feed to the price pipeline
+ * (owner-gated `gold-price-fetch.yml` → `data/*_price.json`) and (b) this flag is flipped. Gold is
+ * never gated by this flag — it is always live.
+ *
+ * Kept a plain constant so the metals UI code has a single, testable source of truth and the build
+ * tree-shakes the non-gold branches while the flag is false.
+ */
+
+/** Master switch for the non-gold metals UI. MUST stay false until live silver data exists. */
+export const METALS_PILOT_ENABLED = false;

--- a/src/config/metals.js
+++ b/src/config/metals.js
@@ -1,0 +1,143 @@
+/**
+ * config/metals.js — precious-metals data-layer foundation.
+ *
+ * A single registry that generalises the site's gold maths to silver, platinum and palladium so a
+ * future phase can add them to the tools **without changing anything about gold**. This module is
+ * foundation only: it is not wired into any live page yet (Phase 33+ does that), and gold's numbers
+ * are guaranteed byte-identical to the existing path (see `tests/metals.test.js`).
+ *
+ * Design rules:
+ *   1. Gold is the primary metal. Its purities ARE the existing `KARATS` — reused, not re-declared —
+ *      so nothing about gold can drift.
+ *   2. Every metal prices with the **same** formula the gold code already uses:
+ *      `(spot per troy ounce × purity) ÷ grams per troy ounce`, using the shared
+ *      `CONSTANTS.TROY_OZ_GRAMS` (31.1035) and, for AED, the fixed peg 3.6725 — both immutable.
+ *   3. Non-gold metals use fineness grades (fine / sterling / coin), not karats.
+ */
+
+import { CONSTANTS } from './constants.js';
+import { KARATS } from './karats.js';
+
+/** The one live metal today; everything else is a pilot behind a future toggle. */
+export const PRIMARY_METAL = 'gold';
+
+/**
+ * @typedef {Object} MetalPurity
+ * @property {string} code       Short grade code (karat number, or fineness like '999').
+ * @property {number} purity     Fraction of pure metal (0–1).
+ * @property {string} labelEn
+ * @property {string} labelAr
+ */
+
+/**
+ * @typedef {Object} Metal
+ * @property {string} key        'gold' | 'silver' | 'platinum' | 'palladium'
+ * @property {string} symbol     Spot symbol used by gold-api.com etc. (XAU/XAG/XPT/XPD).
+ * @property {string} nameEn
+ * @property {string} nameAr
+ * @property {boolean} primary   True only for gold.
+ * @property {MetalPurity[]} purities  Available fineness grades, richest first.
+ * @property {string} defaultPurity    Default grade `code`.
+ */
+
+/** @type {Record<string, Metal>} */
+export const METALS = {
+  gold: {
+    key: 'gold',
+    symbol: 'XAU',
+    nameEn: 'Gold',
+    nameAr: 'الذهب',
+    primary: true,
+    // Gold's grades are the existing karat table verbatim — never re-declared here.
+    purities: KARATS.map((k) => ({
+      code: k.code,
+      purity: k.purity,
+      labelEn: k.labelEn,
+      labelAr: k.labelAr,
+    })),
+    defaultPurity: '24',
+  },
+  silver: {
+    key: 'silver',
+    symbol: 'XAG',
+    nameEn: 'Silver',
+    nameAr: 'الفضة',
+    primary: false,
+    purities: [
+      { code: '999', purity: 0.999, labelEn: 'Fine silver (.999)', labelAr: 'فضة نقية (.999)' },
+      { code: '925', purity: 0.925, labelEn: 'Sterling (.925)', labelAr: 'إسترليني (.925)' },
+      { code: '900', purity: 0.9, labelEn: 'Coin silver (.900)', labelAr: 'فضة عملات (.900)' },
+    ],
+    defaultPurity: '999',
+  },
+  platinum: {
+    key: 'platinum',
+    symbol: 'XPT',
+    nameEn: 'Platinum',
+    nameAr: 'البلاتين',
+    primary: false,
+    purities: [
+      { code: '999', purity: 0.999, labelEn: 'Fine platinum (.999)', labelAr: 'بلاتين نقي (.999)' },
+      { code: '950', purity: 0.95, labelEn: 'Jewellery (.950)', labelAr: 'مجوهرات (.950)' },
+    ],
+    defaultPurity: '999',
+  },
+  palladium: {
+    key: 'palladium',
+    symbol: 'XPD',
+    nameEn: 'Palladium',
+    nameAr: 'البلاديوم',
+    primary: false,
+    purities: [
+      {
+        code: '999',
+        purity: 0.999,
+        labelEn: 'Fine palladium (.999)',
+        labelAr: 'بلاديوم نقي (.999)',
+      },
+      { code: '950', purity: 0.95, labelEn: 'Jewellery (.950)', labelAr: 'مجوهرات (.950)' },
+    ],
+    defaultPurity: '999',
+  },
+};
+
+/** All metal keys, primary (gold) first. */
+export function metalKeys() {
+  return Object.keys(METALS).sort((a, b) =>
+    a === PRIMARY_METAL ? -1 : b === PRIMARY_METAL ? 1 : 0
+  );
+}
+
+/** Look up a metal by key; falls back to gold for any unknown key. */
+export function getMetal(key) {
+  return METALS[key] || METALS[PRIMARY_METAL];
+}
+
+/**
+ * Spot-linked value of one gram of a metal at a given purity, in USD.
+ *
+ * This is the SAME expression the gold code already uses — `(spot × purity) ÷ troyOzGrams` — so gold
+ * is byte-identical and every other metal shares one formula. Returns `null` on non-finite input.
+ *
+ * @param {number} spotUsdPerOz  Spot price per troy ounce, USD.
+ * @param {number} purity        Fraction of pure metal (0–1).
+ * @param {number} [troyOzGrams] Grams per troy ounce (defaults to the immutable constant).
+ * @returns {number|null}
+ */
+export function metalUsdPerGram(spotUsdPerOz, purity, troyOzGrams = CONSTANTS.TROY_OZ_GRAMS) {
+  if (!Number.isFinite(spotUsdPerOz) || !Number.isFinite(purity) || !Number.isFinite(troyOzGrams)) {
+    return null;
+  }
+  return (spotUsdPerOz * purity) / troyOzGrams;
+}
+
+/**
+ * Convert a USD/gram value to AED/gram using the fixed peg (3.6725). Kept here so metals share the
+ * one immutable peg rather than re-deriving it.
+ * @param {number} usdPerGram
+ * @returns {number|null}
+ */
+export function usdToAedPerGram(usdPerGram) {
+  if (!Number.isFinite(usdPerGram)) return null;
+  return usdPerGram * CONSTANTS.AED_PEG;
+}

--- a/src/lib/metal-pricing.js
+++ b/src/lib/metal-pricing.js
@@ -1,0 +1,55 @@
+/**
+ * lib/metal-pricing.js — the resolution layer between the metals registry and the tools.
+ *
+ * Pure, side-effect-free. Given a metal, a purity grade, and the available spot prices, it returns a
+ * single tagged result the UI can render honestly:
+ *   • `{ state: 'ok', usdPerGram, aedPerGram, … }`  — priced (gold today; other metals once enabled)
+ *   • `{ state: 'pending-data' }`                    — enabled metal but no spot feed yet
+ *   • `{ state: 'disabled' }`                        — non-gold metal while the pilot is off
+ *
+ * Gold always prices (never gated) and uses the byte-identical `metalUsdPerGram` from the registry,
+ * so wiring this into a tool cannot change gold's numbers. This module is not imported by any live
+ * page yet — it is the safe building block the calculator/tracker will call once the silver pilot is
+ * greenlit (see reports/metals/PHASE-33-silver-ui-plan.md).
+ */
+
+import { getMetal, metalUsdPerGram, usdToAedPerGram } from '../config/metals.js';
+import { METALS_PILOT_ENABLED } from '../config/metals-flags.js';
+
+/**
+ * @param {string} metalKey                     'gold' | 'silver' | 'platinum' | 'palladium'
+ * @param {string} purityCode                   grade code (karat number or fineness); falls back to the metal default
+ * @param {Record<string, number|null|undefined>} spotByMetal  spot USD/oz per metal key (only gold today)
+ * @param {{ pilotEnabled?: boolean }} [opts]   override the pilot flag (for tests)
+ * @returns {{ state: 'ok'|'pending-data'|'disabled', metal: string, purity?: string, usdPerGram?: number|null, aedPerGram?: number|null }}
+ */
+export function resolveMetalGramPrice(metalKey, purityCode, spotByMetal = {}, opts = {}) {
+  const pilotEnabled = opts.pilotEnabled ?? METALS_PILOT_ENABLED;
+  const metal = getMetal(metalKey);
+  const isGold = metal.key === 'gold';
+
+  // Non-gold metals stay hidden until the pilot is enabled.
+  if (!isGold && !pilotEnabled) return { state: 'disabled', metal: metal.key };
+
+  const spot = spotByMetal ? spotByMetal[metal.key] : undefined;
+  if (!Number.isFinite(spot)) return { state: 'pending-data', metal: metal.key };
+
+  const grade =
+    metal.purities.find((p) => p.code === purityCode) ||
+    metal.purities.find((p) => p.code === metal.defaultPurity) ||
+    metal.purities[0];
+  const usdPerGram = metalUsdPerGram(spot, grade.purity);
+  return {
+    state: 'ok',
+    metal: metal.key,
+    purity: grade.code,
+    usdPerGram,
+    aedPerGram: usdToAedPerGram(usdPerGram),
+  };
+}
+
+/** Metal keys the UI should offer right now — gold always, others only when the pilot is enabled. */
+export function availableMetalKeys(opts = {}) {
+  const pilotEnabled = opts.pilotEnabled ?? METALS_PILOT_ENABLED;
+  return pilotEnabled ? ['gold', 'silver', 'platinum', 'palladium'] : ['gold'];
+}

--- a/tests/metal-pricing.test.js
+++ b/tests/metal-pricing.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+/**
+ * Metal pricing-resolution layer — proves gold is unaffected and the silver pilot is safely gated.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const PRICING = new URL('../src/lib/metal-pricing.js', `file://${__filename}`).href;
+const METALS = new URL('../src/config/metals.js', `file://${__filename}`).href;
+const CONST = new URL('../src/config/constants.js', `file://${__filename}`).href;
+const FLAGS = new URL('../src/config/metals-flags.js', `file://${__filename}`).href;
+
+test('metal-pricing: pilot flag ships OFF', async () => {
+  const { METALS_PILOT_ENABLED } = await import(FLAGS);
+  assert.equal(METALS_PILOT_ENABLED, false);
+});
+
+test('metal-pricing: only gold is offered while the pilot is off', async () => {
+  const { availableMetalKeys } = await import(PRICING);
+  assert.deepEqual(availableMetalKeys(), ['gold']);
+  assert.deepEqual(availableMetalKeys({ pilotEnabled: true }), [
+    'gold',
+    'silver',
+    'platinum',
+    'palladium',
+  ]);
+});
+
+test('metal-pricing: gold prices identically to the registry formula', async () => {
+  const { resolveMetalGramPrice } = await import(PRICING);
+  const { metalUsdPerGram, usdToAedPerGram } = await import(METALS);
+  const spot = 4149.0;
+  const r = resolveMetalGramPrice('gold', '22', { gold: spot });
+  assert.equal(r.state, 'ok');
+  assert.equal(r.metal, 'gold');
+  assert.equal(r.purity, '22');
+  assert.equal(r.usdPerGram, metalUsdPerGram(spot, 22 / 24));
+  assert.equal(r.aedPerGram, usdToAedPerGram(metalUsdPerGram(spot, 22 / 24)));
+});
+
+test('metal-pricing: gold 24K matches the direct value (byte-identical)', async () => {
+  const { resolveMetalGramPrice } = await import(PRICING);
+  const { CONSTANTS } = await import(CONST);
+  const spot = 3333.33;
+  const r = resolveMetalGramPrice('gold', '24', { gold: spot });
+  assert.equal(r.usdPerGram, (spot * 1.0) / CONSTANTS.TROY_OZ_GRAMS);
+});
+
+test('metal-pricing: silver is disabled while the pilot is off', async () => {
+  const { resolveMetalGramPrice } = await import(PRICING);
+  const r = resolveMetalGramPrice('silver', '999', { gold: 4149, silver: 33 });
+  assert.equal(r.state, 'disabled');
+  assert.equal(r.metal, 'silver');
+});
+
+test('metal-pricing: silver prices when the pilot is on and data exists', async () => {
+  const { resolveMetalGramPrice } = await import(PRICING);
+  const { metalUsdPerGram } = await import(METALS);
+  const r = resolveMetalGramPrice('silver', '925', { silver: 33.0 }, { pilotEnabled: true });
+  assert.equal(r.state, 'ok');
+  assert.equal(r.usdPerGram, metalUsdPerGram(33.0, 0.925));
+});
+
+test('metal-pricing: enabled metal with no spot feed is pending-data (not a fake price)', async () => {
+  const { resolveMetalGramPrice } = await import(PRICING);
+  const r = resolveMetalGramPrice('platinum', '999', { gold: 4149 }, { pilotEnabled: true });
+  assert.equal(r.state, 'pending-data');
+  assert.equal(r.usdPerGram, undefined);
+});
+
+test('metal-pricing: gold with no spot feed is pending-data', async () => {
+  const { resolveMetalGramPrice } = await import(PRICING);
+  const r = resolveMetalGramPrice('gold', '24', {});
+  assert.equal(r.state, 'pending-data');
+});

--- a/tests/metals.test.js
+++ b/tests/metals.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+/**
+ * Metals data-layer foundation — guards the "gold math stays byte-identical" invariant.
+ *
+ * The metals registry generalises pricing to silver/platinum/palladium. This test proves that doing
+ * so changes NOTHING about gold: the generalised formula reproduces the existing gold expression
+ * exactly, gold's purities are the karat table verbatim, and the shared constants are untouched.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const METALS_MOD = new URL('../src/config/metals.js', `file://${__filename}`).href;
+const KARATS_MOD = new URL('../src/config/karats.js', `file://${__filename}`).href;
+const CONST_MOD = new URL('../src/config/constants.js', `file://${__filename}`).href;
+
+test('metals: registry exposes gold/silver/platinum/palladium with correct spot symbols', async () => {
+  const { METALS } = await import(METALS_MOD);
+  assert.deepEqual(Object.fromEntries(Object.values(METALS).map((m) => [m.key, m.symbol])), {
+    gold: 'XAU',
+    silver: 'XAG',
+    platinum: 'XPT',
+    palladium: 'XPD',
+  });
+  for (const m of Object.values(METALS)) {
+    assert.equal(typeof m.nameEn, 'string');
+    assert.equal(typeof m.nameAr, 'string');
+    assert.ok(Array.isArray(m.purities) && m.purities.length > 0, `${m.key} needs purities`);
+    assert.ok(
+      m.purities.some((p) => p.code === m.defaultPurity),
+      `${m.key} defaultPurity must exist in purities`
+    );
+  }
+});
+
+test('metals: only gold is primary', async () => {
+  const { METALS, PRIMARY_METAL } = await import(METALS_MOD);
+  assert.equal(PRIMARY_METAL, 'gold');
+  const primaries = Object.values(METALS).filter((m) => m.primary);
+  assert.deepEqual(
+    primaries.map((m) => m.key),
+    ['gold']
+  );
+});
+
+test('metals: gold purities are the karat table verbatim (no drift)', async () => {
+  const { METALS } = await import(METALS_MOD);
+  const { KARATS } = await import(KARATS_MOD);
+  assert.deepEqual(
+    METALS.gold.purities.map((p) => [p.code, p.purity]),
+    KARATS.map((k) => [k.code, k.purity])
+  );
+});
+
+test('metals: metalUsdPerGram is byte-identical to the existing gold formula', async () => {
+  const { metalUsdPerGram } = await import(METALS_MOD);
+  const { CONSTANTS } = await import(CONST_MOD);
+  const TROY = CONSTANTS.TROY_OZ_GRAMS;
+  // The exact expression used across the gold code (e.g. src/lib/export.js): (spot * purity) / TROY.
+  const goldFormula = (spot, purity) => (spot * purity) / TROY;
+  const spots = [0.5, 1, 25.4, 1980.75, 2500, 3333.33, 4149.0, 99999.99];
+  const purities = [1.0, 22 / 24, 21 / 24, 18 / 24, 0.999, 0.925, 0.95, 0.9];
+  for (const spot of spots) {
+    for (const purity of purities) {
+      assert.equal(
+        metalUsdPerGram(spot, purity),
+        goldFormula(spot, purity),
+        `mismatch at spot=${spot} purity=${purity}`
+      );
+    }
+  }
+});
+
+test('metals: gold 24K via the registry equals the direct gold gram value', async () => {
+  const { METALS, metalUsdPerGram } = await import(METALS_MOD);
+  const { CONSTANTS } = await import(CONST_MOD);
+  const spot = 4149.0; // matches a committed data/gold_price.json snapshot
+  const k24 = METALS.gold.purities.find((p) => p.code === '24');
+  assert.equal(metalUsdPerGram(spot, k24.purity), (spot * 1.0) / CONSTANTS.TROY_OZ_GRAMS);
+});
+
+test('metals: immutable constants are untouched', async () => {
+  const { CONSTANTS } = await import(CONST_MOD);
+  assert.equal(CONSTANTS.AED_PEG, 3.6725);
+  assert.equal(CONSTANTS.TROY_OZ_GRAMS, 31.1035);
+});
+
+test('metals: usdToAedPerGram applies the fixed peg', async () => {
+  const { usdToAedPerGram } = await import(METALS_MOD);
+  const { CONSTANTS } = await import(CONST_MOD);
+  assert.equal(usdToAedPerGram(100), 100 * CONSTANTS.AED_PEG);
+  assert.equal(usdToAedPerGram(Number.NaN), null);
+});
+
+test('metals: metalUsdPerGram rejects non-finite input', async () => {
+  const { metalUsdPerGram } = await import(METALS_MOD);
+  assert.equal(metalUsdPerGram(Number.NaN, 1), null);
+  assert.equal(metalUsdPerGram(2000, Number.NaN), null);
+  assert.equal(metalUsdPerGram(Infinity, 1), null);
+});


### PR DESCRIPTION
## Phase 33 — Silver on tracker + calculator (Yellow)

> **Depends on PR #569** (Phase 32 metals foundation) — this branch is based on it, so the diff includes #569's files. Merge #569 first.

Silver-on-the-tools is genuinely blocked: live **silver spot data** is owner-gated (must come from `gold-price-fetch.yml`, untouched), and rewriting the flagship calculator/tracker pricing for a feature that can't work yet is high-risk. Per the guardrails, this ships the **safe, tested resolution layer + a default-OFF pilot flag** that make the eventual wiring trivial — without changing gold or advertising a dead feature.

### Shipped (safe, no live change)
- **`metals-flags.js`** — `METALS_PILOT_ENABLED = false` (gold never gated by it).
- **`metal-pricing.js`** — pure `resolveMetalGramPrice()` → tagged result: `ok` (priced via the byte-identical `metalUsdPerGram`, so gold can't move), `pending-data` (enabled metal, no feed — never a fake price), `disabled` (non-gold while pilot off). `availableMetalKeys()` → `['gold']` today.
- **`tests/metal-pricing.test.js`** (8): pilot ships OFF; gold prices identically + 24K matches direct; silver disabled while off, prices when on+data, `pending-data` (not fake) when enabled without data.
- Neither module imported by a live page → tree-shaken out; **zero behaviour change**.

### Wiring design (when greenlit)
Metal switcher (default gold) built from `availableMetalKeys()` — renders nothing while it returns only gold. Tools call `resolveMetalGramPrice()` (byte-identical for gold). `pending-data` → "silver pricing being added" note; `disabled` never shown; no fabricated prices. Full design in the report.

### Owner-gated dependency (recommend-only)
Live silver needs `data/silver_price.json` written by the owner-gated `gold-price-fetch.yml` (fetching the `XAG` symbol already in the registry). **Not modified.**

### Verification
`npm run build` + `npm run validate` + `npm test` (1302 pass / 0 fail, +8) + `npm run lint` — all green.

Full write-up: `reports/metals/PHASE-33-silver-ui-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pricing and registry code are isolated from live UI; gold parity is test-guarded and the pilot ships disabled, so user-visible behaviour should not change until a later integration phase.
> 
> **Overview**
> Adds a **precious-metals data layer** and a **pricing resolution API** ahead of calculator/tracker UI work, with **no change to live pages** (new modules are not imported there yet).
> 
> **`metals.js`** registers gold (karats from existing `KARATS`), silver, platinum, and palladium with spot symbols and shared **`metalUsdPerGram` / `usdToAedPerGram`** using the same troy-oz and AED peg constants as today’s gold math. **`metals-flags.js`** sets **`METALS_PILOT_ENABLED = false`**, so non-gold metals stay off until spot feeds and the flag are enabled. **`metal-pricing.js`** exposes **`resolveMetalGramPrice`** (`ok` / `pending-data` / `disabled`) and **`availableMetalKeys()`** (only `gold` while the pilot is off).
> 
> **16 new tests** lock the byte-identical gold formula, pilot gating, and honest states when spot data is missing. Phase reports describe future wiring (metal switcher, owner-gated `silver_price.json`) without touching owner workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff01743706b89fd20421aab7b0f7d3fee6c10546. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->