### PR TITLE
Phase 43: descriptive market-analysis module (template-based, no LLM/forecasts)

### DIFF
--- a/reports/analysis/PHASE-43-market-analysis.md
+++ b/reports/analysis/PHASE-43-market-analysis.md
@@ -1,0 +1,53 @@
+# Phase 43 — Descriptive market-analysis module (Yellow)
+
+A client-side, **template-based** generator that turns factual gold price data into a plain-language
+_description_ — never a forecast, a recommendation, or an invented cause. It mirrors the honesty
+rules of the backend `server/services/ai-drafts.js` on the client, and bakes them into a CI guard.
+
+## What shipped
+
+- **`src/analysis/market-analysis.js`**
+  - `buildMarketAnalysis(input, { lang })` — from
+    `{ price, previous, dayOpen, high, low, rangeDays, timestamp, reason }` produces
+    `{ status, headline, sentences[], movement, dataTimestamp, disclaimer }`. Sentences state,
+    factually: the current reference price, the change vs the previous reading (with a magnitude
+    band), the change vs the Dubai session open, and the reference range.
+  - `assertDescriptiveOnly(text)` — throws on forecast/advice vocabulary (`will`, `expected to`,
+    `forecast`, `buy`, `sell`, `bullish`, `target price`, …) **and** invented-cause vocabulary
+    (`because`, `due to`, `driven by`, …). Exported so callers can validate injected `reason` text.
+  - Bilingual (EN/AR); every result — including `unavailable` — carries the spot-linked
+    reference-estimate disclaimer.
+
+## The honesty contract (enforced, not just intended)
+
+- **No LLM.** Pure deterministic string templates filled from data.
+- **No forecasts / no advice.** It says what the numbers _are_, never what they _will_ do or what to
+  _do_ about them. A test runs `assertDescriptiveOnly()` over the full generated output.
+- **No invented causes.** It never says _why_ a price moved. A caller may pass `reason`, which is
+  rendered with an explicit **"Unconfirmed context, not a stated cause"** label (mirroring the
+  backend speculation label) — factual observation only.
+- **Magnitude is descriptive.** Bands (`unchanged` → `little changed` → `modest` → `notable` →
+  `sharp`) classify |%change| after the fact; they never imply direction of a _future_ move.
+
+## Tests — `tests/market-analysis.test.js` (9)
+
+Unavailable on bad price (still discloses); up / down / unchanged described correctly; magnitude
+bands classify by |pct| only; day-open and range sentences appear with the right numbers; the full
+generated output passes `assertDescriptiveOnly`; the guard rejects forecasts, advice, and invented
+causes; a supplied `reason` renders unconfirmed (no cause words); Arabic localises and the timestamp
+is echoed.
+
+## Relationship to existing surfaces
+
+Complements the backend `ai-drafts.js` (editorial drafts, human-reviewed) with an in-page
+descriptive summary the Market-insights / tracker surfaces can render. Additive/unimported →
+tree-shaken; no page files touched.
+
+## Constraints honoured
+
+$0 / no dependency; no LLM; **no forecasts / predictions** (excluded by policy and by the guard); no
+invented causes; reference-estimate framing on every result; additive module only.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (**1295 pass, +9**) + `npm run lint` — all green.

--- a/src/analysis/market-analysis.js
+++ b/src/analysis/market-analysis.js
@@ -1,0 +1,201 @@
+/**
+ * analysis/market-analysis.js — template-based, descriptive market-analysis text (Phase 43).
+ *
+ * Turns factual gold price data into a plain-language *description* of what the numbers are — never a
+ * forecast, a recommendation, or an invented cause. It mirrors the honesty rules of the backend
+ * `server/services/ai-drafts.js` on the client:
+ *
+ *   - **No LLM.** Pure string templates filled from data. Deterministic.
+ *   - **No forecasts / no advice.** It states what happened, not what will happen or what to do.
+ *   - **No invented causes.** It never says *why* a price moved. A caller may pass an explicit
+ *     `reason`, which is rendered with an "unconfirmed" label — factual observation only.
+ *   - **Always disclosed.** Every result carries the spot-linked reference-estimate disclaimer.
+ *
+ * The generator is deliberately conservative: `assertDescriptiveOnly()` (used by tests) scans output
+ * for forecast/advice vocabulary so a regression that introduces "will rise", "buy", "bullish", etc.
+ * fails CI.
+ */
+
+const FORECAST_PATTERNS =
+  /\b(will|won't|going to|expected to|forecast|predict|projection|outlook|likely to|could (?:rise|fall|reach|hit)|should (?:buy|sell|invest)|buy|sell|target price|undervalued|overvalued|bullish|bearish|rally ahead|set to)\b/i;
+
+const CAUSE_PATTERNS =
+  /\b(because|due to|driven by|on the back of|thanks to|owing to|as a result of)\b/i;
+
+/** Movement magnitude bands by absolute % change — descriptive only, never predictive. */
+const MAGNITUDE = [
+  { key: 'unchanged', max: 0.05, en: 'unchanged', ar: 'دون تغيير' },
+  { key: 'little-changed', max: 0.25, en: 'little changed', ar: 'شبه مستقر' },
+  { key: 'modest', max: 1, en: 'modestly', ar: 'بشكل طفيف' },
+  { key: 'notable', max: 2.5, en: 'notably', ar: 'بشكل ملحوظ' },
+  { key: 'sharp', max: Infinity, en: 'sharply', ar: 'بشكل حاد' },
+];
+
+function pickLang(lang) {
+  return lang === 'ar' ? 'ar' : 'en';
+}
+
+function fmtUsd(n) {
+  return `$${Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function fmtPct(n) {
+  return `${Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%`;
+}
+
+function classifyMagnitude(pct) {
+  const mag = Math.abs(pct);
+  return MAGNITUDE.find((band) => mag < band.max) || MAGNITUDE[MAGNITUDE.length - 1];
+}
+
+const DISCLAIMER = {
+  en: 'Spot-linked bullion-equivalent reference estimate only — not retail pricing, not a forecast, and not financial advice.',
+  ar: 'تقدير مرجعي مبني على السعر الفوري وما يعادله من السبائك فقط — وليس سعر تجزئة ولا توقعًا ولا نصيحة مالية.',
+};
+
+const DIRECTION = {
+  up: { en: 'higher than', ar: 'أعلى من' },
+  down: { en: 'lower than', ar: 'أقل من' },
+};
+
+/**
+ * Build a descriptive market-analysis view model from factual price data.
+ *
+ * @param {object} input
+ * @param {number} input.price          Current reference XAU/USD per ounce (required, > 0).
+ * @param {number} [input.previous]     Previous reference reading (for change).
+ * @param {number} [input.dayOpen]      Session-open reference (for vs-open change).
+ * @param {number} [input.high]         Range high over `rangeDays`.
+ * @param {number} [input.low]          Range low over `rangeDays`.
+ * @param {number} [input.rangeDays]    Window length for the range sentence.
+ * @param {string} [input.timestamp]    Data timestamp to echo (as given, not generated).
+ * @param {string} [input.reason]       OPTIONAL caller-supplied context; rendered as unconfirmed.
+ * @param {{lang?: 'en'|'ar'}} [options]
+ * @returns {{
+ *   status: 'ok'|'unavailable',
+ *   headline?: string,
+ *   sentences?: string[],
+ *   movement?: { key: string, direction: 'up'|'down'|'flat', pctChange: number|null, absChange: number|null },
+ *   dataTimestamp?: string|null,
+ *   disclaimer: string,
+ * }}
+ */
+export function buildMarketAnalysis(input = {}, options = {}) {
+  const lang = pickLang(options.lang);
+  const disclaimer = DISCLAIMER[lang];
+  const price = Number(input.price);
+  if (!Number.isFinite(price) || price <= 0) {
+    return { status: 'unavailable', disclaimer };
+  }
+
+  const sentences = [];
+  const headline =
+    lang === 'ar'
+      ? `السعر المرجعي للذهب: ${fmtUsd(price)} للأونصة.`
+      : `Gold reference price: ${fmtUsd(price)} per ounce.`;
+  sentences.push(headline);
+
+  // Change vs previous reading.
+  let movement = { key: 'unchanged', direction: 'flat', pctChange: null, absChange: null };
+  const previous = Number(input.previous);
+  if (Number.isFinite(previous) && previous > 0) {
+    const absChange = price - previous;
+    const pctChange = (absChange / previous) * 100;
+    const band = classifyMagnitude(pctChange);
+    const direction = pctChange > 0 ? 'up' : pctChange < 0 ? 'down' : 'flat';
+    movement = { key: band.key, direction, pctChange, absChange };
+
+    if (band.key === 'unchanged' || direction === 'flat') {
+      sentences.push(
+        lang === 'ar'
+          ? 'وهو دون تغيير عن القراءة المرجعية السابقة.'
+          : 'That is unchanged from the previous reference reading.'
+      );
+    } else {
+      const dir = DIRECTION[direction];
+      sentences.push(
+        lang === 'ar'
+          ? `وهو ${fmtUsd(Math.abs(absChange))} (${fmtPct(pctChange)}) ${dir.ar} القراءة المرجعية السابقة، متغيرًا ${band.ar}.`
+          : `That is ${fmtUsd(Math.abs(absChange))} (${fmtPct(pctChange)}) ${dir.en} the previous reference reading — a ${band.en} move.`
+      );
+    }
+  }
+
+  // Change vs session open.
+  const dayOpen = Number(input.dayOpen);
+  if (Number.isFinite(dayOpen) && dayOpen > 0) {
+    const pct = ((price - dayOpen) / dayOpen) * 100;
+    const dir = pct > 0 ? DIRECTION.up : pct < 0 ? DIRECTION.down : null;
+    if (dir) {
+      sentences.push(
+        lang === 'ar'
+          ? `ومقارنةً بافتتاح جلسة دبي، فهو ${dir.ar} الافتتاح بنسبة ${fmtPct(pct)}.`
+          : `Against the Dubai session open it is ${dir.en} the open by ${fmtPct(pct)}.`
+      );
+    } else {
+      sentences.push(
+        lang === 'ar'
+          ? 'وهو عند مستوى افتتاح جلسة دبي نفسه.'
+          : 'It is at the same level as the Dubai session open.'
+      );
+    }
+  }
+
+  // Reference range.
+  const high = Number(input.high);
+  const low = Number(input.low);
+  if (Number.isFinite(high) && Number.isFinite(low) && high > 0 && low > 0) {
+    const days = Number.isFinite(input.rangeDays) ? input.rangeDays : null;
+    const window =
+      days != null
+        ? lang === 'ar'
+          ? `آخر ${days} يومًا`
+          : `the last ${days} days`
+        : lang === 'ar'
+          ? 'الفترة المرصودة'
+          : 'the observed window';
+    sentences.push(
+      lang === 'ar'
+        ? `وخلال ${window} تراوح النطاق المرجعي بين ${fmtUsd(low)} و${fmtUsd(high)}.`
+        : `Over ${window} the reference range was ${fmtUsd(low)} to ${fmtUsd(high)}.`
+    );
+  }
+
+  // Optional caller-supplied context — explicitly labelled unconfirmed, never asserted as cause.
+  if (input.reason && typeof input.reason === 'string') {
+    sentences.push(
+      lang === 'ar'
+        ? `[سياق غير مؤكد، وليس تفسيرًا للسبب: ${input.reason}]`
+        : `[Unconfirmed context, not a stated cause: ${input.reason}]`
+    );
+  }
+
+  return {
+    status: 'ok',
+    headline,
+    sentences,
+    movement,
+    dataTimestamp: input.timestamp || null,
+    disclaimer,
+  };
+}
+
+/**
+ * Guard: throw if any string contains forecast/advice or invented-cause language. Used by tests to
+ * lock the descriptive-only contract; also exported so a caller can validate injected `reason` text.
+ * @param {string|string[]} text
+ */
+export function assertDescriptiveOnly(text) {
+  const parts = Array.isArray(text) ? text : [text];
+  for (const part of parts) {
+    if (FORECAST_PATTERNS.test(part)) {
+      throw new Error(`forecast/advice language is not allowed: ${part}`);
+    }
+    if (CAUSE_PATTERNS.test(part)) {
+      throw new Error(`invented-cause language is not allowed: ${part}`);
+    }
+  }
+  return true;
+}
+
+export { FORECAST_PATTERNS, CAUSE_PATTERNS };

--- a/tests/market-analysis.test.js
+++ b/tests/market-analysis.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+/**
+ * Descriptive market-analysis — proves the generator is deterministic and descriptive-only: it
+ * states change/range factually, classifies magnitude without predicting, always carries the
+ * reference-estimate disclaimer, and never emits forecast/advice or invented-cause language.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const MOD = new URL('../src/analysis/market-analysis.js', `file://${__filename}`).href;
+
+test('market-analysis: unavailable when price is missing or invalid', async () => {
+  const { buildMarketAnalysis } = await import(MOD);
+  assert.equal(buildMarketAnalysis({}).status, 'unavailable');
+  assert.equal(buildMarketAnalysis({ price: 0 }).status, 'unavailable');
+  assert.equal(buildMarketAnalysis({ price: -5 }).status, 'unavailable');
+  // Even unavailable carries the disclaimer.
+  assert.match(buildMarketAnalysis({}).disclaimer, /not financial advice/i);
+});
+
+test('market-analysis: an up move is described factually with correct magnitude', async () => {
+  const { buildMarketAnalysis } = await import(MOD);
+  const r = buildMarketAnalysis({ price: 4149, previous: 4100 });
+  assert.equal(r.status, 'ok');
+  assert.equal(r.movement.direction, 'up');
+  assert.equal(r.movement.key, 'notable'); // 1.20% → notable band
+  assert.ok(r.sentences.some((s) => /higher than/.test(s)));
+  assert.ok(r.sentences.some((s) => /\$4,149\.00/.test(s)));
+});
+
+test('market-analysis: a down move and an unchanged reading', async () => {
+  const { buildMarketAnalysis } = await import(MOD);
+  const down = buildMarketAnalysis({ price: 4000, previous: 4200 });
+  assert.equal(down.movement.direction, 'down');
+  assert.ok(down.sentences.some((s) => /lower than/.test(s)));
+
+  const flat = buildMarketAnalysis({ price: 4100, previous: 4100 });
+  assert.equal(flat.movement.direction, 'flat');
+  assert.equal(flat.movement.key, 'unchanged');
+  assert.ok(flat.sentences.some((s) => /unchanged/.test(s)));
+});
+
+test('market-analysis: magnitude bands classify by |pct| only', async () => {
+  const { buildMarketAnalysis } = await import(MOD);
+  assert.equal(buildMarketAnalysis({ price: 4105, previous: 4100 }).movement.key, 'little-changed');
+  assert.equal(buildMarketAnalysis({ price: 4120, previous: 4100 }).movement.key, 'modest');
+  assert.equal(buildMarketAnalysis({ price: 4180, previous: 4100 }).movement.key, 'notable');
+  assert.equal(buildMarketAnalysis({ price: 4305, previous: 4100 }).movement.key, 'sharp');
+});
+
+test('market-analysis: day-open and range sentences appear when data is present', async () => {
+  const { buildMarketAnalysis } = await import(MOD);
+  const r = buildMarketAnalysis({
+    price: 4149,
+    previous: 4100,
+    dayOpen: 4120,
+    high: 4200,
+    low: 4050,
+    rangeDays: 30,
+  });
+  assert.ok(r.sentences.some((s) => /session open/.test(s)));
+  assert.ok(
+    r.sentences.some((s) => /the last 30 days/.test(s) && /\$4,050\.00 to \$4,200\.00/.test(s))
+  );
+});
+
+test('market-analysis: generated output is descriptive-only (no forecast/advice/cause)', async () => {
+  const { buildMarketAnalysis, assertDescriptiveOnly } = await import(MOD);
+  const r = buildMarketAnalysis({
+    price: 4149,
+    previous: 4000,
+    dayOpen: 4120,
+    high: 4200,
+    low: 3900,
+    rangeDays: 90,
+  });
+  // Never throws → no forbidden vocabulary in any sentence.
+  assert.equal(assertDescriptiveOnly(r.sentences), true);
+});
+
+test('market-analysis: assertDescriptiveOnly rejects forecasts and invented causes', async () => {
+  const { assertDescriptiveOnly } = await import(MOD);
+  assert.throws(() => assertDescriptiveOnly('Gold will rise next week.'), /forecast\/advice/);
+  assert.throws(() => assertDescriptiveOnly('A good time to buy gold.'), /forecast\/advice/);
+  assert.throws(() => assertDescriptiveOnly('Analysts are bullish on gold.'), /forecast\/advice/);
+  assert.throws(() => assertDescriptiveOnly('Gold rose because of inflation.'), /invented-cause/);
+});
+
+test('market-analysis: optional reason is labelled unconfirmed, not asserted as cause', async () => {
+  const { buildMarketAnalysis } = await import(MOD);
+  const r = buildMarketAnalysis({
+    price: 4149,
+    previous: 4100,
+    reason: 'a stronger US dollar session',
+  });
+  const reasonLine = r.sentences.find((s) => /Unconfirmed context/.test(s));
+  assert.ok(reasonLine, 'reason should render with an unconfirmed label');
+  assert.ok(!/\bbecause\b|\bdue to\b/.test(reasonLine));
+});
+
+test('market-analysis: Arabic output localises and echoes the timestamp', async () => {
+  const { buildMarketAnalysis } = await import(MOD);
+  const r = buildMarketAnalysis(
+    { price: 4149, previous: 4100, timestamp: '2026-07-07T10:00:00Z' },
+    { lang: 'ar' }
+  );
+  assert.equal(r.status, 'ok');
+  assert.match(r.headline, /السعر المرجعي للذهب/);
+  assert.match(r.disclaimer, /ليس.*نصيحة مالية|نصيحة مالية/);
+  assert.equal(r.dataTimestamp, '2026-07-07T10:00:00Z');
+});


### PR DESCRIPTION
## Phase 43 — Descriptive market-analysis module (Yellow)

A client-side, **template-based** generator that turns factual gold price data into a plain-language *description* — never a forecast, a recommendation, or an invented cause. It mirrors the honesty rules of the backend `server/services/ai-drafts.js` on the client, and bakes them into a CI guard.

### What shipped
- **`src/analysis/market-analysis.js`**
  - `buildMarketAnalysis(input, { lang })` — from `{ price, previous, dayOpen, high, low, rangeDays, timestamp, reason }` produces `{ status, headline, sentences[], movement, dataTimestamp, disclaimer }`. Sentences state, factually: the current reference price, the change vs the previous reading (with a magnitude band), the change vs the Dubai session open, and the reference range.
  - `assertDescriptiveOnly(text)` — throws on forecast/advice vocabulary (`will`, `expected to`, `forecast`, `buy`, `sell`, `bullish`, `target price`, …) **and** invented-cause vocabulary (`because`, `due to`, `driven by`, …). Exported so callers can validate injected `reason` text.
  - Bilingual (EN/AR); every result — including `unavailable` — carries the spot-linked reference-estimate disclaimer.

### The honesty contract (enforced, not just intended)
- **No LLM.** Pure deterministic string templates filled from data.
- **No forecasts / no advice.** It says what the numbers *are*, never what they *will* do or what to *do* about them. A test runs `assertDescriptiveOnly()` over the full generated output.
- **No invented causes.** It never says *why* a price moved. A caller may pass `reason`, rendered with an explicit **"Unconfirmed context, not a stated cause"** label (mirroring the backend speculation label) — factual observation only.
- **Magnitude is descriptive.** Bands (`unchanged` → `little changed` → `modest` → `notable` → `sharp`) classify |%change| after the fact; they never imply direction of a *future* move.

### Tests — `tests/market-analysis.test.js` (9)
Unavailable on bad price (still discloses); up / down / unchanged described correctly; magnitude bands classify by |pct| only; day-open and range sentences appear with the right numbers; the full generated output passes `assertDescriptiveOnly`; the guard rejects forecasts, advice, and invented causes; a supplied `reason` renders unconfirmed (no cause words); Arabic localises and the timestamp is echoed.

### Relationship to existing surfaces
Complements the backend `ai-drafts.js` (editorial drafts, human-reviewed) with an in-page descriptive summary the Market-insights / tracker surfaces can render. Additive/unimported → tree-shaken; no page files touched.

### Constraints honoured
$0 / no dependency; no LLM; **no forecasts / predictions** (excluded by policy and by the guard); no invented causes; reference-estimate framing on every result; additive module only.

### Gate
`npm run build` + `npm run validate` + `npm test` (**1295 pass, +9**) + `npm run lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive library and tests only; no page or API wiring, so user-facing behavior is unchanged until something imports it.
> 
> **Overview**
> Adds a **client-side, deterministic** market-analysis helper under `src/analysis/market-analysis.js` so UI surfaces can render plain-language gold price copy without an LLM. **`buildMarketAnalysis`** turns factual inputs (price, previous, Dubai session open, range, optional timestamp/`reason`) into a view model (`headline`, `sentences`, `movement`, disclaimer) in **EN or AR**, with magnitude bands and a mandatory reference-estimate disclaimer even when data is invalid (`unavailable`).
> 
> **`assertDescriptiveOnly`** enforces the same honesty posture as backend `ai-drafts.js`: regex guards block forecast/advice and invented-cause wording; tests scan full generated output so regressions fail CI. Optional `reason` text is shown only inside an explicit unconfirmed-context label.
> 
> Nine new tests in `tests/market-analysis.test.js` cover moves, bands, session/range sentences, Arabic, and the guard. A Phase 43 report documents scope. The module is **additive** (not wired into pages yet); no production call sites changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10d76a1a78da302db4bafbc3a226b216396e58d1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->