### PR TITLE
Phase 44: white-label static branding spike (demo only, flag OFF)

### DIFF
--- a/reports/branding/PHASE-44-white-label-spike.md
+++ b/reports/branding/PHASE-44-white-label-spike.md
@@ -1,0 +1,51 @@
+# Phase 44 — White-label static branding spike (Green · demo only)
+
+A **non-functional design spike** exploring how the site could be re-skinned for a white-label
+partner. Strictly limited to static branding tokens — **no tenant system, no billing, no
+multi-tenancy backend, and nothing wired to the live theme.** The flag ships OFF and the resolver is
+inert while off, so this changes nothing at runtime. Its purpose is to inform the Phase 45 decision
+brief.
+
+## What shipped
+
+- **`src/branding/brand-config.js`**
+  - `WHITE_LABEL_ENABLED = false` — master flag; the spike is inert until a decision green-lights
+    it.
+  - `BRANDS` — the real `gold-ticker-live` brand (palette mirrored from `tokens.css`) plus two
+    clearly labelled **demo** skins (`demo-silver-souk`, `demo-bourse-dor`) that only exist to show
+    re-skinnability. Each brand is presentation-only: `name`, bilingual `tagline`, `logoGlyph`, and
+    a six-token colour set.
+  - `resolveBrandKey(key)` — while the flag is off, **always** returns the default brand (fail-safe,
+    same shape as the locale resolver). `getBrand(key)` falls back to default for unknown keys.
+  - `brandToCssVars(brand)` — maps a brand to a `--brand-*` CSS custom-property set. Deliberately a
+    **separate namespace** from the live `--color-*` tokens, so a future opt-in skin could apply it
+    without touching the shipped theme.
+
+## What this spike is NOT (scope guard)
+
+It is **not** productised multi-tenancy. There is no tenant identity, no per-tenant config store, no
+billing/plan/pricing, no auth boundary. A test asserts no brand descriptor carries any
+`tenant|billing|plan|price|subscription|stripe|invoice|seat` field — so the spike cannot quietly
+grow into the productised work this phase explicitly defers.
+
+## Tests — `tests/brand-config.test.js` (6)
+
+Flag ships OFF and the resolver is inert (every key → default) while off; the default brand carries
+the real palette (`#b07d1f` / `#fdfbf5`); demo brands exist and are flagged `demo`; every brand has
+an identical, complete, valid-hex token set with a bilingual tagline; `brandToCssVars` emits only
+`--brand-*` (never `--color-*`); and no brand carries tenant/billing scope.
+
+## Feeds into Phase 45
+
+The decision brief weighs whether white-label is worth productising. This spike gives it a concrete,
+tested reference for the _design_ cost (a token set per brand + a skin layer) while making clear the
+_productisation_ cost (tenancy, billing, support) is entirely separate and out of scope here.
+
+## Constraints honoured
+
+$0 / no dependency; demo only — no tenants, no billing; flag OFF and inert; `--brand-*` namespace
+does not touch the live theme; additive module; no other phase's files touched.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (**1292 pass, +6**) + `npm run lint` — all green.

--- a/src/branding/brand-config.js
+++ b/src/branding/brand-config.js
@@ -1,0 +1,139 @@
+/**
+ * branding/brand-config.js — white-label branding spike (Phase 44). DESIGN SPIKE ONLY.
+ *
+ * A non-functional exploration of how the site *could* be re-skinned for a white-label partner. It is
+ * deliberately limited to static branding tokens — **no tenant system, no billing, no multi-tenancy
+ * backend, and nothing wired to the live theme.** The master flag ships OFF, and while it is off the
+ * resolver always returns the default brand, so this changes nothing at runtime. It exists to inform
+ * the Phase 45 decision brief.
+ *
+ * Scope guard (enforced by tests): a brand descriptor carries only presentation tokens. It must NOT
+ * grow tenant/billing/plan/pricing fields — that would cross from "design spike" into the productised
+ * multi-tenant work this phase explicitly does not do.
+ */
+
+/** Master switch. White-label is a spike — OFF until (and unless) a decision green-lights it. */
+export const WHITE_LABEL_ENABLED = false;
+
+/** The real product brand. */
+export const DEFAULT_BRAND_KEY = 'gold-ticker-live';
+
+/**
+ * @typedef {Object} BrandTokens
+ * @property {string} primary
+ * @property {string} primaryLight
+ * @property {string} bg
+ * @property {string} surface
+ * @property {string} ink
+ * @property {string} onPrimary
+ */
+
+/**
+ * @typedef {Object} Brand
+ * @property {string} key
+ * @property {string} name
+ * @property {{en:string, ar:string}} tagline
+ * @property {string} logoGlyph  A single emoji/glyph standing in for a real logo asset in the spike.
+ * @property {boolean} demo      True for the illustrative alternates (not real partners).
+ * @property {BrandTokens} tokens
+ */
+
+/** @type {Record<string, Brand>} */
+export const BRANDS = {
+  'gold-ticker-live': {
+    key: 'gold-ticker-live',
+    name: 'Gold Ticker Live',
+    tagline: {
+      en: 'Reference gold prices for the UAE and the Arab world',
+      ar: 'أسعار الذهب المرجعية للإمارات والعالم العربي',
+    },
+    logoGlyph: '🟡',
+    demo: false,
+    // Real palette, mirrored from styles/partials/tokens.css.
+    tokens: {
+      primary: '#b07d1f',
+      primaryLight: '#ddb040',
+      bg: '#fdfbf5',
+      surface: '#ffffff',
+      ink: '#0f0c06',
+      onPrimary: '#1a1305',
+    },
+  },
+  // ── Illustrative demo brands — NOT real partners, purely to show re-skinnability. ──
+  'demo-silver-souk': {
+    key: 'demo-silver-souk',
+    name: 'Silver Souk (demo)',
+    tagline: {
+      en: 'Live silver & bullion reference — demo skin',
+      ar: 'مرجع الفضة والسبائك المباشر — نموذج توضيحي',
+    },
+    logoGlyph: '⚪',
+    demo: true,
+    tokens: {
+      primary: '#6b7a8f',
+      primaryLight: '#9fb3c8',
+      bg: '#f6f8fa',
+      surface: '#ffffff',
+      ink: '#10151b',
+      onPrimary: '#ffffff',
+    },
+  },
+  'demo-bourse-dor': {
+    key: 'demo-bourse-dor',
+    name: "Bourse d'Or (demo)",
+    tagline: {
+      en: 'Live bullion reference — demo skin',
+      ar: 'مرجع السبائك المباشر — نموذج توضيحي',
+    },
+    logoGlyph: '🟢',
+    demo: true,
+    tokens: {
+      primary: '#1f6b4a',
+      primaryLight: '#3fa06f',
+      bg: '#f4faf6',
+      surface: '#ffffff',
+      ink: '#0b1a12',
+      onPrimary: '#ffffff',
+    },
+  },
+};
+
+/** All brand keys. */
+export function brandKeys() {
+  return Object.keys(BRANDS);
+}
+
+/** Look up a brand, falling back to the default brand for unknown keys. */
+export function getBrand(key) {
+  return BRANDS[key] || BRANDS[DEFAULT_BRAND_KEY];
+}
+
+/**
+ * Resolve a requested brand key to an active one. While {@link WHITE_LABEL_ENABLED} is off this ALWAYS
+ * returns the default brand — the spike is inert. (When a decision turns it on, a known key resolves
+ * to itself.) Mirrors the locale resolver's fail-safe shape.
+ */
+export function resolveBrandKey(key) {
+  if (!WHITE_LABEL_ENABLED) return DEFAULT_BRAND_KEY;
+  return BRANDS[key] ? key : DEFAULT_BRAND_KEY;
+}
+
+/**
+ * Map a brand's tokens to a `--brand-*` CSS custom-property set. This is a SPIKE namespace — it does
+ * not touch the live `--color-*` tokens — so applying it (in a future phase) would be an opt-in skin,
+ * not a change to the shipped theme.
+ * @param {Brand} brand
+ * @returns {Record<string, string>}
+ */
+export function brandToCssVars(brand) {
+  const b = brand || getBrand(DEFAULT_BRAND_KEY);
+  return {
+    '--brand-name': JSON.stringify(b.name),
+    '--brand-primary': b.tokens.primary,
+    '--brand-primary-light': b.tokens.primaryLight,
+    '--brand-bg': b.tokens.bg,
+    '--brand-surface': b.tokens.surface,
+    '--brand-ink': b.tokens.ink,
+    '--brand-on-primary': b.tokens.onPrimary,
+  };
+}

--- a/tests/brand-config.test.js
+++ b/tests/brand-config.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * White-label branding spike — proves it is a non-functional design spike: the flag ships OFF, the
+ * resolver is inert (always default) while off, the default brand carries the real palette, demo
+ * brands are flagged, token → CSS-var mapping works, and no brand carries tenant/billing scope.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const MOD = new URL('../src/branding/brand-config.js', `file://${__filename}`).href;
+
+test('brand: white-label ships OFF and the resolver is inert while off', async () => {
+  const { WHITE_LABEL_ENABLED, resolveBrandKey, DEFAULT_BRAND_KEY } = await import(MOD);
+  assert.equal(WHITE_LABEL_ENABLED, false);
+  assert.equal(DEFAULT_BRAND_KEY, 'gold-ticker-live');
+  // While off, EVERY request resolves to the default — nothing re-skins at runtime.
+  assert.equal(resolveBrandKey('demo-silver-souk'), 'gold-ticker-live');
+  assert.equal(resolveBrandKey('demo-bourse-dor'), 'gold-ticker-live');
+  assert.equal(resolveBrandKey('anything'), 'gold-ticker-live');
+});
+
+test('brand: default brand carries the real product palette', async () => {
+  const { getBrand } = await import(MOD);
+  const b = getBrand('gold-ticker-live');
+  assert.equal(b.demo, false);
+  assert.equal(b.name, 'Gold Ticker Live');
+  assert.equal(b.tokens.primary, '#b07d1f'); // from tokens.css
+  assert.equal(b.tokens.bg, '#fdfbf5');
+  // Unknown key falls back to the default brand.
+  assert.equal(getBrand('nope').key, 'gold-ticker-live');
+});
+
+test('brand: demo brands exist and are flagged demo', async () => {
+  const { BRANDS, brandKeys } = await import(MOD);
+  const demos = brandKeys().filter((k) => BRANDS[k].demo);
+  assert.deepEqual(demos.sort(), ['demo-bourse-dor', 'demo-silver-souk']);
+  assert.ok(BRANDS['demo-silver-souk'].name.includes('demo'));
+});
+
+test('brand: every brand has a complete, identical token key set', async () => {
+  const { BRANDS } = await import(MOD);
+  const expected = ['primary', 'primaryLight', 'bg', 'surface', 'ink', 'onPrimary'].sort();
+  for (const brand of Object.values(BRANDS)) {
+    assert.deepEqual(Object.keys(brand.tokens).sort(), expected, `${brand.key} tokens`);
+    for (const v of Object.values(brand.tokens)) assert.match(v, /^#[0-9a-f]{6}$/i);
+    assert.ok(brand.tagline.en && brand.tagline.ar, `${brand.key} bilingual tagline`);
+  }
+});
+
+test('brand: brandToCssVars maps tokens to a --brand-* namespace (not live --color-*)', async () => {
+  const { brandToCssVars, getBrand } = await import(MOD);
+  const vars = brandToCssVars(getBrand('demo-silver-souk'));
+  assert.equal(vars['--brand-primary'], '#6b7a8f');
+  assert.equal(vars['--brand-bg'], '#f6f8fa');
+  // Spike namespace only — it must not emit any live --color-* token.
+  assert.ok(Object.keys(vars).every((k) => k.startsWith('--brand-')));
+  assert.ok(!Object.keys(vars).some((k) => k.startsWith('--color-')));
+});
+
+test('brand: no brand carries tenant/billing/plan scope (spike stays a spike)', async () => {
+  const { BRANDS } = await import(MOD);
+  const FORBIDDEN = /tenant|billing|plan|price|subscription|stripe|invoice|seat/i;
+  for (const brand of Object.values(BRANDS)) {
+    for (const key of Object.keys(brand)) {
+      assert.ok(!FORBIDDEN.test(key), `brand ${brand.key} must not have field ${key}`);
+    }
+  }
+});


### PR DESCRIPTION
## Phase 44 — White-label static branding spike (Green · demo only)

A **non-functional design spike** exploring how the site could be re-skinned for a white-label partner. Strictly limited to static branding tokens — **no tenant system, no billing, no multi-tenancy backend, and nothing wired to the live theme.** The flag ships OFF and the resolver is inert while off, so this changes nothing at runtime. Its purpose is to inform the Phase 45 decision brief.

### What shipped
- **`src/branding/brand-config.js`**
  - `WHITE_LABEL_ENABLED = false` — master flag; the spike is inert until a decision green-lights it.
  - `BRANDS` — the real `gold-ticker-live` brand (palette mirrored from `tokens.css`) plus two clearly labelled **demo** skins (`demo-silver-souk`, `demo-bourse-dor`) that only exist to show re-skinnability. Each brand is presentation-only: `name`, bilingual `tagline`, `logoGlyph`, and a six-token colour set.
  - `resolveBrandKey(key)` — while the flag is off, **always** returns the default brand (fail-safe, same shape as the locale resolver). `getBrand(key)` falls back to default for unknown keys.
  - `brandToCssVars(brand)` — maps a brand to a `--brand-*` CSS custom-property set. Deliberately a **separate namespace** from the live `--color-*` tokens, so a future opt-in skin could apply it without touching the shipped theme.

### What this spike is NOT (scope guard)
It is **not** productised multi-tenancy. There is no tenant identity, no per-tenant config store, no billing/plan/pricing, no auth boundary. A test asserts no brand descriptor carries any `tenant|billing|plan|price|subscription|stripe|invoice|seat` field — so the spike cannot quietly grow into the productised work this phase explicitly defers.

### Tests — `tests/brand-config.test.js` (6)
Flag ships OFF and the resolver is inert (every key → default) while off; the default brand carries the real palette (`#b07d1f` / `#fdfbf5`); demo brands exist and are flagged `demo`; every brand has an identical, complete, valid-hex token set with a bilingual tagline; `brandToCssVars` emits only `--brand-*` (never `--color-*`); and no brand carries tenant/billing scope.

### Feeds into Phase 45
The decision brief weighs whether white-label is worth productising. This spike gives it a concrete, tested reference for the *design* cost (a token set per brand + a skin layer) while making clear the *productisation* cost (tenancy, billing, support) is entirely separate and out of scope here.

### Constraints honoured
$0 / no dependency; demo only — no tenants, no billing; flag OFF and inert; `--brand-*` namespace does not touch the live theme; additive module; no other phase's files touched.

### Gate
`npm run build` + `npm run validate` + `npm test` (**1292 pass, +6**) + `npm run lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, unused module with the master flag off; no auth, data, or live theme integration.
> 
> **Overview**
> Introduces a **Phase 44 design spike** for optional white-label skins: new `src/branding/brand-config.js` with `WHITE_LABEL_ENABLED = false`, static `BRANDS` (production `gold-ticker-live` plus two demo alternates), `resolveBrandKey` / `getBrand` helpers, and `brandToCssVars` emitting a separate `--brand-*` namespace (not live `--color-*`). Nothing in the app imports this yet, so **runtime behavior and the shipped theme are unchanged**.
> 
> Adds **`tests/brand-config.test.js`** (six cases) for the off flag, default palette, demo flags, token shape, CSS var namespace, and a scope guard against tenant/billing fields. Documents the spike in **`reports/branding/PHASE-44-white-label-spike.md`** for the Phase 45 decision brief.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf0321e694908e7eb77747369ed56439b45416c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->