### PR TITLE
Phase 38: N-locale i18n scaffolding (additive, EN/AR unchanged)

### DIFF
--- a/reports/i18n/PHASE-38-locale-scaffolding.md
+++ b/reports/i18n/PHASE-38-locale-scaffolding.md
@@ -1,0 +1,58 @@
+# Phase 38 — N-locale i18n scaffolding (Yellow · EN/AR unchanged)
+
+A de-risked foundation for adding locales beyond EN/AR. It introduces a **locale registry** (source
+of truth) and the **canonical translate helper** that 30+ call sites already hand-write inline — as
+purely additive modules. No existing consumer is touched, and EN/AR output is **provably identical**
+to today. The French (39) and Urdu (40) pilots build on this.
+
+## The problem it de-risks
+
+Two patterns are copy-pasted across the codebase:
+
+- **Locale resolution** — `const lang = urlLang === 'ar' ? 'ar' : 'en'` in ~15 page entry points.
+- **Translation lookup** — `TRANSLATIONS[locale]?.[key] ?? TRANSLATIONS.en?.[key] ?? key` in 30+.
+
+Adding a third or fourth language by editing every one of those sites is exactly the kind of wide,
+error-prone change this phase removes. Instead there is now one resolver and one lookup to adopt.
+
+## Shipped (additive — no consumers changed this phase)
+
+- **`src/config/locales.js`** — the registry:
+  - `LOCALES` — `en`/`ar` **enabled**; `fr`/`ur` **declared but disabled** (each with `endonym`,
+    `englishName`, `dir`), so switcher/direction/hreflang scaffolding is ready before the pilot
+    ships.
+  - `DEFAULT_LOCALE`, `SUPPORTED_LOCALE_CODES`, `ACTIVE_LOCALE_CODES` (`['en','ar']` today).
+  - `resolveLocale(requested)` — maps a raw `?lang=` value to a live locale, defaulting to `en`.
+  - `getLocaleMeta` / `getLocaleDir` / `isRtlLocale` / `isActiveLocale`.
+- **`src/lib/i18n.js`** — `translate(translations, locale, key, { fallback, vars })` implementing
+  the exact `locale → default → fallback → key` chain, plus `interpolate()` (`{token}` /
+  `{{token}}`) and `createTranslator(dict, locale)` returning the `t(key, vars)` shape pages already
+  use locally.
+
+## The EN/AR-unchanged invariant (guarded by tests)
+
+- `resolveLocale(x)` is asserted **byte-for-byte identical** to the legacy
+  `x === 'ar' ? 'ar' : 'en'` across a battery of inputs (`ar`, `en`, `''`, `AR`, `fr`, `ur`, `xx`,
+  `null`, `undefined`, …). It is exact-match only, so while `en`/`ar` are the active set the output
+  cannot differ. When Phase 39/40 flips `fr`/`ur` to `enabled: true`, `resolveLocale('fr')` starts
+  returning `'fr'` automatically — no other change needed.
+- `translate(TRANSLATIONS, locale, key)` is asserted equal to the inline
+  `TRANSLATIONS[locale]?.[key] ?? TRANSLATIONS.en?.[key] ?? key` for **every** EN key across `en`,
+  `ar`, and an unknown locale — proving zero divergence from current behaviour.
+
+## How the pilots (39/40) adopt this
+
+1. Flip `LOCALES.fr.enabled` (or `ur`) to `true`.
+2. Add a `TRANSLATIONS.fr` block.
+3. Swap the inline `=== 'ar'` resolution for `resolveLocale(...)` and inline lookups for
+   `translate(...)` at the surfaces in scope. Direction/RTL comes from `isRtlLocale` (Urdu reuses
+   the AR RTL infra).
+
+## Constraints honoured
+
+EN/AR behaviour unchanged (proven, not asserted); $0 / no dependency; additive only — no other
+phase's files touched; parked locales ship disabled so nothing renders until its pilot.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (**1297 pass, +11**) + `npm run lint` — all green.

--- a/src/config/locales.js
+++ b/src/config/locales.js
@@ -1,0 +1,77 @@
+/**
+ * config/locales.js — the locale registry and single source of truth for supported languages.
+ *
+ * Phase 38 (N-locale i18n scaffolding). Today the site is bilingual EN/AR; this registry is the
+ * de-risked foundation that lets later phases add French (39) and Urdu (40) by flipping one
+ * `enabled` flag and adding a `TRANSLATIONS` block — with **no change to EN/AR behaviour**.
+ *
+ * Invariant (guarded by tests): while only `en` and `ar` are active, `resolveLocale(x)` is
+ * byte-for-byte identical to the legacy inline `x === 'ar' ? 'ar' : 'en'` used across the app. The
+ * registry is additive — existing consumers are untouched by this phase; the pilots adopt it.
+ */
+
+/** The universal fallback locale. English is the base dictionary everywhere. */
+export const DEFAULT_LOCALE = 'en';
+
+/**
+ * @typedef {Object} LocaleMeta
+ * @property {string} code      BCP-47 primary subtag ('en', 'ar', 'fr', 'ur').
+ * @property {string} endonym   Native name, shown in the language switcher.
+ * @property {string} englishName
+ * @property {'ltr'|'rtl'} dir
+ * @property {boolean} enabled  Whether the locale is live. EN/AR true; FR/UR wait for their phase.
+ */
+
+/**
+ * Registry of every locale the codebase knows about. `enabled: false` entries are declared so the
+ * scaffolding (dir handling, switcher, hreflang) is ready, but they are NOT active until their pilot
+ * phase turns them on and ships a translation block.
+ * @type {Record<string, LocaleMeta>}
+ */
+export const LOCALES = {
+  en: { code: 'en', endonym: 'English', englishName: 'English', dir: 'ltr', enabled: true },
+  ar: { code: 'ar', endonym: 'العربية', englishName: 'Arabic', dir: 'rtl', enabled: true },
+  // Parked pilots — declared, disabled. Flipped on in Phases 39 (fr) and 40 (ur).
+  fr: { code: 'fr', endonym: 'Français', englishName: 'French', dir: 'ltr', enabled: false },
+  ur: { code: 'ur', endonym: 'اردو', englishName: 'Urdu', dir: 'rtl', enabled: false },
+};
+
+/** Every declared locale code, active or parked. */
+export const SUPPORTED_LOCALE_CODES = Object.keys(LOCALES);
+
+/** Only the live locale codes (default first), e.g. ['en', 'ar'] today. */
+export const ACTIVE_LOCALE_CODES = SUPPORTED_LOCALE_CODES.filter(
+  (code) => LOCALES[code].enabled
+).sort((a, b) => (a === DEFAULT_LOCALE ? -1 : b === DEFAULT_LOCALE ? 1 : 0));
+
+/** True if `code` is a live locale. */
+export function isActiveLocale(code) {
+  return Boolean(LOCALES[code]?.enabled);
+}
+
+/**
+ * Resolve a requested language (typically the raw `?lang=` value) to a live locale code.
+ * Unknown, parked, or missing values fall back to {@link DEFAULT_LOCALE}. Exact-match only, so while
+ * `en`/`ar` are the active set this is identical to the legacy `req === 'ar' ? 'ar' : 'en'`.
+ *
+ * @param {string|null|undefined} requested
+ * @returns {string} an active locale code
+ */
+export function resolveLocale(requested) {
+  return isActiveLocale(requested) ? requested : DEFAULT_LOCALE;
+}
+
+/** Full metadata for a locale, falling back to the default locale's metadata for unknown codes. */
+export function getLocaleMeta(code) {
+  return LOCALES[code] || LOCALES[DEFAULT_LOCALE];
+}
+
+/** Text direction ('ltr' | 'rtl') for a locale; defaults to the default locale's direction. */
+export function getLocaleDir(code) {
+  return getLocaleMeta(code).dir;
+}
+
+/** True if the locale is right-to-left. Mirrors the app's `lang === 'ar'` RTL checks, generalised. */
+export function isRtlLocale(code) {
+  return getLocaleDir(code) === 'rtl';
+}

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -1,0 +1,53 @@
+/**
+ * lib/i18n.js — the canonical translation lookup, factored out of 30+ inline call sites.
+ *
+ * Phase 38 (N-locale i18n scaffolding). Across the app the same fallback chain is hand-written:
+ *   `TRANSLATIONS[locale]?.[key] ?? TRANSLATIONS.en?.[key] ?? fallback`
+ * This module makes that chain a single tested helper so new locales (French/Urdu) inherit identical
+ * fallback semantics for free, and so `{token}` interpolation is consistent. It changes no behaviour
+ * on its own — it is the shared implementation the pilots adopt. EN/AR output is unchanged.
+ */
+
+import { DEFAULT_LOCALE } from '../config/locales.js';
+
+/**
+ * Interpolate `{token}` / `{{token}}` placeholders from a vars map. Missing tokens are left as-is.
+ * @param {string} template
+ * @param {Record<string, string|number>} vars
+ * @returns {string}
+ */
+export function interpolate(template, vars) {
+  if (!vars || typeof template !== 'string') return template;
+  return template.replace(/\{\{?\s*(\w+)\s*\}?\}/g, (match, token) =>
+    Object.prototype.hasOwnProperty.call(vars, token) ? String(vars[token]) : match
+  );
+}
+
+/**
+ * Look up a translation with the canonical locale → default-locale → fallback chain.
+ *
+ * @param {Record<string, Record<string, string>>} translations  e.g. the `TRANSLATIONS` map.
+ * @param {string} locale  Target locale code.
+ * @param {string} key     Dot-namespaced translation key.
+ * @param {{ fallback?: string, vars?: Record<string, string|number> }} [options]
+ *   `fallback` is used when neither the locale nor the default locale has the key (defaults to the
+ *   key itself, matching the app's existing `?? key` behaviour); `vars` interpolates placeholders.
+ * @returns {string}
+ */
+export function translate(translations, locale, key, options = {}) {
+  const dicts = translations || {};
+  const raw = dicts[locale]?.[key] ?? dicts[DEFAULT_LOCALE]?.[key] ?? options.fallback ?? key;
+  return options.vars ? interpolate(raw, options.vars) : raw;
+}
+
+/**
+ * Bind a `translations` map and `locale` into a reusable `t(key, vars?)` function — the shape most
+ * page modules already expose locally, now sourced from one implementation.
+ *
+ * @param {Record<string, Record<string, string>>} translations
+ * @param {string} locale
+ * @returns {(key: string, vars?: Record<string, string|number>) => string}
+ */
+export function createTranslator(translations, locale) {
+  return (key, vars) => translate(translations, locale, key, { vars });
+}

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * Shared translate helper — proves it reproduces the app's inline
+ * `TRANSLATIONS[locale]?.[key] ?? TRANSLATIONS.en?.[key] ?? key` chain exactly (so EN/AR output is
+ * unchanged), plus `{token}` interpolation and the bound-translator shape.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const I18N = new URL('../src/lib/i18n.js', `file://${__filename}`).href;
+const CFG = new URL('../src/config/index.js', `file://${__filename}`).href;
+
+// Synthetic fixture for edge cases we can control precisely.
+const DICT = {
+  en: { greet: 'Hello', only_en: 'English only', tpl: '{n} of {total}' },
+  ar: { greet: 'مرحبا' }, // no `only_en`, no `tpl` → must fall back to en
+};
+
+test('i18n: locale hit returns the locale string', async () => {
+  const { translate } = await import(I18N);
+  assert.equal(translate(DICT, 'ar', 'greet'), 'مرحبا');
+  assert.equal(translate(DICT, 'en', 'greet'), 'Hello');
+});
+
+test('i18n: missing key in locale falls back to English, then to the key', async () => {
+  const { translate } = await import(I18N);
+  assert.equal(translate(DICT, 'ar', 'only_en'), 'English only'); // en fallback
+  assert.equal(translate(DICT, 'ar', 'nope'), 'nope'); // key fallback
+  assert.equal(translate(DICT, 'ar', 'nope', { fallback: '—' }), '—'); // explicit fallback
+});
+
+test('i18n: unknown locale falls back to English', async () => {
+  const { translate } = await import(I18N);
+  assert.equal(translate(DICT, 'fr', 'greet'), 'Hello');
+});
+
+test('i18n: interpolation fills {token} and {{token}}, leaves unknown tokens', async () => {
+  const { translate, interpolate } = await import(I18N);
+  assert.equal(translate(DICT, 'en', 'tpl', { vars: { n: 3, total: 9 } }), '3 of 9');
+  assert.equal(interpolate('{{a}}-{b}', { a: 'x', b: 'y' }), 'x-y');
+  assert.equal(interpolate('{missing} kept', {}), '{missing} kept');
+});
+
+test('i18n: createTranslator binds dict + locale into t(key, vars)', async () => {
+  const { createTranslator } = await import(I18N);
+  const t = createTranslator(DICT, 'ar');
+  assert.equal(t('greet'), 'مرحبا');
+  assert.equal(t('only_en'), 'English only');
+  assert.equal(t('tpl', { n: 1, total: 2 }), '1 of 2');
+});
+
+test('i18n: matches the legacy inline chain across a sweep of real TRANSLATIONS keys', async () => {
+  const { translate } = await import(I18N);
+  const { TRANSLATIONS } = await import(CFG);
+  const legacy = (locale, key) => TRANSLATIONS[locale]?.[key] ?? TRANSLATIONS.en?.[key] ?? key;
+
+  const keys = Object.keys(TRANSLATIONS.en);
+  assert.ok(keys.length > 50, 'expected a substantial EN dictionary');
+  for (const locale of ['en', 'ar', 'fr']) {
+    for (const key of keys) {
+      assert.equal(
+        translate(TRANSLATIONS, locale, key),
+        legacy(locale, key),
+        `divergence at ${locale}:${key}`
+      );
+    }
+  }
+});

--- a/tests/locales.test.js
+++ b/tests/locales.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/**
+ * Locale registry — proves the scaffolding is additive and, crucially, that `resolveLocale` is
+ * byte-for-byte identical to the legacy `x === 'ar' ? 'ar' : 'en'` while only en/ar are active,
+ * so EN/AR behaviour is unchanged. Parked pilots (fr/ur) are declared but disabled.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const LOC = new URL('../src/config/locales.js', `file://${__filename}`).href;
+
+test('locales: en/ar are active, fr/ur are declared but parked', async () => {
+  const { LOCALES, ACTIVE_LOCALE_CODES, SUPPORTED_LOCALE_CODES, isActiveLocale } = await import(
+    LOC
+  );
+  assert.equal(LOCALES.en.enabled, true);
+  assert.equal(LOCALES.ar.enabled, true);
+  assert.equal(LOCALES.fr.enabled, false);
+  assert.equal(LOCALES.ur.enabled, false);
+  assert.deepEqual(ACTIVE_LOCALE_CODES, ['en', 'ar']);
+  assert.deepEqual(SUPPORTED_LOCALE_CODES.sort(), ['ar', 'en', 'fr', 'ur']);
+  assert.equal(isActiveLocale('fr'), false);
+  assert.equal(isActiveLocale('ar'), true);
+});
+
+test('locales: direction metadata matches the app (ar/ur rtl, en/fr ltr)', async () => {
+  const { getLocaleDir, isRtlLocale } = await import(LOC);
+  assert.equal(getLocaleDir('en'), 'ltr');
+  assert.equal(getLocaleDir('ar'), 'rtl');
+  assert.equal(getLocaleDir('fr'), 'ltr');
+  assert.equal(getLocaleDir('ur'), 'rtl');
+  assert.equal(isRtlLocale('ar'), true);
+  assert.equal(isRtlLocale('en'), false);
+  // Unknown code falls back to the default locale's direction.
+  assert.equal(getLocaleDir('zz'), 'ltr');
+});
+
+test('locales: resolveLocale is byte-identical to the legacy binary for every input', async () => {
+  const { resolveLocale, DEFAULT_LOCALE } = await import(LOC);
+  assert.equal(DEFAULT_LOCALE, 'en');
+  const legacy = (x) => (x === 'ar' ? 'ar' : 'en');
+  const inputs = ['ar', 'en', '', 'AR', 'EN', 'fr', 'ur', 'xx', 'arabic', null, undefined];
+  for (const input of inputs) {
+    assert.equal(resolveLocale(input), legacy(input), `resolveLocale(${JSON.stringify(input)})`);
+  }
+});
+
+test('locales: parked pilots resolve to the default until enabled', async () => {
+  const { resolveLocale } = await import(LOC);
+  // fr/ur are declared but disabled → not yet returned by the resolver.
+  assert.equal(resolveLocale('fr'), 'en');
+  assert.equal(resolveLocale('ur'), 'en');
+});
+
+test('locales: getLocaleMeta returns full metadata and default-falls-back', async () => {
+  const { getLocaleMeta } = await import(LOC);
+  assert.equal(getLocaleMeta('ar').endonym, 'العربية');
+  assert.equal(getLocaleMeta('fr').englishName, 'French');
+  assert.equal(getLocaleMeta('nope').code, 'en'); // unknown → default meta
+});


### PR DESCRIPTION
## Phase 38 — N-locale i18n scaffolding (Yellow · EN/AR unchanged)

A de-risked foundation for adding locales beyond EN/AR. Introduces a **locale registry** (source of truth) and the **canonical translate helper** that 30+ call sites already hand-write inline — as purely additive modules. No existing consumer is touched, and EN/AR output is **provably identical** to today. The French (39) and Urdu (40) pilots build on this.

### The problem it de-risks
Two patterns are copy-pasted across the codebase:
- **Locale resolution** — `const lang = urlLang === 'ar' ? 'ar' : 'en'` in ~15 page entry points.
- **Translation lookup** — `TRANSLATIONS[locale]?.[key] ?? TRANSLATIONS.en?.[key] ?? key` in 30+.

Adding a 3rd/4th language by editing every one of those sites is exactly the wide, error-prone change this phase removes — there is now one resolver and one lookup to adopt.

### Shipped (additive — no consumers changed this phase)
- **`src/config/locales.js`** — the registry:
  - `LOCALES` — `en`/`ar` **enabled**; `fr`/`ur` **declared but disabled** (each with `endonym`, `englishName`, `dir`), so switcher/direction/hreflang scaffolding is ready before the pilot ships.
  - `DEFAULT_LOCALE`, `SUPPORTED_LOCALE_CODES`, `ACTIVE_LOCALE_CODES` (`['en','ar']` today).
  - `resolveLocale(requested)` — maps a raw `?lang=` value to a live locale, defaulting to `en`.
  - `getLocaleMeta` / `getLocaleDir` / `isRtlLocale` / `isActiveLocale`.
- **`src/lib/i18n.js`** — `translate(translations, locale, key, { fallback, vars })` implementing the exact `locale → default → fallback → key` chain, plus `interpolate()` (`{token}` / `{{token}}`) and `createTranslator(dict, locale)` returning the `t(key, vars)` shape pages already use locally.

### The EN/AR-unchanged invariant (guarded by tests)
- `resolveLocale(x)` is asserted **byte-for-byte identical** to the legacy `x === 'ar' ? 'ar' : 'en'` across a battery of inputs (`ar`, `en`, `''`, `AR`, `fr`, `ur`, `xx`, `null`, `undefined`, …). Exact-match only, so while `en`/`ar` are the active set the output cannot differ. When Phase 39/40 flips `fr`/`ur` to `enabled: true`, `resolveLocale('fr')` starts returning `'fr'` automatically.
- `translate(TRANSLATIONS, locale, key)` is asserted equal to the inline `TRANSLATIONS[locale]?.[key] ?? TRANSLATIONS.en?.[key] ?? key` for **every** EN key across `en`, `ar`, and an unknown locale — proving zero divergence.

### How the pilots (39/40) adopt this
1. Flip `LOCALES.fr.enabled` (or `ur`) to `true`.
2. Add a `TRANSLATIONS.fr` block.
3. Swap the inline `=== 'ar'` resolution for `resolveLocale(...)` and inline lookups for `translate(...)` at the surfaces in scope. Direction/RTL comes from `isRtlLocale` (Urdu reuses the AR RTL infra).

### Constraints honoured
EN/AR behaviour unchanged (proven, not asserted); $0 / no dependency; additive only — no other phase's files touched; parked locales ship disabled so nothing renders until its pilot.

### Gate
`npm run build` + `npm run validate` + `npm test` (**1297 pass, +11**) + `npm run lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production call sites are switched; behavior is guarded by tests and FR/UR stay disabled until later phases.
> 
> **Overview**
> Introduces **additive** i18n scaffolding for locales beyond EN/AR: a central **locale registry** and a shared **translation helper**, without wiring either into existing pages yet.
> 
> **`src/config/locales.js`** defines `LOCALES` (EN/AR enabled; FR/UR declared but disabled), active/supported code lists, and helpers such as `resolveLocale`, `getLocaleMeta`, and `isRtlLocale`. **`src/lib/i18n.js`** centralizes the locale → English → fallback → key lookup chain, plus `interpolate` and `createTranslator`.
> 
> **`reports/i18n/PHASE-38-locale-scaffolding.md`** documents the phase. **`tests/locales.test.js`** and **`tests/i18n.test.js`** lock `resolveLocale` to the legacy `ar` vs `en` rule and prove `translate` matches today’s inline `TRANSLATIONS` lookups across real keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3e30af3a45029494a277796e2638dfabcc65bd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->