### PR TITLE
Phase 42: PWA hardening / installability (sw.js recommend-only)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,11 @@
 {
+  "id": "/",
   "name": "Gold Ticker Live — Reference Gold Price Tracker",
   "short_name": "Gold Ticker Live",
   "description": "Gold Ticker Live — reference gold prices for the UAE, GCC and the Arab world. Track 24K, 22K, 21K, 18K gold in 24+ currencies.",
   "start_url": "/",
   "scope": "/",
+  "dir": "ltr",
   "display": "standalone",
   "orientation": "any",
   "background_color": "#fdfbf5",

--- a/reports/pwa/PHASE-42-pwa-hardening.md
+++ b/reports/pwa/PHASE-42-pwa-hardening.md
@@ -1,0 +1,54 @@
+# Phase 42 — PWA hardening / installability (Green)
+
+The "mobile app" is the PWA (React Native remains out of scope). This phase hardens installability
+with **additive, tested tooling** plus a small safe manifest improvement — and, because `sw.js` is
+owner-gated, records service-worker suggestions as **recommend-only**.
+
+## What shipped
+
+- **`manifest.json`** — two safe hardening additions:
+  - `"id": "/"` — a stable app identity (prevents the browser treating scope/start_url changes as a
+    different app; recommended by Chromium).
+  - `"dir": "ltr"` — declared base direction.
+  - Everything else was already solid (name/short_name, `display: standalone`, 192 + 512 +
+    **maskable 512** icons, `theme_color`, categories, shortcuts).
+- **`src/pwa/manifest-audit.js`** — a pure installability auditor. `auditManifest(manifest)` →
+  `{ installable, errors, warnings }` against the Chromium/A2HS criteria (name/short_name,
+  start_url, installable `display`, ≥192 & ≥512 icons) with recommended-hardening warnings (maskable
+  icon, `theme_color`, `background_color`, `id`, `short_name`, `screenshots`, `categories`). No I/O,
+  no DOM.
+- **`src/pwa/install-controller.js`** — a reusable, dependency-injected A2HS controller: the shared
+  version of the inline `beforeinstallprompt` handling. `createInstallController({ win })` →
+  `{ init, canInstall, isInstalled, promptInstall, getState, subscribe }`. Suppresses the
+  mini-infobar, stores the deferred prompt (single-use), and detects installed state via
+  `display-mode: standalone` **and** iOS `navigator.standalone`. SSR/no-DOM safe. Does **not** touch
+  the service worker.
+
+Both modules are additive/unimported → tree-shaken; the existing home-page install banner is left
+untouched (it belongs to the homepage surface).
+
+## Audit result for the committed manifest
+
+`auditManifest(manifest.json)` → **installable: true**, no `id`/`maskable`/`theme_color` warnings
+after this phase. The one remaining recommendation is **`screenshots`** (still empty) — populating
+it enriches the desktop/Android install dialog. Not added here because it needs real,
+license-registered device screenshots (see `assets/MANIFEST.md`), which is an asset-pipeline task.
+
+## Recommend-only (owner-gated `sw.js`)
+
+Not modified. Suggestions for the owner, to be applied to `sw.js` directly:
+
+- Confirm the offline fallback (`offline.html`) is precached and served for navigations when the
+  network is unavailable — the biggest installed-app reliability win.
+- Consider a `navigationPreload` + stale-while-revalidate strategy for the shell so the installed
+  app opens instantly, and versioned cache names so old caches are cleaned on activate.
+- Keep the SW scope aligned with the manifest `scope` (`/`).
+
+## Constraints honoured
+
+$0 / no dependency; `sw.js` untouched (recommend-only); RN out of scope; additive modules; no other
+phase's page files touched; manifest change limited to safe identity/direction fields.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (**1298 pass, +12**) + `npm run lint` — all green.

--- a/src/pwa/install-controller.js
+++ b/src/pwa/install-controller.js
@@ -1,0 +1,89 @@
+/**
+ * pwa/install-controller.js — reusable, DI'd add-to-home-screen (A2HS) controller (Phase 42).
+ *
+ * A shared, framework-agnostic version of the inline `beforeinstallprompt` handling: captures the
+ * deferred install event, tracks installed/standalone state, and exposes a clean surface any page can
+ * mount an install button on — without each page re-implementing the event dance. The `window` is
+ * injected so it is fully unit-testable (and SSR/no-DOM safe). It does NOT touch the service worker.
+ *
+ * Usage:
+ *   const install = createInstallController();
+ *   install.init();
+ *   install.subscribe((state) => renderButton(state.canInstall));
+ *   button.onclick = () => install.promptInstall();
+ */
+
+/** @returns {Window | undefined} */
+function defaultWindow() {
+  return typeof window === 'undefined' ? undefined : window;
+}
+
+/**
+ * @param {{ win?: any }} [options]
+ */
+export function createInstallController(options = {}) {
+  const win = options.win ?? defaultWindow();
+  let deferredPrompt = null;
+  let installed = false;
+  const listeners = new Set();
+
+  function isStandalone() {
+    if (!win) return false;
+    const mm = typeof win.matchMedia === 'function' && win.matchMedia('(display-mode: standalone)');
+    // iOS Safari exposes navigator.standalone instead of the display-mode media query.
+    return Boolean((mm && mm.matches) || win.navigator?.standalone === true);
+  }
+
+  function isInstalled() {
+    return installed || isStandalone();
+  }
+
+  function canInstall() {
+    return Boolean(deferredPrompt) && !isInstalled();
+  }
+
+  function getState() {
+    return { canInstall: canInstall(), installed: isInstalled() };
+  }
+
+  function notify() {
+    const state = getState();
+    for (const fn of listeners) fn(state);
+  }
+
+  function subscribe(fn) {
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+  }
+
+  function init() {
+    if (!win || typeof win.addEventListener !== 'function') return;
+    win.addEventListener('beforeinstallprompt', (event) => {
+      // Suppress the mini-infobar so the app controls when/where to offer install.
+      if (event && typeof event.preventDefault === 'function') event.preventDefault();
+      deferredPrompt = event;
+      notify();
+    });
+    win.addEventListener('appinstalled', () => {
+      deferredPrompt = null;
+      installed = true;
+      notify();
+    });
+  }
+
+  /**
+   * Trigger the browser install prompt.
+   * @returns {Promise<{ outcome: 'accepted'|'dismissed'|'unavailable' }>}
+   */
+  async function promptInstall() {
+    if (!deferredPrompt) return { outcome: 'unavailable' };
+    const event = deferredPrompt;
+    deferredPrompt = null; // a deferred prompt can only be used once
+    event.prompt();
+    const choice = (await event.userChoice) || {};
+    notify();
+    return { outcome: choice.outcome === 'accepted' ? 'accepted' : 'dismissed' };
+  }
+
+  return { init, canInstall, isInstalled, promptInstall, getState, subscribe };
+}

--- a/src/pwa/manifest-audit.js
+++ b/src/pwa/manifest-audit.js
@@ -1,0 +1,65 @@
+/**
+ * pwa/manifest-audit.js — pure web-app-manifest installability auditor (Phase 42).
+ *
+ * Given a parsed manifest object, report whether it satisfies the baseline installability criteria
+ * (the Chromium/Android + iOS add-to-home-screen requirements) and which recommended fields are
+ * missing. No I/O, no DOM — just validation, so it can run in CI against the committed `manifest.json`
+ * and against any candidate manifest. It never mutates the input.
+ *
+ * `errors` block installability; `warnings` are recommended-but-optional hardening.
+ */
+
+const INSTALLABLE_DISPLAYS = new Set(['standalone', 'fullscreen', 'minimal-ui']);
+
+/** Largest square icon edge (px) declared for a given purpose, 0 if none. `any`-sized icons count. */
+function maxIconEdge(icons, purpose) {
+  let max = 0;
+  for (const icon of icons) {
+    const purposes = String(icon.purpose || 'any').split(/\s+/);
+    if (purpose && !purposes.includes(purpose)) continue;
+    for (const token of String(icon.sizes || '').split(/\s+/)) {
+      if (token === 'any') {
+        max = Math.max(max, Infinity);
+        continue;
+      }
+      const edge = Number(token.split('x')[0]);
+      if (Number.isFinite(edge)) max = Math.max(max, edge);
+    }
+  }
+  return max;
+}
+
+/**
+ * Audit a manifest object for installability.
+ * @param {object} manifest
+ * @returns {{ installable: boolean, errors: string[], warnings: string[] }}
+ */
+export function auditManifest(manifest) {
+  const errors = [];
+  const warnings = [];
+  const m = manifest || {};
+  const icons = Array.isArray(m.icons) ? m.icons : [];
+
+  // ── Hard requirements ──────────────────────────────────────────────────────
+  if (!m.name && !m.short_name) errors.push('missing name and short_name');
+  if (!m.start_url) errors.push('missing start_url');
+  if (!INSTALLABLE_DISPLAYS.has(m.display)) {
+    errors.push(`display must be one of ${[...INSTALLABLE_DISPLAYS].join(', ')}`);
+  }
+  const anyEdge = maxIconEdge(icons, null);
+  if (anyEdge < 192) errors.push('needs an icon of at least 192px');
+  if (anyEdge < 512) errors.push('needs an icon of at least 512px');
+
+  // ── Recommended hardening ──────────────────────────────────────────────────
+  if (maxIconEdge(icons, 'maskable') < 192) warnings.push('add a maskable icon (>=192px)');
+  if (!m.theme_color) warnings.push('add theme_color');
+  if (!m.background_color) warnings.push('add background_color');
+  if (!m.id) warnings.push('add id for a stable app identity');
+  if (!m.short_name) warnings.push('add short_name for the home-screen label');
+  if (!Array.isArray(m.screenshots) || m.screenshots.length === 0) {
+    warnings.push('add screenshots for a richer install dialog');
+  }
+  if (!Array.isArray(m.categories) || m.categories.length === 0) warnings.push('add categories');
+
+  return { installable: errors.length === 0, errors, warnings };
+}

--- a/tests/pwa-install-controller.test.js
+++ b/tests/pwa-install-controller.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * PWA install controller — proves the beforeinstallprompt/appinstalled state machine with an injected
+ * fake window: install becomes available on the deferred event, the prompt resolves accepted/dismissed
+ * and is single-use, installed/standalone detection works (display-mode + iOS navigator.standalone),
+ * and a no-DOM environment is safe.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const CTRL = new URL('../src/pwa/install-controller.js', `file://${__filename}`).href;
+
+function makeWin({ standaloneMedia = false, navStandalone = undefined } = {}) {
+  const handlers = {};
+  return {
+    addEventListener(type, fn) {
+      (handlers[type] ||= []).push(fn);
+    },
+    _emit(type, event) {
+      (handlers[type] || []).forEach((fn) => fn(event));
+    },
+    matchMedia() {
+      return { matches: standaloneMedia };
+    },
+    navigator: { standalone: navStandalone },
+  };
+}
+
+function bipEvent(outcome = 'accepted') {
+  let prompted = false;
+  return {
+    preventDefault() {
+      this._prevented = true;
+    },
+    prompt() {
+      prompted = true;
+    },
+    get _wasPrompted() {
+      return prompted;
+    },
+    userChoice: Promise.resolve({ outcome }),
+  };
+}
+
+test('install: beforeinstallprompt makes install available and notifies subscribers', async () => {
+  const { createInstallController } = await import(CTRL);
+  const win = makeWin();
+  const ctrl = createInstallController({ win });
+  const states = [];
+  ctrl.subscribe((s) => states.push(s));
+  ctrl.init();
+  assert.equal(ctrl.canInstall(), false);
+
+  const ev = bipEvent();
+  win._emit('beforeinstallprompt', ev);
+  assert.equal(ev._prevented, true); // mini-infobar suppressed
+  assert.equal(ctrl.canInstall(), true);
+  assert.deepEqual(states.at(-1), { canInstall: true, installed: false });
+});
+
+test('install: promptInstall accepts, is single-use, and reports outcome', async () => {
+  const { createInstallController } = await import(CTRL);
+  const win = makeWin();
+  const ctrl = createInstallController({ win });
+  ctrl.init();
+  win._emit('beforeinstallprompt', bipEvent('accepted'));
+
+  const res = await ctrl.promptInstall();
+  assert.deepEqual(res, { outcome: 'accepted' });
+  // Deferred prompt is consumed → no longer installable, second prompt unavailable.
+  assert.equal(ctrl.canInstall(), false);
+  assert.deepEqual(await ctrl.promptInstall(), { outcome: 'unavailable' });
+});
+
+test('install: a dismissed choice is reported as dismissed', async () => {
+  const { createInstallController } = await import(CTRL);
+  const win = makeWin();
+  const ctrl = createInstallController({ win });
+  ctrl.init();
+  win._emit('beforeinstallprompt', bipEvent('dismissed'));
+  assert.deepEqual(await ctrl.promptInstall(), { outcome: 'dismissed' });
+});
+
+test('install: promptInstall with no deferred event is unavailable', async () => {
+  const { createInstallController } = await import(CTRL);
+  const ctrl = createInstallController({ win: makeWin() });
+  ctrl.init();
+  assert.deepEqual(await ctrl.promptInstall(), { outcome: 'unavailable' });
+});
+
+test('install: appinstalled marks installed and disables install', async () => {
+  const { createInstallController } = await import(CTRL);
+  const win = makeWin();
+  const ctrl = createInstallController({ win });
+  ctrl.init();
+  win._emit('beforeinstallprompt', bipEvent());
+  assert.equal(ctrl.canInstall(), true);
+  win._emit('appinstalled', {});
+  assert.equal(ctrl.isInstalled(), true);
+  assert.equal(ctrl.canInstall(), false);
+});
+
+test('install: standalone display-mode and iOS navigator.standalone count as installed', async () => {
+  const { createInstallController } = await import(CTRL);
+  const byMedia = createInstallController({ win: makeWin({ standaloneMedia: true }) });
+  assert.equal(byMedia.isInstalled(), true);
+  const byIos = createInstallController({ win: makeWin({ navStandalone: true }) });
+  assert.equal(byIos.isInstalled(), true);
+  // Even with a deferred prompt, an already-installed app should not offer install.
+  const win = makeWin({ standaloneMedia: true });
+  const ctrl = createInstallController({ win });
+  ctrl.init();
+  win._emit('beforeinstallprompt', bipEvent());
+  assert.equal(ctrl.canInstall(), false);
+});
+
+test('install: no-DOM environment is safe', async () => {
+  const { createInstallController } = await import(CTRL);
+  const ctrl = createInstallController({ win: undefined });
+  ctrl.init(); // no throw
+  assert.equal(ctrl.isInstalled(), false);
+  assert.equal(ctrl.canInstall(), false);
+  assert.deepEqual(await ctrl.promptInstall(), { outcome: 'unavailable' });
+});

--- a/tests/pwa-manifest-audit.test.js
+++ b/tests/pwa-manifest-audit.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * PWA manifest auditor — proves it flags the real installability blockers, surfaces recommended
+ * hardening as warnings, and confirms the committed manifest.json is installable.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const AUDIT = new URL('../src/pwa/manifest-audit.js', `file://${__filename}`).href;
+const ROOT = path.resolve(__dirname, '..');
+
+const GOOD = {
+  id: '/',
+  name: 'App',
+  short_name: 'App',
+  start_url: '/',
+  display: 'standalone',
+  theme_color: '#000',
+  background_color: '#fff',
+  categories: ['finance'],
+  screenshots: [{ src: 's.png' }],
+  icons: [
+    { src: 'i192.png', sizes: '192x192', purpose: 'any' },
+    { src: 'i512.png', sizes: '512x512', purpose: 'any' },
+    { src: 'm.png', sizes: '512x512', purpose: 'maskable' },
+  ],
+};
+
+test('manifest-audit: a complete manifest is installable with no warnings', async () => {
+  const { auditManifest } = await import(AUDIT);
+  const res = auditManifest(GOOD);
+  assert.equal(res.installable, true);
+  assert.deepEqual(res.errors, []);
+  assert.deepEqual(res.warnings, []);
+});
+
+test('manifest-audit: missing icons / bad display block installability', async () => {
+  const { auditManifest } = await import(AUDIT);
+  const noIcons = auditManifest({ name: 'A', start_url: '/', display: 'standalone', icons: [] });
+  assert.equal(noIcons.installable, false);
+  assert.ok(noIcons.errors.some((e) => /192px/.test(e)));
+  assert.ok(noIcons.errors.some((e) => /512px/.test(e)));
+
+  const badDisplay = auditManifest({ ...GOOD, display: 'browser' });
+  assert.equal(badDisplay.installable, false);
+  assert.ok(badDisplay.errors.some((e) => /display must be/.test(e)));
+
+  const noName = auditManifest({ ...GOOD, name: undefined, short_name: undefined });
+  assert.equal(noName.installable, false);
+  assert.ok(noName.errors.some((e) => /name/.test(e)));
+});
+
+test('manifest-audit: recommended fields surface as warnings, not errors', async () => {
+  const { auditManifest } = await import(AUDIT);
+  // Installable but sparse: no maskable, no theme_color, no id, no screenshots, no categories.
+  const sparse = {
+    name: 'A',
+    start_url: '/',
+    display: 'standalone',
+    icons: [
+      { src: 'i192.png', sizes: '192x192' },
+      { src: 'i512.png', sizes: '512x512' },
+    ],
+  };
+  const res = auditManifest(sparse);
+  assert.equal(res.installable, true);
+  assert.ok(res.warnings.some((w) => /maskable/.test(w)));
+  assert.ok(res.warnings.some((w) => /theme_color/.test(w)));
+  assert.ok(res.warnings.some((w) => /\bid\b/.test(w)));
+  assert.ok(res.warnings.some((w) => /screenshots/.test(w)));
+});
+
+test('manifest-audit: an "any"-sized icon satisfies the size requirements', async () => {
+  const { auditManifest } = await import(AUDIT);
+  const svgOnly = {
+    name: 'A',
+    start_url: '/',
+    display: 'standalone',
+    icons: [{ src: 'i.svg', sizes: 'any', type: 'image/svg+xml' }],
+  };
+  assert.equal(auditManifest(svgOnly).installable, true);
+});
+
+test('manifest-audit: committed manifest.json is installable', async () => {
+  const { auditManifest } = await import(AUDIT);
+  const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifest.json'), 'utf8'));
+  const res = auditManifest(manifest);
+  assert.equal(res.installable, true, `errors: ${res.errors.join('; ')}`);
+  // Phase 42 hardening: id present, maskable icon present, theme_color present.
+  assert.equal(manifest.id, '/');
+  assert.ok(!res.warnings.some((w) => /maskable/.test(w)));
+  assert.ok(!res.warnings.some((w) => /theme_color/.test(w)));
+  assert.ok(!res.warnings.some((w) => /\bid\b/.test(w)));
+});


### PR DESCRIPTION
## Phase 42 — PWA hardening / installability (Green)

The "mobile app" is the PWA (React Native remains out of scope). This phase hardens installability with **additive, tested tooling** plus a small safe manifest improvement — and, because `sw.js` is owner-gated, records service-worker suggestions as **recommend-only**.

### What shipped
- **`manifest.json`** — two safe hardening additions:
  - `"id": "/"` — a stable app identity (prevents the browser treating scope/start_url changes as a different app; recommended by Chromium).
  - `"dir": "ltr"` — declared base direction.
  - Everything else was already solid (name/short_name, `display: standalone`, 192 + 512 + **maskable 512** icons, `theme_color`, categories, shortcuts).
- **`src/pwa/manifest-audit.js`** — a pure installability auditor. `auditManifest(manifest)` → `{ installable, errors, warnings }` against the Chromium/A2HS criteria (name/short_name, start_url, installable `display`, ≥192 & ≥512 icons) with recommended-hardening warnings (maskable icon, `theme_color`, `background_color`, `id`, `short_name`, `screenshots`, `categories`). No I/O, no DOM.
- **`src/pwa/install-controller.js`** — a reusable, dependency-injected A2HS controller: the shared version of the inline `beforeinstallprompt` handling. `createInstallController({ win })` → `{ init, canInstall, isInstalled, promptInstall, getState, subscribe }`. Suppresses the mini-infobar, stores the deferred prompt (single-use), and detects installed state via `display-mode: standalone` **and** iOS `navigator.standalone`. SSR/no-DOM safe. Does **not** touch the service worker.

Both modules are additive/unimported → tree-shaken; the existing home-page install banner is left untouched (it belongs to the homepage surface).

### Audit result for the committed manifest
`auditManifest(manifest.json)` → **installable: true**, no `id`/`maskable`/`theme_color` warnings after this phase. The one remaining recommendation is **`screenshots`** (still empty) — populating it enriches the desktop/Android install dialog. Not added here because it needs real, license-registered device screenshots (see `assets/MANIFEST.md`), an asset-pipeline task.

### Recommend-only (owner-gated `sw.js`)
Not modified. Suggestions for the owner, to apply to `sw.js` directly:
- Confirm the offline fallback (`offline.html`) is precached and served for navigations when the network is unavailable.
- Consider `navigationPreload` + stale-while-revalidate for the shell, and versioned cache names cleaned on activate.
- Keep the SW scope aligned with the manifest `scope` (`/`).

### Constraints honoured
$0 / no dependency; `sw.js` untouched (recommend-only); RN out of scope; additive modules; no other phase's page files touched; manifest change limited to safe identity/direction fields.

### Gate
`npm run build` + `npm run validate` + `npm test` (**1298 pass, +12**) + `npm run lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive libraries and two safe manifest fields only; no service worker or live page wiring changes.
> 
> **Overview**
> **Phase 42** tightens PWA installability with a small **`manifest.json`** update (`id: "/"`, `dir: "ltr"`) and new **additive, tree-shaken** helpers under `src/pwa/`.
> 
> **`auditManifest`** validates installability (errors vs. optional hardening warnings) so CI/tests can assert the committed manifest stays installable. **`createInstallController`** centralizes deferred `beforeinstallprompt` handling, standalone/iOS installed detection, and single-use `promptInstall` — the existing homepage install banner is **not** switched over yet.
> 
> A phase report documents **recommend-only** `sw.js` ideas (offline precache, cache strategy); **`sw.js` is unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd5f323a50078da1fc5756bec58f69fc4b50fbb0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->