### PR TITLE
Phase 40: Urdu pilot UI translation (RTL, reuses AR infra)

### DIFF
--- a/reports/i18n/PHASE-40-urdu-pilot.md
+++ b/reports/i18n/PHASE-40-urdu-pilot.md
@@ -1,0 +1,51 @@
+# Phase 40 — Urdu pilot UI translation (Green · RTL, reuses AR infra)
+
+Activates Urdu as a live locale and ships the **same curated core-pages surface** as the French
+pilot, translated into Urdu. Urdu is right-to-left and **reuses the exact RTL infrastructure Arabic
+already uses** — no new direction/layout plumbing. Uncovered strings fall back to English. EN/AR
+behaviour is unchanged.
+
+> **Stacks on [#576](https://github.com/vctb12/GoldTickerLive/pull/576) (Phase 39) → #575 (Phase
+> 38).** Cut from the Phase-39 branch so the locale registry stays consistent (en→ar→fr→ur
+> progressively enabled). Merge order: #575 → #576 → this.
+
+## What shipped
+
+- **`src/config/locales.js`** — flip `ur.enabled` to `true`. Urdu now resolves:
+  `resolveLocale('ur') === 'ur'`, `isRtlLocale('ur') === true`,
+  `getLocaleDir('ur') === getLocaleDir('ar')`, `ACTIVE_LOCALE_CODES === ['en','ar','fr','ur']`.
+- **`src/i18n/ur-pilot.js`** — the Urdu pilot dictionary: the identical ~60-key core surface as the
+  French pilot (shared shell + homepage price surface), in Urdu. Plus `UR_PILOT_KEYS` and
+  `withUrduPilot(translations)`, which grafts it on as the `ur` locale without mutating the input.
+- Updated the shared locale tests for Urdu going live (EN/AR resolution still proven unchanged).
+
+## RTL: reusing Arabic's infrastructure
+
+Urdu shares Arabic's script direction. Because the registry marks `ur` as `dir: 'rtl'`, everything
+that already keys off direction — `document.dir`, the mirrored nav/layout, the RTL CSS shipped in
+the bilingual work — applies to Urdu with **zero new code**. A test asserts
+`getLocaleDir('ur') === getLocaleDir('ar')` to lock that equivalence in.
+
+## Guarantees (guarded by tests — `tests/ur-pilot.test.js`, 6)
+
+- Urdu is an **active, RTL** locale, with direction identical to Arabic.
+- **No orphan strings**: every pilot key exists in `TRANSLATIONS.en`.
+- **Key-set parity with the French pilot** — the two pilots cover exactly the same surface, so the
+  locales stay in lockstep as the core grows.
+- Every Urdu value is a **non-empty** string; all but the legitimately-identical few (e.g. `USD`)
+  differ from English.
+- `withUrduPilot(TRANSLATIONS)` renders **Urdu for covered keys** (`nav.home → ہوم`,
+  `card.copy → کاپی`) and **English for the rest** — never a raw key — without mutating the input.
+- **Reference-estimate framing preserved**: both disclaimers carry "مالی مشورہ نہیں" (not financial
+  advice); `spotlight.note` keeps the bullion-equivalent wording.
+
+## Constraints honoured
+
+EN/AR unchanged (proven); $0 / no dependency; no other phase's page files touched; Urdu limited to a
+hand-checked core subset with English fallback; RTL via the existing Arabic infra;
+reference-estimate framing intact in Urdu.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (**1308 pass, +6**, i18n parity guards green) +
+`npm run lint` — all green.

--- a/src/config/locales.js
+++ b/src/config/locales.js
@@ -34,8 +34,9 @@ export const LOCALES = {
   // French pilot — activated in Phase 39 (LTR). Ships a curated core-pages dictionary
   // (see src/i18n/fr-pilot.js); uncovered keys fall back to English via the translate helper.
   fr: { code: 'fr', endonym: 'Français', englishName: 'French', dir: 'ltr', enabled: true },
-  // Parked pilot — declared, disabled. Flipped on in Phase 40 (ur, reuses AR RTL infra).
-  ur: { code: 'ur', endonym: 'اردو', englishName: 'Urdu', dir: 'rtl', enabled: false },
+  // Urdu pilot — activated in Phase 40 (RTL, reuses the same rtl infra as Arabic).
+  // Curated core-pages dictionary in src/i18n/ur-pilot.js; uncovered keys fall back to English.
+  ur: { code: 'ur', endonym: 'اردو', englishName: 'Urdu', dir: 'rtl', enabled: true },
 };
 
 /** Every declared locale code, active or parked. */

--- a/src/i18n/ur-pilot.js
+++ b/src/i18n/ur-pilot.js
@@ -1,0 +1,124 @@
+/**
+ * i18n/ur-pilot.js — Urdu pilot dictionary (Phase 40, RTL).
+ *
+ * The same curated **core-pages** surface as the French pilot (shared shell + homepage price
+ * surface), translated into Urdu. Urdu is right-to-left and **reuses the exact RTL infrastructure
+ * Arabic already uses** — `getLocaleDir('ur') === 'rtl'` / `isRtlLocale('ur') === true`, so the
+ * document direction, mirrored layout, and RTL CSS apply with no new plumbing.
+ *
+ * Like the French pilot it is kept OUT of the parity-guarded `src/config/translations.js` (EN/AR are
+ * held to exact key parity; Urdu is a partial pilot). Every key here MUST exist in `TRANSLATIONS.en`
+ * (guarded by tests); uncovered keys fall back to English via the shared `translate()` helper. The
+ * reference-estimate framing (bullion-equivalent, "not financial advice") is preserved in Urdu.
+ */
+
+/** @type {Record<string, string>} — Urdu strings, keyed by the existing EN translation key. */
+export const UR_PILOT = {
+  // ── Header / language ──────────────────────────────────────────────────────
+  'header.title': 'سونے کی قیمتیں براہِ راست',
+  'header.subtitle': 'قیراط اور کرنسی کے مطابق اسپاٹ سے منسلک بُلین تخمینے',
+  'lang.toggle': 'English',
+
+  // ── Primary navigation ─────────────────────────────────────────────────────
+  'nav.home': 'ہوم',
+  'nav.tracker': 'براہِ راست ٹریکر',
+  'nav.calculator': 'کیلکولیٹر',
+  'nav.learn': 'سیکھنے کا مرکز',
+  'nav.shops': 'دکانیں اور بازار',
+  'nav.methodology': 'طریقہ کار',
+  'nav.terms': 'شرائطِ خدمات',
+  'nav.privacy': 'رازداری کی پالیسی',
+  'nav.invest': 'سرمایہ کاری',
+  'nav.insights': 'مارکیٹ تجزیہ',
+  'nav.countries': 'ممالک',
+  'nav.compare': 'ممالک کا موازنہ',
+  'nav.heatmap': 'عالمی نقشہ',
+  'nav.glossary': 'لغت',
+  'nav.market': 'سونے کی قیمت کیسے طے ہوتی ہے',
+  'nav.portfolio': 'پورٹ فولیو',
+  'nav.dubai': 'دبئی اور یو اے ای میں سونے کی قیمت',
+  'nav.country': 'ملک',
+  'breadcrumbs.ariaLabel': 'بریڈ کرمب',
+
+  // ── Footer ─────────────────────────────────────────────────────────────────
+  'footer.goldSource': 'سونے کا ڈیٹا: Gold-API.com (gold-api.com)',
+  'footer.fxSource': 'زرِ مبادلہ ڈیٹا: ExchangeRate-API (open.er-api.com)',
+  'footer.disclaimer':
+    'صرف بُلین کے مساوی تخمینی اقدار۔ خوردہ اور زیورات کی قیمتیں نمایاں طور پر مختلف ہو سکتی ہیں۔ یہ مالی مشورہ نہیں ہے۔',
+
+  // ── Gold / FX / AED freshness + badges ─────────────────────────────────────
+  'gold.freshness.label': 'سونا اپ ڈیٹ ہوا:',
+  'gold.countdown.label': 'اگلی تازہ کاری:',
+  'gold.badge': 'براہِ راست',
+  'fx.freshness.label': 'زرِ مبادلہ کی شرحیں اپ ڈیٹ ہوئیں:',
+  'fx.next.label': 'اگلی زرِ مبادلہ تازہ کاری:',
+  'fx.badge': 'روزانہ',
+  'aed.badge': 'مقررہ پیگ',
+  'aed.note': 'یو اے ای مرکزی بینک کی امریکی ڈالر سے سرکاری پیگ',
+
+  // ── Homepage spotlight ─────────────────────────────────────────────────────
+  'spotlight.title': 'یو اے ای میں سونے کی قیمتیں',
+  'spotlight.note': 'بُلین کے مساوی تخمینی قدر',
+  'spotlight.perOzUsd': 'فی اونس (USD)',
+  'spotlight.perOzAed': 'فی اونس (AED)',
+  'spotlight.perGramUsd': 'فی گرام (USD)',
+  'spotlight.perGramAed': 'فی گرام (AED)',
+  'spotlight.karat.label': 'قیراط:',
+
+  // ── Price movement ─────────────────────────────────────────────────────────
+  'change.title': 'قیمت میں تبدیلی',
+  'change.vsPrev': 'پچھلے ریکارڈ کے مقابلے میں',
+  'change.vsOpen': 'دبئی کی ابتدائی قیمت کے مقابلے میں',
+  'change.note': '24 قیراط فی اونس · USD · اسپاٹ سے منسلک تخمینہ',
+
+  // ── Price-by-karat table ───────────────────────────────────────────────────
+  'karat.title': 'قیراط کے حساب سے قیمت',
+  'karat.col.karat': 'قیراط',
+  'karat.col.usd': 'USD',
+  'karat.col.aed': 'AED (مقررہ پیگ)',
+  'karat.disclaimer':
+    'بُلین کے مساوی تخمینی اقدار۔ خوردہ اور زیورات کی قیمتیں مختلف ہو سکتی ہیں۔ یہ مالی مشورہ نہیں ہے۔',
+
+  // ── Units ──────────────────────────────────────────────────────────────────
+  'unit.gram': 'فی گرام',
+  'unit.oz': 'فی اونس',
+
+  // ── Country / price cards ──────────────────────────────────────────────────
+  'card.perGram': 'فی گرام',
+  'card.perOz': 'فی اونس',
+  'card.copy': 'کاپی',
+  'card.copied': 'کاپی ہو گیا!',
+  'card.stale': 'پرانا',
+  'card.noData': 'کوئی ڈیٹا نہیں',
+  'card.addFavorite': 'پسندیدہ میں شامل کریں',
+  'card.removeFavorite': 'پسندیدہ سے ہٹائیں',
+
+  // ── Status / freshness messages ────────────────────────────────────────────
+  'status.loading': 'قیمتیں لوڈ ہو رہی ہیں...',
+  'status.offline': 'آپ آف لائن ہیں۔ محفوظ شدہ ڈیٹا دکھایا جا رہا ہے۔',
+  'status.goldStale': 'سونے کا ڈیٹا پرانا ہو سکتا ہے۔ محفوظ شدہ قیمت استعمال کی جا رہی ہے۔',
+  'status.fxStale': 'زرِ مبادلہ کی شرحیں پرانی ہو سکتی ہیں۔ محفوظ شدہ شرحیں استعمال کی جا رہی ہیں۔',
+  'status.goldError':
+    'سونے کی قیمت تازہ نہیں کی جا سکی۔ دستیاب ہونے پر آخری محفوظ شدہ قدر دکھائی جا رہی ہے۔',
+  'status.fxError':
+    'زرِ مبادلہ کی شرحیں تازہ نہیں کی جا سکیں۔ دستیاب ہونے پر آخری محفوظ شدہ شرحیں دکھائی جا رہی ہیں۔',
+  'status.noData':
+    'قیمتیں اس وقت دستیاب نہیں ہیں۔ اپنا کنکشن چیک کریں اور دوبارہ کوشش کریں دبائیں۔',
+  'status.retry': 'دوبارہ کوشش کریں',
+  'status.cacheHealth': 'ڈیٹا کی تازگی:',
+};
+
+/** Keys covered by the Urdu pilot. Everything else falls back to English. */
+export const UR_PILOT_KEYS = Object.keys(UR_PILOT);
+
+/**
+ * Return a translations map with the Urdu pilot grafted on as the `ur` locale, so
+ * `translate(withUrduPilot(TRANSLATIONS), 'ur', key)` yields Urdu for covered keys and English for
+ * the rest. The input map is not mutated.
+ *
+ * @param {Record<string, Record<string, string>>} translations  e.g. `TRANSLATIONS`.
+ * @returns {Record<string, Record<string, string>>}
+ */
+export function withUrduPilot(translations) {
+  return { ...(translations || {}), ur: UR_PILOT };
+}

--- a/tests/locales.test.js
+++ b/tests/locales.test.js
@@ -11,18 +11,18 @@ const assert = require('node:assert/strict');
 
 const LOC = new URL('../src/config/locales.js', `file://${__filename}`).href;
 
-test('locales: en/ar/fr are active (fr live in Phase 39), ur still parked', async () => {
+test('locales: en/ar/fr/ur are all active (ur live in Phase 40)', async () => {
   const { LOCALES, ACTIVE_LOCALE_CODES, SUPPORTED_LOCALE_CODES, isActiveLocale } = await import(
     LOC
   );
   assert.equal(LOCALES.en.enabled, true);
   assert.equal(LOCALES.ar.enabled, true);
   assert.equal(LOCALES.fr.enabled, true); // Phase 39 — French pilot activated.
-  assert.equal(LOCALES.ur.enabled, false); // Phase 40 — still parked.
-  assert.deepEqual(ACTIVE_LOCALE_CODES, ['en', 'ar', 'fr']);
+  assert.equal(LOCALES.ur.enabled, true); // Phase 40 — Urdu pilot activated.
+  assert.deepEqual(ACTIVE_LOCALE_CODES, ['en', 'ar', 'fr', 'ur']);
   assert.deepEqual(SUPPORTED_LOCALE_CODES.sort(), ['ar', 'en', 'fr', 'ur']);
   assert.equal(isActiveLocale('fr'), true);
-  assert.equal(isActiveLocale('ur'), false);
+  assert.equal(isActiveLocale('ur'), true);
   assert.equal(isActiveLocale('ar'), true);
 });
 
@@ -38,10 +38,10 @@ test('locales: direction metadata matches the app (ar/ur rtl, en/fr ltr)', async
   assert.equal(getLocaleDir('zz'), 'ltr');
 });
 
-test('locales: EN/AR resolution is unchanged; fr now resolves to fr', async () => {
+test('locales: EN/AR resolution is unchanged; fr/ur now resolve to themselves', async () => {
   const { resolveLocale, DEFAULT_LOCALE } = await import(LOC);
   assert.equal(DEFAULT_LOCALE, 'en');
-  // EN/AR (and everything not-yet-active) behave exactly as the legacy `x === 'ar' ? 'ar' : 'en'`.
+  // EN/AR (and every unknown value) behave exactly as the legacy `x === 'ar' ? 'ar' : 'en'`.
   const enArLegacy = (x) => (x === 'ar' ? 'ar' : 'en');
   for (const input of ['ar', 'en', '', 'AR', 'EN', 'xx', 'arabic', null, undefined]) {
     assert.equal(
@@ -50,14 +50,15 @@ test('locales: EN/AR resolution is unchanged; fr now resolves to fr', async () =
       `resolveLocale(${JSON.stringify(input)})`
     );
   }
-  // Phase 39: French is live, so the resolver now returns it (exact-match only).
+  // Pilots are live, so the resolver now returns them (exact-match only).
   assert.equal(resolveLocale('fr'), 'fr');
+  assert.equal(resolveLocale('ur'), 'ur');
 });
 
-test('locales: still-parked pilots resolve to the default until enabled', async () => {
+test('locales: unknown codes still resolve to the default', async () => {
   const { resolveLocale } = await import(LOC);
-  // ur is declared but disabled → not yet returned by the resolver.
-  assert.equal(resolveLocale('ur'), 'en');
+  assert.equal(resolveLocale('de'), 'en');
+  assert.equal(resolveLocale('zz'), 'en');
 });
 
 test('locales: getLocaleMeta returns full metadata and default-falls-back', async () => {

--- a/tests/ur-pilot.test.js
+++ b/tests/ur-pilot.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+/**
+ * Urdu pilot — proves Urdu is a live, RTL locale that reuses the Arabic RTL infra; the pilot only
+ * translates keys that exist in EN (no orphan strings); covered keys render Urdu while everything
+ * else falls back to English; the pilot mirrors the French pilot's key set; and the
+ * reference-estimate framing survives translation.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const UR = new URL('../src/i18n/ur-pilot.js', `file://${__filename}`).href;
+const FR = new URL('../src/i18n/fr-pilot.js', `file://${__filename}`).href;
+const LOC = new URL('../src/config/locales.js', `file://${__filename}`).href;
+const I18N = new URL('../src/lib/i18n.js', `file://${__filename}`).href;
+const CFG = new URL('../src/config/index.js', `file://${__filename}`).href;
+
+test('ur-pilot: Urdu is an active, RTL locale (reuses AR direction infra)', async () => {
+  const { isActiveLocale, isRtlLocale, resolveLocale, getLocaleDir, getLocaleMeta } = await import(
+    LOC
+  );
+  assert.equal(isActiveLocale('ur'), true);
+  assert.equal(isRtlLocale('ur'), true); // Urdu is right-to-left, same as Arabic.
+  assert.equal(getLocaleDir('ur'), getLocaleDir('ar')); // identical rtl handling
+  assert.equal(resolveLocale('ur'), 'ur');
+  assert.equal(getLocaleMeta('ur').endonym, 'اردو');
+});
+
+test('ur-pilot: every pilot key exists in TRANSLATIONS.en (no orphan strings)', async () => {
+  const { UR_PILOT_KEYS } = await import(UR);
+  const { TRANSLATIONS } = await import(CFG);
+  const enKeys = new Set(Object.keys(TRANSLATIONS.en));
+  const orphans = UR_PILOT_KEYS.filter((k) => !enKeys.has(k));
+  assert.deepEqual(orphans, [], 'pilot must only translate existing EN keys');
+  assert.ok(UR_PILOT_KEYS.length >= 50, 'pilot should cover the core-pages surface');
+});
+
+test('ur-pilot: covers the same key set as the French pilot', async () => {
+  const { UR_PILOT_KEYS } = await import(UR);
+  const { FR_PILOT_KEYS } = await import(FR);
+  assert.deepEqual([...UR_PILOT_KEYS].sort(), [...FR_PILOT_KEYS].sort());
+});
+
+test('ur-pilot: all Urdu values are non-empty strings and mostly differ from English', async () => {
+  const { UR_PILOT } = await import(UR);
+  const { TRANSLATIONS } = await import(CFG);
+  let differ = 0;
+  for (const [key, value] of Object.entries(UR_PILOT)) {
+    assert.equal(typeof value, 'string');
+    assert.ok(value.trim().length > 0, `empty Urdu value for ${key}`);
+    if (value !== TRANSLATIONS.en[key]) differ += 1;
+  }
+  assert.ok(differ >= Object.keys(UR_PILOT).length - 3, 'most keys must be actually translated');
+});
+
+test('ur-pilot: withUrduPilot yields Urdu for covered keys, English for the rest', async () => {
+  const { withUrduPilot } = await import(UR);
+  const { translate } = await import(I18N);
+  const { TRANSLATIONS } = await import(CFG);
+  const dict = withUrduPilot(TRANSLATIONS);
+
+  assert.equal(translate(dict, 'ur', 'nav.home'), 'ہوم');
+  assert.equal(translate(dict, 'ur', 'card.copy'), 'کاپی');
+  // Not covered by the pilot → English fallback (not a raw key, not Arabic).
+  const uncovered = Object.keys(TRANSLATIONS.en).find(
+    (k) => k.startsWith('tracker.') && TRANSLATIONS.en[k]
+  );
+  assert.equal(translate(dict, 'ur', uncovered), TRANSLATIONS.en[uncovered]);
+  assert.equal(TRANSLATIONS.ur, undefined); // input not mutated
+});
+
+test('ur-pilot: reference-estimate framing is preserved in Urdu', async () => {
+  const { UR_PILOT } = await import(UR);
+  // "not financial advice" carries into both disclaimers.
+  assert.match(UR_PILOT['footer.disclaimer'], /مالی مشورہ نہیں/);
+  assert.match(UR_PILOT['karat.disclaimer'], /مالی مشورہ نہیں/);
+  // Estimated bullion-equivalent framing.
+  assert.match(UR_PILOT['spotlight.note'], /بُلین کے مساوی/);
+});


### PR DESCRIPTION
## Phase 40 — Urdu pilot UI translation (Green · RTL, reuses AR infra)

Activates Urdu as a live locale and ships the **same curated core-pages surface** as the French pilot, translated into Urdu. Urdu is right-to-left and **reuses the exact RTL infrastructure Arabic already uses** — no new direction/layout plumbing. Uncovered strings fall back to English. EN/AR behaviour is unchanged.

> **Stacks on #576 (Phase 39) → #575 (Phase 38).** Cut from the Phase-39 branch so the locale registry stays consistent (en→ar→fr→ur progressively enabled). Merge order: #575 → #576 → this.

### What shipped
- **`src/config/locales.js`** — flip `ur.enabled` to `true`. Urdu now resolves: `resolveLocale('ur') === 'ur'`, `isRtlLocale('ur') === true`, `getLocaleDir('ur') === getLocaleDir('ar')`, `ACTIVE_LOCALE_CODES === ['en','ar','fr','ur']`.
- **`src/i18n/ur-pilot.js`** — the Urdu pilot dictionary: the identical ~60-key core surface as the French pilot (shared shell + homepage price surface), in Urdu. Plus `UR_PILOT_KEYS` and `withUrduPilot(translations)`, which grafts it on as the `ur` locale without mutating the input.
- Updated the shared locale tests for Urdu going live (EN/AR resolution still proven unchanged).

### RTL: reusing Arabic's infrastructure
Urdu shares Arabic's script direction. Because the registry marks `ur` as `dir: 'rtl'`, everything that already keys off direction — `document.dir`, the mirrored nav/layout, the RTL CSS shipped in the bilingual work — applies to Urdu with **zero new code**. A test asserts `getLocaleDir('ur') === getLocaleDir('ar')` to lock that equivalence in.

### Guarantees (guarded by tests — `tests/ur-pilot.test.js`, 6)
- Urdu is an **active, RTL** locale, with direction identical to Arabic.
- **No orphan strings**: every pilot key exists in `TRANSLATIONS.en`.
- **Key-set parity with the French pilot** — the two pilots cover exactly the same surface.
- Every Urdu value is **non-empty**; all but the legitimately-identical few (e.g. `USD`) differ from English.
- `withUrduPilot(TRANSLATIONS)` renders **Urdu for covered keys** (`nav.home → ہوم`, `card.copy → کاپی`) and **English for the rest** — never a raw key — without mutating the input.
- **Reference-estimate framing preserved**: both disclaimers carry "مالی مشورہ نہیں" (not financial advice); `spotlight.note` keeps the bullion-equivalent wording.

### Constraints honoured
EN/AR unchanged (proven); $0 / no dependency; no other phase's page files touched; Urdu limited to a hand-checked core subset with English fallback; RTL via the existing Arabic infra; reference-estimate framing intact in Urdu.

### Gate
`npm run build` + `npm run validate` + `npm test` (**1308 pass, +6**, i18n parity guards green) + `npm run lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive i18n pilot with English fallback; EN/AR resolution paths stay guarded by tests and no auth or data-layer changes appear in the diff.
> 
> **Overview**
> **Urdu goes live** in the locale registry (`ur.enabled: true`), so `resolveLocale('ur')` returns `ur` and active locales are `en`, `ar`, `fr`, and `ur`. RTL is handled via existing `dir: 'rtl'` metadata—no new layout or direction code.
> 
> Adds **`src/i18n/ur-pilot.js`**: ~60 core UI strings (nav, homepage price surface, disclaimers) matching the French pilot key set, plus **`withUrduPilot()`** to attach the `ur` block without mutating the main `TRANSLATIONS` map; uncovered keys still resolve through English.
> 
> **Tests** update shared locale expectations for Urdu activation and add **`tests/ur-pilot.test.js`** (RTL parity with Arabic, EN key coverage, FR key parity, fallback behavior, legal/disclaimer wording). A Phase 40 report doc documents the rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ec47e0c764b7924cbc12d1a3608ad3e2e5ae68b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->