### PR TITLE
Phase 36: crypto price-history plumbing (no UI, pilot OFF)

### DIFF
--- a/reports/crypto/PHASE-36-crypto-plumbing.md
+++ b/reports/crypto/PHASE-36-crypto-plumbing.md
@@ -1,0 +1,51 @@
+# Phase 36 — Crypto price-history plumbing (Yellow · no UI)
+
+Plumbing only, exactly as scoped ("no UI"). Adds the client-side foundation so a future
+gold-vs-crypto correlation view (Phase 37) can pull BTC/ETH history through the **same**
+`historical-data.js` pipeline the gold chart already uses — with zero new charting code and zero
+change to gold.
+
+## Shipped
+
+- **`src/config/crypto-assets.js`** — registry: `btc` (`BTC/USD`, primary) and `eth` (`ETH/USD`),
+  bilingual names, display decimals. `CRYPTO_PILOT_ENABLED = false` — the master switch, off until a
+  real feed and a UI phase exist. Helpers `cryptoKeys()`, `getCryptoAsset()`.
+- **`src/lib/crypto-history.js`** — `normalizeCryptoPoint()` / `normalizeCryptoHistory()` turn raw
+  crypto points (`{date|time, price|close|value}`, ISO/epoch/Date accepted) into the **exact
+  `{ date, price, granularity, source, asset }` records** that `historical-data.js` consumes. Series
+  are sorted ascending, de-duplicated per date (last write wins), and non-positive/unparseable
+  points dropped.
+- Both modules are **unimported** → tree-shaken out. No UI, no live fetch, no behaviour change.
+
+## Why this shape
+
+The gold chart's `toChartData(records)` is asset-generic (`{date, price}` → `{time, value}`), and
+`filterByRange` works on any dated records. By emitting crypto history in the identical record
+shape, Phase 37 can chart gold and BTC on the same axis and compute a rolling correlation using the
+existing utilities — no parallel charting stack.
+
+## Tests — `tests/crypto-history.test.js` (5)
+
+Pilot ships OFF; registry has BTC(primary)/ETH with pair symbols; `normalizeCryptoPoint` rejects
+junk (zero/negative price, bad date, unknown asset) and accepts valid points;
+`normalizeCryptoHistory` sorts, de-dupes, and drops bad points; and **the normalized records flow
+through the real `toChartData` unchanged**.
+
+## Owner-gated dependency (recommend-only)
+
+Live crypto history needs a price feed — e.g. an owner-added workflow writing `data/crypto/btc.json`
+(and eth), mirroring the gold pipeline. No such fetch is added here (owner-gated territory), and the
+`BTC/USD` / `ETH/USD` symbols in the registry match the common feed conventions.
+
+## Honesty framing (carried to Phase 37)
+
+Crypto is for **descriptive comparison only** — correlation, not causation, never a prediction or
+investment signal. The pilot flag keeps all of it off until that framing ships with the UI.
+
+## Constraints honoured
+
+Gold history untouched; $0 / no dependency; pilot OFF; no owner-gated files modified; no UI.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (1291 pass, +5) + `npm run lint` — all green.

--- a/src/config/crypto-assets.js
+++ b/src/config/crypto-assets.js
@@ -1,0 +1,59 @@
+/**
+ * config/crypto-assets.js — registry for the crypto price-history pilot (BTC, optional ETH).
+ *
+ * Foundation/plumbing only — NO UI, no live data. It exists so a future gold-vs-crypto correlation
+ * view (Phase 37) can pull crypto history through the *same* `historical-data.js` pipeline the gold
+ * chart already uses. Everything is OFF until (a) the owner adds a crypto price feed and (b) the flag
+ * below is flipped. Nothing here touches gold.
+ *
+ * Framing rule (carried from the roadmap): crypto is shown for **descriptive comparison only** —
+ * correlation, not causation, and never a prediction or investment signal.
+ */
+
+/** Master switch for anything crypto-facing. MUST stay false until a real feed + a UI phase exist. */
+export const CRYPTO_PILOT_ENABLED = false;
+
+/** The lead crypto asset for the pilot. */
+export const PRIMARY_CRYPTO = 'btc';
+
+/**
+ * @typedef {Object} CryptoAsset
+ * @property {string} key       'btc' | 'eth'
+ * @property {string} symbol    Pair symbol used by feeds (BTC/USD, ETH/USD).
+ * @property {string} nameEn
+ * @property {string} nameAr
+ * @property {number} decimals  Display decimals for USD price.
+ * @property {boolean} primary
+ */
+
+/** @type {Record<string, CryptoAsset>} */
+export const CRYPTO_ASSETS = {
+  btc: {
+    key: 'btc',
+    symbol: 'BTC/USD',
+    nameEn: 'Bitcoin',
+    nameAr: 'بيتكوين',
+    decimals: 0,
+    primary: true,
+  },
+  eth: {
+    key: 'eth',
+    symbol: 'ETH/USD',
+    nameEn: 'Ethereum',
+    nameAr: 'إيثيريوم',
+    decimals: 0,
+    primary: false,
+  },
+};
+
+/** All crypto keys, primary first. */
+export function cryptoKeys() {
+  return Object.keys(CRYPTO_ASSETS).sort((a, b) =>
+    a === PRIMARY_CRYPTO ? -1 : b === PRIMARY_CRYPTO ? 1 : 0
+  );
+}
+
+/** Look up a crypto asset by key; null for unknown keys (unlike metals, no gold-style fallback). */
+export function getCryptoAsset(key) {
+  return CRYPTO_ASSETS[key] || null;
+}

--- a/src/lib/crypto-history.js
+++ b/src/lib/crypto-history.js
@@ -1,0 +1,65 @@
+/**
+ * lib/crypto-history.js — normalise a crypto price series into the shared history-record shape.
+ *
+ * Plumbing only (Phase 36) — NO UI, no live fetch. Its single job is to turn raw crypto points into
+ * the exact `{ date, price, granularity, source, … }` records that `historical-data.js` already
+ * consumes, so crypto series can flow through the existing `toChartData` / `filterByRange` pipeline
+ * with **zero new charting code** when a correlation view is built (Phase 37). Gold is untouched.
+ *
+ * A raw point is `{ date: 'YYYY-MM-DD' | 'YYYY-MM' | epoch-ms | Date, price|close|value: number }`.
+ */
+
+import { getCryptoAsset } from '../config/crypto-assets.js';
+
+/** Coerce a raw crypto point's date to the ISO string the history pipeline expects. */
+function toIsoKey(date) {
+  if (date instanceof Date) {
+    return Number.isFinite(date.getTime()) ? date.toISOString().slice(0, 10) : null;
+  }
+  if (typeof date === 'number') {
+    const d = new Date(date);
+    return Number.isFinite(d.getTime()) ? d.toISOString().slice(0, 10) : null;
+  }
+  if (typeof date === 'string') {
+    // Accept YYYY-MM and YYYY-MM-DD directly; otherwise try to parse.
+    if (/^\d{4}-\d{2}(-\d{2})?$/.test(date)) return date;
+    const d = new Date(date);
+    return Number.isFinite(d.getTime()) ? d.toISOString().slice(0, 10) : null;
+  }
+  return null;
+}
+
+/**
+ * Normalise one raw crypto point into a history record, or `null` if it's unusable.
+ * @param {object} raw
+ * @param {string} assetKey  'btc' | 'eth'
+ * @returns {{ date: string, price: number, granularity: 'daily'|'monthly', source: string, asset: string } | null}
+ */
+export function normalizeCryptoPoint(raw, assetKey) {
+  if (!raw || !getCryptoAsset(assetKey)) return null;
+  const date = toIsoKey(raw.date ?? raw.time ?? raw.t);
+  const price = Number(raw.price ?? raw.close ?? raw.value);
+  if (!date || !Number.isFinite(price) || price <= 0) return null;
+  return {
+    date,
+    price,
+    granularity: date.length === 7 ? 'monthly' : 'daily',
+    source: raw.source || 'crypto-feed',
+    asset: assetKey,
+  };
+}
+
+/**
+ * Normalise a raw crypto series into ascending, de-duplicated history records.
+ * @param {object[]} points
+ * @param {string} assetKey
+ * @returns {Array<{date:string, price:number, granularity:string, source:string, asset:string}>}
+ */
+export function normalizeCryptoHistory(points, assetKey) {
+  const byDate = new Map();
+  for (const p of points || []) {
+    const rec = normalizeCryptoPoint(p, assetKey);
+    if (rec) byDate.set(rec.date, rec); // last write wins per date
+  }
+  return [...byDate.values()].sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+}

--- a/tests/crypto-history.test.js
+++ b/tests/crypto-history.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/**
+ * Crypto price-history plumbing — proves the normaliser produces records the existing gold history
+ * pipeline (`toChartData` / `filterByRange`) consumes unchanged, and that the pilot ships OFF.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const ASSETS = new URL('../src/config/crypto-assets.js', `file://${__filename}`).href;
+const CRYPTO = new URL('../src/lib/crypto-history.js', `file://${__filename}`).href;
+const HIST = new URL('../src/lib/historical-data.js', `file://${__filename}`).href;
+
+test('crypto: pilot ships OFF', async () => {
+  const { CRYPTO_PILOT_ENABLED } = await import(ASSETS);
+  assert.equal(CRYPTO_PILOT_ENABLED, false);
+});
+
+test('crypto: registry has BTC (primary) and ETH with pair symbols', async () => {
+  const { CRYPTO_ASSETS, PRIMARY_CRYPTO, cryptoKeys } = await import(ASSETS);
+  assert.equal(PRIMARY_CRYPTO, 'btc');
+  assert.equal(CRYPTO_ASSETS.btc.symbol, 'BTC/USD');
+  assert.equal(CRYPTO_ASSETS.eth.symbol, 'ETH/USD');
+  assert.equal(CRYPTO_ASSETS.btc.primary, true);
+  assert.deepEqual(cryptoKeys(), ['btc', 'eth']);
+});
+
+test('crypto: normalizeCryptoPoint rejects junk, accepts valid points', async () => {
+  const { normalizeCryptoPoint } = await import(CRYPTO);
+  assert.equal(normalizeCryptoPoint(null, 'btc'), null);
+  assert.equal(normalizeCryptoPoint({ date: '2026-01-01', price: 0 }, 'btc'), null);
+  assert.equal(normalizeCryptoPoint({ date: 'nope', price: 5 }, 'btc'), null);
+  assert.equal(normalizeCryptoPoint({ date: '2026-01-01', price: 5 }, 'unknown'), null);
+  const ok = normalizeCryptoPoint({ date: '2026-01-01', close: 42000 }, 'btc');
+  assert.deepEqual(ok, {
+    date: '2026-01-01',
+    price: 42000,
+    granularity: 'daily',
+    source: 'crypto-feed',
+    asset: 'btc',
+  });
+});
+
+test('crypto: normalizeCryptoHistory sorts, de-dupes, and drops bad points', async () => {
+  const { normalizeCryptoHistory } = await import(CRYPTO);
+  const recs = normalizeCryptoHistory(
+    [
+      { date: '2026-03-01', price: 60000 },
+      { date: '2026-01-01', price: 42000 },
+      { date: '2026-01-01', price: 43000 }, // dup date → last wins
+      { date: 'bad', price: 1 },
+      { date: '2026-02-01', price: -1 }, // non-positive → dropped
+    ],
+    'btc'
+  );
+  assert.deepEqual(
+    recs.map((r) => [r.date, r.price]),
+    [
+      ['2026-01-01', 43000],
+      ['2026-03-01', 60000],
+    ]
+  );
+});
+
+test('crypto: normalized records flow through the gold history pipeline unchanged', async () => {
+  const { normalizeCryptoHistory } = await import(CRYPTO);
+  const { toChartData } = await import(HIST);
+  const recs = normalizeCryptoHistory(
+    [
+      { date: '2026-01-01', price: 42000 },
+      { date: '2026-02-01', price: 50000 },
+    ],
+    'btc'
+  );
+  // toChartData is asset-generic ({date,price} -> {time,value}); crypto records must just work.
+  assert.deepEqual(toChartData(recs), [
+    { time: '2026-01-01', value: 42000 },
+    { time: '2026-02-01', value: 50000 },
+  ]);
+});


### PR DESCRIPTION
## Phase 36 — Crypto price-history plumbing (Yellow · no UI)

Plumbing only, exactly as scoped ("no UI"). Adds the client-side foundation so a future gold-vs-crypto correlation view (Phase 37) can pull BTC/ETH history through the **same** `historical-data.js` pipeline the gold chart already uses — with zero new charting code and zero change to gold.

### Shipped
- **`src/config/crypto-assets.js`** — registry: `btc` (`BTC/USD`, primary) and `eth` (`ETH/USD`), bilingual names, display decimals. `CRYPTO_PILOT_ENABLED = false` — master switch, off until a real feed and a UI phase exist. Helpers `cryptoKeys()`, `getCryptoAsset()`.
- **`src/lib/crypto-history.js`** — `normalizeCryptoPoint()` / `normalizeCryptoHistory()` turn raw crypto points (`{date|time, price|close|value}`, ISO/epoch/Date accepted) into the **exact `{ date, price, granularity, source, asset }` records** that `historical-data.js` consumes. Series sorted ascending, de-duplicated per date (last write wins), non-positive/unparseable points dropped.
- Both modules are **unimported** → tree-shaken out. No UI, no live fetch, no behaviour change.

### Why this shape
`toChartData(records)` is asset-generic (`{date, price}` → `{time, value}`) and `filterByRange` works on any dated records. Emitting crypto history in the identical record shape lets Phase 37 chart gold and BTC on the same axis and compute a rolling correlation with the existing utilities — no parallel charting stack.

### Tests — `tests/crypto-history.test.js` (5)
Pilot ships OFF; registry has BTC(primary)/ETH with pair symbols; `normalizeCryptoPoint` rejects junk (zero/negative price, bad date, unknown asset) and accepts valid points; `normalizeCryptoHistory` sorts, de-dupes, drops bad points; and the normalized records **flow through the real `toChartData` unchanged**.

### Owner-gated dependency (recommend-only)
Live crypto history needs a price feed — e.g. an owner-added workflow writing `data/crypto/btc.json` (and eth), mirroring the gold pipeline. No such fetch is added here (owner-gated territory); the `BTC/USD` / `ETH/USD` symbols match common feed conventions.

### Honesty framing (carried to Phase 37)
Crypto is for **descriptive comparison only** — correlation, not causation, never a prediction or investment signal. The pilot flag keeps it all off until that framing ships with the UI.

### Constraints honoured
Gold history untouched; $0 / no dependency; pilot OFF; no owner-gated files modified; no UI.

### Gate
`npm run build` + `npm run validate` + `npm test` (1291 pass, +5) + `npm run lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated new modules with no imports from app code; gold pipeline unchanged and pilot disabled by default.
> 
> **Overview**
> Adds **plumbing-only** support so future BTC/ETH series can reuse the same `historical-data.js` chart path as gold, with **no UI, no live fetch, and no gold changes**.
> 
> Introduces `src/config/crypto-assets.js` (BTC/ETH registry, bilingual labels, **`CRYPTO_PILOT_ENABLED = false`**) and `src/lib/crypto-history.js` (`normalizeCryptoPoint` / `normalizeCryptoHistory` → shared `{ date, price, granularity, source, asset }` records, sorted and de-duped). New code stays **unimported** so it should tree-shake until a later phase wires it up.
> 
> Adds `tests/crypto-history.test.js` (5 cases) covering the pilot flag, registry, normalisation edge cases, and compatibility with real `toChartData`. Includes `reports/crypto/PHASE-36-crypto-plumbing.md` phase notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03ad090e084eec0b6940eb0c7bc54286e4b3267a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->