### PR TITLE
Phase 41: content translation policy + first FR batch (noindex until reviewed)

### DIFF
--- a/docs/i18n/content-translation-policy.md
+++ b/docs/i18n/content-translation-policy.md
@@ -1,0 +1,63 @@
+# Content Translation Policy
+
+_Phase 41. Governs how translated **content** is produced, reviewed, and — critically — whether it
+may be indexed. Enforced in code by `src/i18n/translation-status.js`; guarded by
+`tests/translation-status.test.js`._
+
+## The one hard rule
+
+> **Machine-translated (or agent-drafted) content is never indexed until a human reviews it.**
+
+Encoded as `MT_ONLY_INDEXABLE = false`. A translation surface is indexable **only** when its review
+status is `human-reviewed`. Anything else (`pending-human-review`, unknown) is treated as `noindex`.
+
+## Two tiers of translation
+
+| Tier         | What                                  | Examples                         | Indexing                                            |
+| ------------ | ------------------------------------- | -------------------------------- | --------------------------------------------------- |
+| **UI shell** | Hand-authored chrome / labels         | nav, footer, buttons, freshness  | Not indexable _content_ — chrome, not a page's body |
+| **Content**  | Prose that is the substance of a page | methodology, learn articles, FAQ | Governed here — **noindex until human-reviewed**    |
+
+The Phase 39 (French) and Phase 40 (Urdu) pilots are **UI shell**. This phase introduces the first
+**content** batch.
+
+## Workflow for a content batch
+
+1. **Draft** — produce the translation (machine translation or agent-drafted). Register it via a
+   `*_META` descriptor with `status: REVIEW_STATUS.PENDING`.
+2. **Ship dark** — the batch renders for users who explicitly choose the locale, but the SEO layer
+   reads `isBatchIndexable(id) === false` and emits `noindex` (and omits it from the sitemap and
+   from indexable `hreflang` alternates). No unreviewed content reaches search engines.
+3. **Human review** — a human checks the copy — especially the immutable invariants (see below) —
+   and flips the descriptor to `REVIEW_STATUS.REVIEWED`.
+4. **Indexable** — `isBatchIndexable(id)` and `indexableContentLocales()` now include it; the SEO
+   layer may index it and add it to the sitemap / hreflang set.
+
+## Invariants that a reviewer MUST verify before sign-off
+
+Translated content must preserve, verbatim:
+
+- The troy-ounce constant **31.1035** and the AED peg **3.6725**.
+- The pricing formula `price_per_gram_local = (XAU/USD ÷ 31.1035) × karat_factor × local_fx`.
+- The **reference-estimate** framing — every price surface is a spot-linked, bullion-equivalent
+  reference estimate, **not** a retail quote — and "not financial advice".
+
+The Phase 41 tests assert these hold in the first French batch even while it is still `pending`.
+
+## First French content batch
+
+`src/i18n/fr-content-batch-1.js` — the reference **methodology** (23 keys), translated to French.
+Ships `pending-human-review` → **not indexed**. It is a translation of existing `TRANSLATIONS.en`
+keys only (no new strings), and preserves every invariant above.
+
+## How the SEO layer consumes this (adoption)
+
+When emitting robots meta / sitemap entries / hreflang alternates for a translated surface, call
+`isBatchIndexable(id)` (per batch) or `indexableContentLocales()` (per locale). This phase adds the
+decision layer and the first batch; wiring it into the robots/sitemap/hreflang emitters is left to
+the SEO-governance surface so this phase touches no other phase's files.
+
+## $0 / constraints
+
+No dependency, no service, no build cost. Additive modules only; EN/AR untouched; UI-shell pilots
+unaffected.

--- a/reports/i18n/PHASE-41-content-translation-policy.md
+++ b/reports/i18n/PHASE-41-content-translation-policy.md
@@ -1,0 +1,63 @@
+# Phase 41 — Content translation policy + first FR batch (Yellow)
+
+Codifies **how translated content is produced and whether it may be indexed**, and ships the first
+French _content_ batch under that policy. The governing rule — _machine/agent-drafted content is
+never indexed until a human reviews it_ — is enforced in code, not just documented.
+
+> **Stacks on [#577](https://github.com/vctb12/GoldTickerLive/pull/577) → #576 → #575.** Continues
+> the i18n chain (38→39→40→41); based on the Phase-40 branch. Merge order: #575 → #576 → #577 →
+> this.
+
+## What shipped
+
+- **`docs/i18n/content-translation-policy.md`** — the policy: two tiers (UI shell vs content), the
+  MT+human-review workflow, the noindex-until-reviewed rule, and the invariants a reviewer must
+  verify.
+- **`src/i18n/review-status.js`** — shared `REVIEW_STATUS` constants (`PENDING`, `REVIEWED`).
+- **`src/i18n/translation-status.js`** — the enforceable half:
+  - `MT_ONLY_INDEXABLE = false` — the single source of truth for the rule.
+  - `isContentIndexable(status)` — true **only** for `human-reviewed`.
+  - `isBatchIndexable(id)` — per-batch, fails **closed** for unknown ids.
+  - `indexableContentLocales()` — locales with ≥1 reviewed batch (what the SEO layer may index).
+- **`src/i18n/fr-content-batch-1.js`** — the first French **content** batch: the reference
+  methodology (23 keys), translated to French, registered as `pending-human-review` → **not
+  indexed**.
+
+## The "no auto-only indexed" guarantee (enforced)
+
+The French methodology renders for a user who chooses French, but because the batch is
+`pending-human-review`, `isBatchIndexable(...) === false` and `indexableContentLocales() === []` —
+so the SEO layer emits `noindex`, omits it from the sitemap, and drops the indexable hreflang
+alternate. Only a human flipping the status to `human-reviewed` opens the gate. Unknown batch ids
+fail closed.
+
+## Invariants preserved verbatim in French (asserted while still pending)
+
+- Troy-ounce constant **31.1035** (`methodology.stepGram`) and AED peg **3.6725**
+  (`methodology.stepLocal`).
+- The pricing formula preserved character-for-character.
+- Reference-estimate framing ("Estimation de référence", not retail) — the surface stays a
+  spot-linked bullion-equivalent reference estimate.
+
+## Tests — `tests/translation-status.test.js` (7)
+
+MT-only is never indexable and only `human-reviewed` is; the FR batch ships pending → not indexable
+and no content locale is indexable yet; unknown batch → not indexable; the sign-off path opens the
+gate; every batch key exists in `TRANSLATIONS.en` and is a `methodology.*` key; the invariants
+(31.1035 / 3.6725 / formula / reference framing) hold in French; values are non-empty and (bar the
+formula) differ from English.
+
+## Adoption (not done here)
+
+The robots/sitemap/hreflang emitters call `isBatchIndexable(id)` / `indexableContentLocales()` when
+deciding indexability for translated surfaces. This phase adds the decision layer + first batch and
+touches no other phase's files.
+
+## Constraints honoured
+
+$0 / no dependency; EN/AR untouched; UI-shell pilots unaffected; **no unreviewed content is
+indexable**; immutable invariants preserved in the French copy; additive modules only.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (**1315 pass, +7**) + `npm run lint` — all green.

--- a/src/i18n/fr-content-batch-1.js
+++ b/src/i18n/fr-content-batch-1.js
@@ -1,0 +1,61 @@
+/**
+ * i18n/fr-content-batch-1.js — first French *content* batch (Phase 41): the reference methodology.
+ *
+ * Unlike the Phase 39 UI-shell pilot, this is long-form *content* (prose that explains how prices are
+ * derived). Per the content-translation policy (`docs/i18n/content-translation-policy.md`) content
+ * translations ship at review status `pending-human-review` and are therefore **not indexable** until
+ * a human signs off — machine/agent-drafted content is never auto-indexed. Users who choose French
+ * still see it; search engines do not until it is reviewed.
+ *
+ * The immutable invariants are preserved verbatim in the French copy: the troy-ounce constant
+ * `31.1035`, the AED peg `3.6725`, the pricing formula, and the reference-estimate framing (these are
+ * asserted by tests). Every key exists in `TRANSLATIONS.en`.
+ */
+
+import { REVIEW_STATUS } from './review-status.js';
+
+/** @type {Record<string, string>} — French methodology content, keyed by the existing EN key. */
+export const FR_CONTENT_BATCH_1 = {
+  'methodology.sectionTitle': 'La méthodologie en bref',
+  'methodology.sectionSub':
+    'Cours spot → gramme → carat → devise locale, avec des mentions de transparence explicites à chaque étape.',
+  'methodology.title': 'Méthodologie de référence',
+  'methodology.sub': 'Comment nous établissons chaque estimation de référence publiée.',
+  'methodology.stepSpot': 'Partez du cours spot XAU/USD en direct par once troy.',
+  'methodology.stepGram': "Convertissez l'once en gramme à l'aide de 31.1035.",
+  'methodology.stepKarat': 'Appliquez le facteur de pureté du carat pour le titre sélectionné.',
+  'methodology.stepLocal':
+    "Convertissez l'USD/gramme en devise locale (l'AED utilise une parité fixe de 3.6725).",
+  'methodology.formula': 'price_per_gram_local = (XAU/USD ÷ 31.1035) × karat_factor × local_fx',
+  'methodology.karatTableCaption': 'Facteurs de pureté du carat pour les calculs de référence',
+  'methodology.karatHeader': 'Carat',
+  'methodology.purityHeader': 'Pureté',
+  'methodology.factorHeader': 'Facteur',
+  'methodology.referenceDisclaimer':
+    'Estimation de référence uniquement. Les devis en boutique et en bijouterie peuvent inclure des frais de façonnage, des primes et des taxes.',
+  'methodology.vatDisclaimer':
+    'Les hypothèses de TVA et de frais de façonnage doivent être vérifiées sur la facture finale du vendeur.',
+  'methodology.compareChecklistTitle': 'Comment comparer avec un devis en boutique',
+  'methodology.compareChecklist1':
+    "Faites d'abord correspondre le carat et l'unité (gramme/tola/once).",
+  'methodology.compareChecklist2': "Séparez la valeur de l'or pur des frais de façonnage.",
+  'methodology.compareChecklist3': 'Confirmez le traitement de la TVA/taxe sur la facture.',
+  'methodology.compareChecklist4': "Vérifiez l'horodatage et l'état de fraîcheur avant de décider.",
+  'methodology.fullPageLink': 'Ouvrir la méthodologie complète →',
+  'methodology.calculatorLink': 'Ouvrir la calculatrice →',
+  'methodology.trackerLink': 'Ouvrir le suivi →',
+};
+
+/** Keys covered by this batch. */
+export const FR_CONTENT_BATCH_1_KEYS = Object.keys(FR_CONTENT_BATCH_1);
+
+/** Batch descriptor consumed by the translation-status governance. */
+export const FR_CONTENT_BATCH_1_META = {
+  id: 'fr-content-batch-1-methodology',
+  locale: 'fr',
+  tier: 'content',
+  sourceLocale: 'en',
+  // Ships un-reviewed → NOT indexable until a human reviewer flips this. This is the policy default.
+  status: REVIEW_STATUS.PENDING,
+  keyCount: FR_CONTENT_BATCH_1_KEYS.length,
+};

--- a/src/i18n/review-status.js
+++ b/src/i18n/review-status.js
@@ -1,0 +1,12 @@
+/**
+ * i18n/review-status.js — shared review-status constants for translated content (Phase 41).
+ *
+ * Extracted into its own module so both the content batches and the indexability governance can
+ * import it without a circular dependency.
+ */
+
+/** Review states a content batch can be in. */
+export const REVIEW_STATUS = Object.freeze({
+  PENDING: 'pending-human-review',
+  REVIEWED: 'human-reviewed',
+});

--- a/src/i18n/translation-status.js
+++ b/src/i18n/translation-status.js
@@ -1,0 +1,71 @@
+/**
+ * i18n/translation-status.js — governance for translated *content* indexability (Phase 41).
+ *
+ * Codifies the one rule that keeps machine/agent-drafted translations out of the search index:
+ * **content is indexable only after a human review sign-off.** Everything else — a fresh batch, an
+ * MT draft — is `pending-human-review` and is treated as `noindex` by the SEO layer.
+ *
+ * This is the enforceable half of `docs/i18n/content-translation-policy.md`: pages, sitemap, and
+ * hreflang emission consult `isBatchIndexable()` / `indexableContentLocales()` so no un-reviewed
+ * translation can leak into indexable surfaces. UI-shell pilots (Phases 39/40) are a separate tier —
+ * hand-authored chrome, not indexable *content* — and are not governed here.
+ */
+
+import { REVIEW_STATUS } from './review-status.js';
+import { FR_CONTENT_BATCH_1_META } from './fr-content-batch-1.js';
+
+export { REVIEW_STATUS };
+
+/**
+ * Policy invariant: machine-translated-only (i.e. not-yet-human-reviewed) content is NEVER indexable.
+ * This constant exists so the rule is a single, testable source of truth rather than scattered logic.
+ */
+export const MT_ONLY_INDEXABLE = false;
+
+/**
+ * Static registry of every known content batch, keyed by id. New content batches are added here by
+ * importing their `*_META`. UI-shell pilots are intentionally absent (different tier).
+ * @type {Record<string, { id: string, locale: string, tier: string, status: string, keyCount: number }>}
+ */
+const CONTENT_BATCHES = Object.freeze(
+  [FR_CONTENT_BATCH_1_META].reduce((acc, meta) => {
+    acc[meta.id] = meta;
+    return acc;
+  }, {})
+);
+
+/** All registered content batches. */
+export function contentBatches() {
+  return Object.values(CONTENT_BATCHES);
+}
+
+/**
+ * Whether a given review status makes content indexable. Only an explicit human review does; the
+ * MT-only default is governed by {@link MT_ONLY_INDEXABLE} (false).
+ * @param {string} status
+ * @returns {boolean}
+ */
+export function isContentIndexable(status) {
+  if (status === REVIEW_STATUS.REVIEWED) return true;
+  return MT_ONLY_INDEXABLE; // pending / unknown → the MT-only policy (false)
+}
+
+/** Whether a specific registered batch is indexable. Unknown batch → false (fail closed). */
+export function isBatchIndexable(batchId) {
+  const batch = CONTENT_BATCHES[batchId];
+  return batch ? isContentIndexable(batch.status) : false;
+}
+
+/**
+ * Locales that have at least one human-reviewed content batch — i.e. locales whose translated content
+ * may appear in indexable surfaces (sitemap entries, indexable hreflang alternates). Un-reviewed
+ * locales are excluded, so the SEO layer can `noindex` them.
+ * @returns {string[]}
+ */
+export function indexableContentLocales() {
+  const locales = new Set();
+  for (const batch of contentBatches()) {
+    if (isContentIndexable(batch.status)) locales.add(batch.locale);
+  }
+  return [...locales];
+}

--- a/tests/translation-status.test.js
+++ b/tests/translation-status.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+/**
+ * Content-translation policy — proves the "no auto-only indexed" rule is enforced in code: MT-only
+ * content is never indexable, only an explicit human review is, and the first French content batch
+ * ships pending (→ noindex) while preserving the immutable invariants verbatim.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const STATUS = new URL('../src/i18n/translation-status.js', `file://${__filename}`).href;
+const BATCH = new URL('../src/i18n/fr-content-batch-1.js', `file://${__filename}`).href;
+const CFG = new URL('../src/config/index.js', `file://${__filename}`).href;
+
+test('policy: MT-only content is never indexable; only human review is', async () => {
+  const { MT_ONLY_INDEXABLE, isContentIndexable, REVIEW_STATUS } = await import(STATUS);
+  assert.equal(MT_ONLY_INDEXABLE, false);
+  assert.equal(isContentIndexable(REVIEW_STATUS.PENDING), false);
+  assert.equal(isContentIndexable('anything-else'), false);
+  assert.equal(isContentIndexable(undefined), false);
+  assert.equal(isContentIndexable(REVIEW_STATUS.REVIEWED), true);
+});
+
+test('policy: the first FR content batch ships pending → not indexable', async () => {
+  const { isBatchIndexable, indexableContentLocales, contentBatches } = await import(STATUS);
+  const { FR_CONTENT_BATCH_1_META } = await import(BATCH);
+  assert.equal(FR_CONTENT_BATCH_1_META.status, 'pending-human-review');
+  assert.equal(isBatchIndexable(FR_CONTENT_BATCH_1_META.id), false);
+  // No content locale is indexable yet (the only batch is pending).
+  assert.deepEqual(indexableContentLocales(), []);
+  // The batch is registered in the governance registry.
+  assert.ok(contentBatches().some((b) => b.id === FR_CONTENT_BATCH_1_META.id));
+});
+
+test('policy: unknown batch ids fail closed (not indexable)', async () => {
+  const { isBatchIndexable } = await import(STATUS);
+  assert.equal(isBatchIndexable('no-such-batch'), false);
+});
+
+test('policy: a reviewed status WOULD make it indexable (sign-off path works)', async () => {
+  const { isContentIndexable, indexableContentLocales, REVIEW_STATUS } = await import(STATUS);
+  // Direct proof the gate opens on review without mutating the shipped (pending) batch.
+  assert.equal(isContentIndexable(REVIEW_STATUS.REVIEWED), true);
+  // Sanity: with only a pending batch registered, no locale is indexable.
+  assert.ok(!indexableContentLocales().includes('fr'));
+});
+
+test('fr-content-batch-1: every key exists in TRANSLATIONS.en (no orphan strings)', async () => {
+  const { FR_CONTENT_BATCH_1_KEYS } = await import(BATCH);
+  const { TRANSLATIONS } = await import(CFG);
+  const enKeys = new Set(Object.keys(TRANSLATIONS.en));
+  const orphans = FR_CONTENT_BATCH_1_KEYS.filter((k) => !enKeys.has(k));
+  assert.deepEqual(orphans, [], 'batch must only translate existing EN keys');
+  assert.ok(FR_CONTENT_BATCH_1_KEYS.every((k) => k.startsWith('methodology.')));
+});
+
+test('fr-content-batch-1: immutable invariants preserved verbatim in French', async () => {
+  const { FR_CONTENT_BATCH_1 } = await import(BATCH);
+  // Troy-ounce constant and AED peg carried through exactly.
+  assert.match(FR_CONTENT_BATCH_1['methodology.stepGram'], /31\.1035/);
+  assert.match(FR_CONTENT_BATCH_1['methodology.stepLocal'], /3\.6725/);
+  // The formula is preserved character-for-character.
+  assert.equal(
+    FR_CONTENT_BATCH_1['methodology.formula'],
+    'price_per_gram_local = (XAU/USD ÷ 31.1035) × karat_factor × local_fx'
+  );
+  // Reference-estimate framing survives translation (not retail).
+  assert.match(FR_CONTENT_BATCH_1['methodology.referenceDisclaimer'], /Estimation de référence/i);
+});
+
+test('fr-content-batch-1: French values are non-empty and (bar the formula) differ from English', async () => {
+  const { FR_CONTENT_BATCH_1 } = await import(BATCH);
+  const { TRANSLATIONS } = await import(CFG);
+  let differ = 0;
+  for (const [key, value] of Object.entries(FR_CONTENT_BATCH_1)) {
+    assert.equal(typeof value, 'string');
+    assert.ok(value.trim().length > 0, `empty value for ${key}`);
+    if (value !== TRANSLATIONS.en[key]) differ += 1;
+  }
+  // Only the formula (and code-like headers) may legitimately match EN.
+  assert.ok(differ >= Object.keys(FR_CONTENT_BATCH_1).length - 2);
+});


### PR DESCRIPTION
## Phase 41 — Content translation policy + first FR batch (Yellow)

Codifies **how translated content is produced and whether it may be indexed**, and ships the first French *content* batch under that policy. The governing rule — *machine/agent-drafted content is never indexed until a human reviews it* — is enforced in code, not just documented.

> **Stacks on #577 → #576 → #575.** Continues the i18n chain (38→39→40→41); based on the Phase-40 branch. Merge order: #575 → #576 → #577 → this.

### What shipped
- **`docs/i18n/content-translation-policy.md`** — the policy: two tiers (UI shell vs content), the MT+human-review workflow, the noindex-until-reviewed rule, and the invariants a reviewer must verify.
- **`src/i18n/review-status.js`** — shared `REVIEW_STATUS` constants (`PENDING`, `REVIEWED`).
- **`src/i18n/translation-status.js`** — the enforceable half:
  - `MT_ONLY_INDEXABLE = false` — the single source of truth for the rule.
  - `isContentIndexable(status)` — true **only** for `human-reviewed`.
  - `isBatchIndexable(id)` — per-batch, fails **closed** for unknown ids.
  - `indexableContentLocales()` — locales with ≥1 reviewed batch (what the SEO layer may index).
- **`src/i18n/fr-content-batch-1.js`** — the first French **content** batch: the reference methodology (23 keys), translated to French, registered as `pending-human-review` → **not indexed**.

### The "no auto-only indexed" guarantee (enforced)
The French methodology renders for a user who chooses French, but because the batch is `pending-human-review`, `isBatchIndexable(...) === false` and `indexableContentLocales() === []` — so the SEO layer emits `noindex`, omits it from the sitemap, and drops the indexable hreflang alternate. Only a human flipping the status to `human-reviewed` opens the gate. Unknown batch ids fail closed.

### Invariants preserved verbatim in French (asserted while still pending)
- Troy-ounce constant **31.1035** (`methodology.stepGram`) and AED peg **3.6725** (`methodology.stepLocal`).
- The pricing formula preserved character-for-character.
- Reference-estimate framing ("Estimation de référence", not retail).

### Tests — `tests/translation-status.test.js` (7)
MT-only is never indexable and only `human-reviewed` is; the FR batch ships pending → not indexable and no content locale is indexable yet; unknown batch → not indexable; the sign-off path opens the gate; every batch key exists in `TRANSLATIONS.en` and is a `methodology.*` key; the invariants (31.1035 / 3.6725 / formula / reference framing) hold in French; values non-empty and (bar the formula) differ from English.

### Adoption (not done here)
The robots/sitemap/hreflang emitters call `isBatchIndexable(id)` / `indexableContentLocales()` when deciding indexability for translated surfaces. This phase adds the decision layer + first batch and touches no other phase's files.

### Constraints honoured
$0 / no dependency; EN/AR untouched; UI-shell pilots unaffected; **no unreviewed content is indexable**; immutable invariants preserved in the French copy; additive modules only.

### Gate
`npm run build` + `npm run validate` + `npm test` (**1315 pass, +7**) + `npm run lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive i18n modules and tests only; no SEO wiring or changes to EN/AR or existing UI-shell pilots.
> 
> **Overview**
> Introduces a **content translation policy** (documented and enforced in code) that treats machine- or agent-drafted prose as **not indexable** until review status is `human-reviewed`, via `MT_ONLY_INDEXABLE = false` and helpers in `translation-status.js` (`isContentIndexable`, `isBatchIndexable`, `indexableContentLocales`).
> 
> Ships **`review-status.js`**, a batch registry, and **`fr-content-batch-1.js`** — 23 French `methodology.*` strings with `pending-human-review` metadata so French users can see the copy while indexable locales stay empty until sign-off. **Seven tests** lock policy behavior, orphan-key checks, and verbatim invariants (31.1035, 3.6725, formula, reference-estimate framing).
> 
> **Adoption is deferred:** robots, sitemap, and hreflang are expected to call the new APIs later; this phase does not change those emitters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a640756f9ca4657319ea37f5c0d5cc1f697f7c05. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->