### PR TITLE
Phase 39: French pilot UI translation (LTR, core pages)

### DIFF
--- a/reports/i18n/PHASE-39-french-pilot.md
+++ b/reports/i18n/PHASE-39-french-pilot.md
@@ -1,0 +1,60 @@
+# Phase 39 — French pilot UI translation (Green · LTR, core pages)
+
+Activates French as a live locale and ships a hand-checked **core-pages** translation set, built on
+the Phase 38 scaffold. French is LTR; every uncovered string falls back to English through the
+shared `translate()` helper, so nothing renders as a raw key. EN/AR behaviour is unchanged.
+
+> **Stacks on [#575](https://github.com/vctb12/GoldTickerLive/pull/575) (Phase 38).** Cut from the
+> Phase-38 branch because `locales.js` / `i18n.js` aren't on `main` yet; based on the Phase-38
+> branch so the diff is just Phase 39's activation + dictionary. Merge #575 first.
+
+## What shipped
+
+- **`src/config/locales.js`** — flip `fr.enabled` to `true`. French now resolves:
+  `resolveLocale('fr') === 'fr'`, `isRtlLocale('fr') === false`,
+  `ACTIVE_LOCALE_CODES === ['en','ar','fr']`.
+- **`src/i18n/fr-pilot.js`** — the pilot dictionary: ~60 hand-written French strings for the shared
+  shell (nav, footer, header, breadcrumbs) and the homepage price surface (spotlight, karat table,
+  change, units, cards, freshness/status). Plus `FR_PILOT_KEYS` and `withFrenchPilot(translations)`,
+  which grafts the pilot on as the `fr` locale without mutating the input.
+- Updated the Phase-38 locale tests to reflect French going live, **keeping the EN/AR-unchanged
+  assertion intact** (EN/AR/unknown still resolve exactly as the legacy binary; only `fr` is new).
+
+## Why the pilot dictionary is kept separate from `translations.js`
+
+`src/config/translations.js` is held to **exact EN/AR key parity** by
+`tests/i18n-sitewide-guard.test.js` — no string may ship in one language only. French is a _pilot_
+with deliberate partial coverage, so putting a partial `fr` block there would either fight that
+guard or force 1200+ premature translations. Keeping it in `src/i18n/fr-pilot.js` lets French cover
+the core surface now, fall back to English elsewhere, and grow under Phase 41's content-translation
+policy — without weakening the EN/AR parity guarantee.
+
+## Guarantees (guarded by tests — `tests/fr-pilot.test.js`, 5)
+
+- French is an **active, LTR** locale (`isActiveLocale`, `isRtlLocale`, `resolveLocale`).
+- **No orphan strings**: every pilot key exists in `TRANSLATIONS.en` — this is a translation of an
+  existing surface, never a new string.
+- Every French value is a **non-empty** string, and all but the legitimately-identical few (e.g.
+  `USD`) actually differ from English.
+- `withFrenchPilot(TRANSLATIONS)` renders **French for covered keys** (`nav.home → Accueil`,
+  `card.copied → Copié !`) and **English for the rest** (e.g. any `tracker.*` key) — never a raw
+  key, never Arabic — and does not mutate the input map.
+- **Reference-estimate framing preserved**: both disclaimers carry "conseil financier" (not
+  financial advice); `spotlight.note` keeps the estimated-bullion-equivalent wording, not retail.
+
+## How a page serves French (adoption, not done here)
+
+A core page adopts French by resolving its locale with `resolveLocale(urlLang)` and looking copy up
+via `translate(withFrenchPilot(TRANSLATIONS), locale, key)`. This phase does not rewrite existing
+page files (they belong to earlier phases); it delivers the activation + dictionary + proven render
+path.
+
+## Constraints honoured
+
+EN/AR unchanged (proven); $0 / no dependency; no other phase's page files touched; French limited to
+a hand-checked core subset with English fallback; reference-estimate framing intact in French.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (**1302 pass, +5**, i18n parity guards green) +
+`npm run lint` — all green.

--- a/src/config/locales.js
+++ b/src/config/locales.js
@@ -31,8 +31,10 @@ export const DEFAULT_LOCALE = 'en';
 export const LOCALES = {
   en: { code: 'en', endonym: 'English', englishName: 'English', dir: 'ltr', enabled: true },
   ar: { code: 'ar', endonym: 'العربية', englishName: 'Arabic', dir: 'rtl', enabled: true },
-  // Parked pilots — declared, disabled. Flipped on in Phases 39 (fr) and 40 (ur).
-  fr: { code: 'fr', endonym: 'Français', englishName: 'French', dir: 'ltr', enabled: false },
+  // French pilot — activated in Phase 39 (LTR). Ships a curated core-pages dictionary
+  // (see src/i18n/fr-pilot.js); uncovered keys fall back to English via the translate helper.
+  fr: { code: 'fr', endonym: 'Français', englishName: 'French', dir: 'ltr', enabled: true },
+  // Parked pilot — declared, disabled. Flipped on in Phase 40 (ur, reuses AR RTL infra).
   ur: { code: 'ur', endonym: 'اردو', englishName: 'Urdu', dir: 'rtl', enabled: false },
 };
 

--- a/src/i18n/fr-pilot.js
+++ b/src/i18n/fr-pilot.js
@@ -1,0 +1,127 @@
+/**
+ * i18n/fr-pilot.js — French pilot dictionary (Phase 39, LTR).
+ *
+ * A curated **core-pages** translation set: the shared site shell (nav, footer, header, breadcrumbs)
+ * plus the homepage price surface (spotlight, karat table, change, freshness/status). It is kept
+ * OUT of the parity-guarded `src/config/translations.js` on purpose — French is a *pilot* with
+ * deliberate partial coverage, whereas EN/AR are held to exact key parity. Any key not covered here
+ * falls back to English through the shared `translate()` helper, so nothing renders as a raw key.
+ *
+ * Every key below MUST exist in `TRANSLATIONS.en` (guarded by tests) — this is a translation of an
+ * existing surface, never a new string. The reference-estimate framing (spot-linked,
+ * bullion-equivalent, "not financial advice") is preserved in the French copy.
+ *
+ * Full-content French (all 1200+ keys) is Phase 41's job (MT + human review); this pilot is the
+ * hand-checked shell + homepage core that proves the scaffolding end-to-end.
+ */
+
+/** @type {Record<string, string>} — French strings, keyed by the existing EN translation key. */
+export const FR_PILOT = {
+  // ── Header / language ──────────────────────────────────────────────────────
+  'header.title': "Cours de l'or en direct",
+  'header.subtitle': 'Estimations pour lingots indexées sur le cours spot, par carat et devise',
+  'lang.toggle': 'English',
+
+  // ── Primary navigation ─────────────────────────────────────────────────────
+  'nav.home': 'Accueil',
+  'nav.tracker': 'Suivi en direct',
+  'nav.calculator': 'Calculatrice',
+  'nav.learn': "Centre d'apprentissage",
+  'nav.shops': 'Boutiques et marchés',
+  'nav.methodology': 'Méthodologie',
+  'nav.terms': "Conditions d'utilisation",
+  'nav.privacy': 'Politique de confidentialité',
+  'nav.invest': 'Investir',
+  'nav.insights': 'Analyses de marché',
+  'nav.countries': 'Pays',
+  'nav.compare': 'Comparer les pays',
+  'nav.heatmap': 'Carte du monde',
+  'nav.glossary': 'Glossaire',
+  'nav.market': "Comment l'or est coté",
+  'nav.portfolio': 'Portefeuille',
+  'nav.dubai': "Cours de l'or à Dubaï et aux Émirats",
+  'nav.country': 'Pays',
+  'breadcrumbs.ariaLabel': "Fil d'Ariane",
+
+  // ── Footer ─────────────────────────────────────────────────────────────────
+  'footer.goldSource': 'Données or : Gold-API.com (gold-api.com)',
+  'footer.fxSource': 'Données de change : ExchangeRate-API (open.er-api.com)',
+  'footer.disclaimer':
+    'Valeurs estimées équivalentes en lingots uniquement. Les prix de détail et en bijouterie peuvent différer sensiblement. Ne constitue pas un conseil financier.',
+
+  // ── Gold / FX / AED freshness + badges ─────────────────────────────────────
+  'gold.freshness.label': 'Or mis à jour :',
+  'gold.countdown.label': 'Prochaine actualisation dans :',
+  'gold.badge': 'EN DIRECT',
+  'fx.freshness.label': 'Taux de change mis à jour :',
+  'fx.next.label': 'Prochaine actualisation des taux :',
+  'fx.badge': 'QUOTIDIEN',
+  'aed.badge': 'PARITÉ FIXE',
+  'aed.note': "Parité officielle de la Banque centrale des Émirats avec l'USD",
+
+  // ── Homepage spotlight ─────────────────────────────────────────────────────
+  'spotlight.title': "Cours de l'or aux Émirats",
+  'spotlight.note': 'Valeur estimée équivalente en lingots',
+  'spotlight.perOzUsd': 'Par once (USD)',
+  'spotlight.perOzAed': 'Par once (AED)',
+  'spotlight.perGramUsd': 'Par gramme (USD)',
+  'spotlight.perGramAed': 'Par gramme (AED)',
+  'spotlight.karat.label': 'Carat :',
+
+  // ── Price movement ─────────────────────────────────────────────────────────
+  'change.title': 'Évolution du cours',
+  'change.vsPrev': 'par rapport au relevé précédent',
+  'change.vsOpen': "par rapport à l'ouverture à Dubaï",
+  'change.note': '24 carats par once · USD · Estimation indexée sur le cours spot',
+
+  // ── Price-by-karat table ───────────────────────────────────────────────────
+  'karat.title': 'Cours par carat',
+  'karat.col.karat': 'Carat',
+  'karat.col.usd': 'USD',
+  'karat.col.aed': 'AED (parité fixe)',
+  'karat.disclaimer':
+    'Valeurs estimées équivalentes en lingots. Les prix de détail et en bijouterie peuvent différer. Ne constitue pas un conseil financier.',
+
+  // ── Units ──────────────────────────────────────────────────────────────────
+  'unit.gram': 'Par gramme',
+  'unit.oz': 'Par once',
+
+  // ── Country / price cards ──────────────────────────────────────────────────
+  'card.perGram': 'par gramme',
+  'card.perOz': 'par once',
+  'card.copy': 'Copier',
+  'card.copied': 'Copié !',
+  'card.stale': 'Obsolète',
+  'card.noData': 'Aucune donnée',
+  'card.addFavorite': 'Ajouter aux favoris',
+  'card.removeFavorite': 'Retirer des favoris',
+
+  // ── Status / freshness messages ────────────────────────────────────────────
+  'status.loading': 'Chargement des cours...',
+  'status.offline': 'Vous êtes hors ligne. Affichage des données en cache.',
+  'status.goldStale': "Les données sur l'or peuvent être obsolètes. Utilisation du cours en cache.",
+  'status.fxStale': 'Les taux de change peuvent être obsolètes. Utilisation des taux en cache.',
+  'status.goldError':
+    "Impossible d'actualiser le cours de l'or. Affichage de la dernière valeur en cache si disponible.",
+  'status.fxError':
+    "Impossible d'actualiser les taux de change. Affichage des derniers taux en cache si disponibles.",
+  'status.noData':
+    'Les cours ne sont pas disponibles pour le moment. Vérifiez votre connexion et appuyez sur Réessayer.',
+  'status.retry': 'Réessayer',
+  'status.cacheHealth': 'Fraîcheur des données :',
+};
+
+/** Keys covered by the French pilot. Everything else falls back to English. */
+export const FR_PILOT_KEYS = Object.keys(FR_PILOT);
+
+/**
+ * Return a translations map with the French pilot grafted on as the `fr` locale, so
+ * `translate(withFrenchPilot(TRANSLATIONS), 'fr', key)` yields French for covered keys and English
+ * for the rest. The input map is not mutated.
+ *
+ * @param {Record<string, Record<string, string>>} translations  e.g. `TRANSLATIONS`.
+ * @returns {Record<string, Record<string, string>>}
+ */
+export function withFrenchPilot(translations) {
+  return { ...(translations || {}), fr: FR_PILOT };
+}

--- a/tests/fr-pilot.test.js
+++ b/tests/fr-pilot.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/**
+ * French pilot — proves French is a live, LTR locale; the pilot only translates keys that exist in
+ * EN (no orphan/new strings); covered keys render French while everything else falls back to English
+ * via the shared translate helper; and the reference-estimate framing survives translation.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const FR = new URL('../src/i18n/fr-pilot.js', `file://${__filename}`).href;
+const LOC = new URL('../src/config/locales.js', `file://${__filename}`).href;
+const I18N = new URL('../src/lib/i18n.js', `file://${__filename}`).href;
+const CFG = new URL('../src/config/index.js', `file://${__filename}`).href;
+
+test('fr-pilot: French is an active, LTR locale', async () => {
+  const { isActiveLocale, isRtlLocale, resolveLocale, getLocaleMeta } = await import(LOC);
+  assert.equal(isActiveLocale('fr'), true);
+  assert.equal(isRtlLocale('fr'), false); // French is left-to-right.
+  assert.equal(resolveLocale('fr'), 'fr');
+  assert.equal(getLocaleMeta('fr').endonym, 'Français');
+});
+
+test('fr-pilot: every pilot key exists in TRANSLATIONS.en (no orphan strings)', async () => {
+  const { FR_PILOT_KEYS } = await import(FR);
+  const { TRANSLATIONS } = await import(CFG);
+  const enKeys = new Set(Object.keys(TRANSLATIONS.en));
+  const orphans = FR_PILOT_KEYS.filter((k) => !enKeys.has(k));
+  assert.deepEqual(orphans, [], 'pilot must only translate existing EN keys');
+  assert.ok(FR_PILOT_KEYS.length >= 50, 'pilot should cover the core-pages surface');
+});
+
+test('fr-pilot: all French values are non-empty strings and mostly differ from English', async () => {
+  const { FR_PILOT } = await import(FR);
+  const { TRANSLATIONS } = await import(CFG);
+  let differ = 0;
+  for (const [key, value] of Object.entries(FR_PILOT)) {
+    assert.equal(typeof value, 'string');
+    assert.ok(value.trim().length > 0, `empty French value for ${key}`);
+    if (value !== TRANSLATIONS.en[key]) differ += 1;
+  }
+  // A handful (e.g. 'USD') are legitimately identical; the vast majority must be real translations.
+  assert.ok(differ >= Object.keys(FR_PILOT).length - 3, 'most keys must be actually translated');
+});
+
+test('fr-pilot: withFrenchPilot yields French for covered keys, English for the rest', async () => {
+  const { withFrenchPilot } = await import(FR);
+  const { translate } = await import(I18N);
+  const { TRANSLATIONS } = await import(CFG);
+  const dict = withFrenchPilot(TRANSLATIONS);
+
+  // Covered → French.
+  assert.equal(translate(dict, 'fr', 'nav.home'), 'Accueil');
+  assert.equal(translate(dict, 'fr', 'card.copied'), 'Copié !');
+  // Not covered by the pilot → English fallback (not a raw key, not Arabic).
+  const uncovered = Object.keys(TRANSLATIONS.en).find(
+    (k) => k.startsWith('tracker.') && TRANSLATIONS.en[k]
+  );
+  assert.equal(translate(dict, 'fr', uncovered), TRANSLATIONS.en[uncovered]);
+  // Input map is not mutated.
+  assert.equal(TRANSLATIONS.fr, undefined);
+});
+
+test('fr-pilot: reference-estimate framing is preserved in French', async () => {
+  const { FR_PILOT } = await import(FR);
+  // "Not financial advice" carries into both disclaimers.
+  assert.match(FR_PILOT['footer.disclaimer'], /conseil financier/i);
+  assert.match(FR_PILOT['karat.disclaimer'], /conseil financier/i);
+  // Estimated bullion-equivalent framing, not retail.
+  assert.match(FR_PILOT['spotlight.note'], /estimée équivalente en lingots/i);
+});

--- a/tests/locales.test.js
+++ b/tests/locales.test.js
@@ -11,17 +11,18 @@ const assert = require('node:assert/strict');
 
 const LOC = new URL('../src/config/locales.js', `file://${__filename}`).href;
 
-test('locales: en/ar are active, fr/ur are declared but parked', async () => {
+test('locales: en/ar/fr are active (fr live in Phase 39), ur still parked', async () => {
   const { LOCALES, ACTIVE_LOCALE_CODES, SUPPORTED_LOCALE_CODES, isActiveLocale } = await import(
     LOC
   );
   assert.equal(LOCALES.en.enabled, true);
   assert.equal(LOCALES.ar.enabled, true);
-  assert.equal(LOCALES.fr.enabled, false);
-  assert.equal(LOCALES.ur.enabled, false);
-  assert.deepEqual(ACTIVE_LOCALE_CODES, ['en', 'ar']);
+  assert.equal(LOCALES.fr.enabled, true); // Phase 39 — French pilot activated.
+  assert.equal(LOCALES.ur.enabled, false); // Phase 40 — still parked.
+  assert.deepEqual(ACTIVE_LOCALE_CODES, ['en', 'ar', 'fr']);
   assert.deepEqual(SUPPORTED_LOCALE_CODES.sort(), ['ar', 'en', 'fr', 'ur']);
-  assert.equal(isActiveLocale('fr'), false);
+  assert.equal(isActiveLocale('fr'), true);
+  assert.equal(isActiveLocale('ur'), false);
   assert.equal(isActiveLocale('ar'), true);
 });
 
@@ -37,20 +38,25 @@ test('locales: direction metadata matches the app (ar/ur rtl, en/fr ltr)', async
   assert.equal(getLocaleDir('zz'), 'ltr');
 });
 
-test('locales: resolveLocale is byte-identical to the legacy binary for every input', async () => {
+test('locales: EN/AR resolution is unchanged; fr now resolves to fr', async () => {
   const { resolveLocale, DEFAULT_LOCALE } = await import(LOC);
   assert.equal(DEFAULT_LOCALE, 'en');
-  const legacy = (x) => (x === 'ar' ? 'ar' : 'en');
-  const inputs = ['ar', 'en', '', 'AR', 'EN', 'fr', 'ur', 'xx', 'arabic', null, undefined];
-  for (const input of inputs) {
-    assert.equal(resolveLocale(input), legacy(input), `resolveLocale(${JSON.stringify(input)})`);
+  // EN/AR (and everything not-yet-active) behave exactly as the legacy `x === 'ar' ? 'ar' : 'en'`.
+  const enArLegacy = (x) => (x === 'ar' ? 'ar' : 'en');
+  for (const input of ['ar', 'en', '', 'AR', 'EN', 'xx', 'arabic', null, undefined]) {
+    assert.equal(
+      resolveLocale(input),
+      enArLegacy(input),
+      `resolveLocale(${JSON.stringify(input)})`
+    );
   }
+  // Phase 39: French is live, so the resolver now returns it (exact-match only).
+  assert.equal(resolveLocale('fr'), 'fr');
 });
 
-test('locales: parked pilots resolve to the default until enabled', async () => {
+test('locales: still-parked pilots resolve to the default until enabled', async () => {
   const { resolveLocale } = await import(LOC);
-  // fr/ur are declared but disabled → not yet returned by the resolver.
-  assert.equal(resolveLocale('fr'), 'en');
+  // ur is declared but disabled → not yet returned by the resolver.
   assert.equal(resolveLocale('ur'), 'en');
 });
 


### PR DESCRIPTION
## Phase 39 — French pilot UI translation (Green · LTR, core pages)

Activates French as a live locale and ships a hand-checked **core-pages** translation set, built on the Phase 38 scaffold. French is LTR; every uncovered string falls back to English through the shared `translate()` helper, so nothing renders as a raw key. EN/AR behaviour is unchanged.

> **Stacks on #575 (Phase 38).** Cut from the Phase-38 branch because `locales.js` / `i18n.js` aren't on `main` yet; based on the Phase-38 branch so the diff is just Phase 39's activation + dictionary. Merge #575 first.

### What shipped
- **`src/config/locales.js`** — flip `fr.enabled` to `true`. French now resolves: `resolveLocale('fr') === 'fr'`, `isRtlLocale('fr') === false`, `ACTIVE_LOCALE_CODES === ['en','ar','fr']`.
- **`src/i18n/fr-pilot.js`** — the pilot dictionary: ~60 hand-written French strings for the shared shell (nav, footer, header, breadcrumbs) and the homepage price surface (spotlight, karat table, change, units, cards, freshness/status). Plus `FR_PILOT_KEYS` and `withFrenchPilot(translations)`, which grafts the pilot on as the `fr` locale without mutating the input.
- Updated the Phase-38 locale tests to reflect French going live, **keeping the EN/AR-unchanged assertion intact** (EN/AR/unknown still resolve exactly as the legacy binary; only `fr` is new).

### Why the pilot dictionary is kept separate from `translations.js`
`src/config/translations.js` is held to **exact EN/AR key parity** by `tests/i18n-sitewide-guard.test.js` — no string may ship in one language only. French is a *pilot* with deliberate partial coverage, so a partial `fr` block there would either fight that guard or force 1200+ premature translations. Keeping it in `src/i18n/fr-pilot.js` lets French cover the core surface now, fall back to English elsewhere, and grow under Phase 41's content-translation policy — without weakening the EN/AR parity guarantee.

### Guarantees (guarded by tests — `tests/fr-pilot.test.js`, 5)
- French is an **active, LTR** locale.
- **No orphan strings**: every pilot key exists in `TRANSLATIONS.en` — a translation of an existing surface, never a new string.
- Every French value is **non-empty** and (bar the legitimately-identical few like `USD`) differs from English.
- `withFrenchPilot(TRANSLATIONS)` renders **French for covered keys** (`nav.home → Accueil`, `card.copied → Copié !`) and **English for the rest** (e.g. any `tracker.*` key) — never a raw key, never Arabic — without mutating the input.
- **Reference-estimate framing preserved**: both disclaimers carry "conseil financier" (not financial advice); `spotlight.note` keeps the estimated-bullion-equivalent wording, not retail.

### How a page serves French (adoption, not done here)
A core page adopts French by resolving its locale with `resolveLocale(urlLang)` and looking copy up via `translate(withFrenchPilot(TRANSLATIONS), locale, key)`. This phase does not rewrite existing page files (they belong to earlier phases); it delivers the activation + dictionary + proven render path.

### Constraints honoured
EN/AR unchanged (proven); $0 / no dependency; no other phase's page files touched; French limited to a hand-checked core subset with English fallback; reference-estimate framing intact in French.

### Gate
`npm run build` + `npm run validate` + `npm test` (**1302 pass, +5**, i18n parity guards green) + `npm run lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive i18n scaffolding and copy-only pilot strings; EN/AR resolution is explicitly regression-tested and pages are not modified in this PR.
> 
> **Overview**
> Turns on **French** as a third live locale (`fr.enabled: true`), so `resolveLocale('fr')` returns `fr` and `ACTIVE_LOCALE_CODES` includes `en`, `ar`, and `fr`. **Urdu** stays parked; tests still assert EN/AR (and other non-active inputs) resolve exactly like the legacy `ar ? ar : en` behaviour.
> 
> Adds **`src/i18n/fr-pilot.js`**: ~60 hand-checked French strings for the site shell and homepage price UI, plus **`withFrenchPilot(translations)`** to attach a `fr` block without touching parity-guarded `translations.js`. Uncovered keys use existing **`translate()`** English fallback.
> 
> **`tests/fr-pilot.test.js`** (5 cases) and updated **`tests/locales.test.js`** lock in LTR French, no orphan keys, fallback behaviour, and preserved “not financial advice” / bullion-estimate wording in French. Phase 39 report doc added; **no page wiring** in this diff—consumers adopt `translate(withFrenchPilot(TRANSLATIONS), …)` separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc25ce290ab17de216822b8fc29779196981faf0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->