### PR TITLE
Phase 37: gold-crypto correlation view model (descriptive-only, pilot…

### DIFF
--- a/reports/crypto/PHASE-37-correlation-view.md
+++ b/reports/crypto/PHASE-37-correlation-view.md
@@ -1,0 +1,68 @@
+# Phase 37 — Gold-crypto correlation view (Green · model layer, pilot OFF)
+
+Builds the **computation + presentation model** for a descriptive gold-vs-crypto correlation,
+layered directly on the Phase 36 plumbing. No live fetch, no chart, no owner-gated files — and the
+public entry stays gated OFF until a crypto feed exists. Gold is untouched.
+
+> **Stacks on [#573](https://github.com/vctb12/GoldTickerLive/pull/573) (Phase 36).** This branch is
+> cut from the Phase-36 branch because `crypto-assets.js` / `crypto-history.js` are not on `main`
+> yet, so the PR is based on the Phase-36 branch to keep the diff to Phase 37's own files.
+
+## Why a model layer and not a live chart
+
+The correlation _view_ needs BTC/ETH history, which needs a price feed — and a feed is owner-gated
+territory (a workflow writing `data/crypto/*.json`, mirroring the gold pipeline). Rather than ship a
+disconnected UI that renders nothing real, Phase 37 ships the honest, fully-tested brains of the
+feature: the math and the view model. When the owner adds a feed and a UI phase flips
+`CRYPTO_PILOT_ENABLED`, the chart is a thin render over `buildCorrelationView(...)` — no rework.
+
+## Shipped
+
+- **`src/lib/correlation.js`** — pure, asset-generic math over `{ date, price }` records:
+  - `alignSeriesByDate(a, b)` — intersect two dated series on shared dates, ascending, junk dropped.
+  - `pearson(xs, ys)` — Pearson coefficient in `[-1, 1]`; returns `null` (not `0`) when undefined
+    (fewer than 2 points, length mismatch, or zero variance — a flat line has no correlation).
+  - `rollingCorrelation(dates, a, b, window)` — sliding-window coefficients anchored to each
+    window's last date; zero-variance windows skipped, not reported as 0.
+- **`src/lib/gold-crypto-correlation.js`** — the view model:
+  - `computeCorrelationModel(gold, crypto, opts)` — flag-independent core → `ok` /
+    `insufficient-data` / `unavailable` (unknown asset), with an overall coefficient, plain-word
+    **strength** (negligible→very-strong) and **direction** (together / inverse / no clear link)
+    bands, a rolling series, and a bilingual one-line `framing`.
+  - `buildCorrelationView(...)` — public entry, **gated behind `CRYPTO_PILOT_ENABLED`**; returns a
+    `disabled` state until the pilot is on, then delegates to the core.
+  - Both `framing` and a standalone `disclaimer` (EN + AR) carry the descriptive-only wording, so no
+    caller can surface a coefficient without it.
+- Both modules are **unimported** → tree-shaken out. No behaviour change anywhere.
+
+## Honesty framing (enforced in code, not just docs)
+
+Every returned model — `ok`, `insufficient-data`, `unavailable`, **and** `disabled` — includes a
+`disclaimer`: _"Descriptive correlation over the shared dates only — not a prediction, forecast, or
+investment signal. Correlation does not imply causation."_ (Arabic equivalent for `lang: 'ar'`.) The
+`negligible` band maps to "no clear link" rather than implying a weak signal is meaningful.
+
+## Tests (16 new)
+
+- `tests/correlation.test.js` (8) — perfect +1 / −1, a hand-checked r = 0.5292, all four
+  undefined→`null` cases, `[-1,1]` clamp, alignment on shared dates only, and rolling-window shape
+  incl. the zero-variance skip.
+- `tests/gold-crypto-correlation.test.js` (8) — pilot ships `disabled`; core builds an `ok` model
+  (coefficient, strength/direction bands, framing); inverse series classify inverse; too-few-dates
+  and flat-series → `insufficient-data`; unknown asset → `unavailable`; Arabic localises
+  strength/direction/disclaimer; rolling defaults to a 12-point window.
+
+## Owner-gated dependency (recommend-only)
+
+A live view needs a crypto history feed. Recommendation: an owner-added workflow writing
+`data/crypto/btc.json` (+ eth) in the same shape the gold pipeline uses; the Phase-36 normalisers
+already turn that into records this module consumes. No fetch or workflow is added here.
+
+## Constraints honoured
+
+Gold untouched; $0 / no dependency; pilot OFF; no owner-gated files modified; no live fetch, no UI
+chart; descriptive-only framing enforced in every returned model.
+
+## Gate
+
+`npm run build` + `npm run validate` + `npm test` (**1307 pass, +16**) + `npm run lint` — all green.

--- a/src/lib/correlation.js
+++ b/src/lib/correlation.js
@@ -1,0 +1,108 @@
+/**
+ * lib/correlation.js — asset-generic correlation math over dated price records.
+ *
+ * Pure, deterministic, UI-free (Phase 37). Operates on the shared history-record shape
+ * (`{ date, price }`) that both `historical-data.js` (gold) and `crypto-history.js` (BTC/ETH)
+ * already emit, so a gold-vs-crypto correlation view can be computed with the existing pipeline —
+ * no live fetch and no charting code here. Gold data is untouched.
+ *
+ * Correlation is a *descriptive* statistic only: it measures how two series co-moved over a window.
+ * It is never a prediction, a causal claim, or an investment signal — the presentation layer
+ * (`gold-crypto-correlation.js`) carries that framing to the user.
+ */
+
+/**
+ * Align two dated series on their shared dates, returning parallel price arrays in date order.
+ * Later records win on duplicate dates (matching the normalisers' last-write-wins rule).
+ *
+ * @param {Array<{date:string, price:number}>} recordsA
+ * @param {Array<{date:string, price:number}>} recordsB
+ * @returns {{ dates: string[], a: number[], b: number[] }}
+ */
+export function alignSeriesByDate(recordsA, recordsB) {
+  const mapA = toPriceMap(recordsA);
+  const mapB = toPriceMap(recordsB);
+  const dates = [...mapA.keys()]
+    .filter((d) => mapB.has(d))
+    .sort((x, y) => (x < y ? -1 : x > y ? 1 : 0));
+  return {
+    dates,
+    a: dates.map((d) => mapA.get(d)),
+    b: dates.map((d) => mapB.get(d)),
+  };
+}
+
+/** Build a date→price map, dropping unusable points; last write wins per date. */
+function toPriceMap(records) {
+  const map = new Map();
+  for (const r of records || []) {
+    const date = typeof r?.date === 'string' ? r.date : null;
+    const price = Number(r?.price);
+    if (!date || !Number.isFinite(price) || price <= 0) continue;
+    map.set(date, price);
+  }
+  return map;
+}
+
+/**
+ * Pearson product-moment correlation coefficient of two equal-length numeric arrays.
+ * Returns a value in [-1, 1], or `null` when it is undefined (fewer than 2 points, length
+ * mismatch, or zero variance in either series — a flat line has no correlation).
+ *
+ * @param {number[]} xs
+ * @param {number[]} ys
+ * @returns {number|null}
+ */
+export function pearson(xs, ys) {
+  if (!Array.isArray(xs) || !Array.isArray(ys)) return null;
+  const n = xs.length;
+  if (n < 2 || ys.length !== n) return null;
+
+  const meanX = mean(xs);
+  const meanY = mean(ys);
+  let cov = 0;
+  let varX = 0;
+  let varY = 0;
+  for (let i = 0; i < n; i += 1) {
+    const dx = xs[i] - meanX;
+    const dy = ys[i] - meanY;
+    cov += dx * dy;
+    varX += dx * dx;
+    varY += dy * dy;
+  }
+  if (varX === 0 || varY === 0) return null;
+  const r = cov / Math.sqrt(varX * varY);
+  // Clamp tiny floating-point overshoot so callers can rely on the [-1, 1] contract.
+  return Math.max(-1, Math.min(1, r));
+}
+
+function mean(values) {
+  let sum = 0;
+  for (const v of values) sum += v;
+  return sum / values.length;
+}
+
+/**
+ * Rolling Pearson correlation over a sliding window of `window` aligned points.
+ * Each entry anchors to the window's last date. Windows with undefined correlation
+ * (e.g. a flat segment) are skipped rather than reported as 0.
+ *
+ * @param {string[]} dates   Shared, ascending dates (from {@link alignSeriesByDate}).
+ * @param {number[]} a
+ * @param {number[]} b
+ * @param {number} window    Points per window (>= 2).
+ * @returns {Array<{ date: string, coefficient: number }>}
+ */
+export function rollingCorrelation(dates, a, b, window) {
+  const size = Math.floor(window);
+  if (!Array.isArray(dates) || size < 2 || a.length !== dates.length || b.length !== dates.length) {
+    return [];
+  }
+  const out = [];
+  for (let end = size; end <= dates.length; end += 1) {
+    const start = end - size;
+    const r = pearson(a.slice(start, end), b.slice(start, end));
+    if (r !== null) out.push({ date: dates[end - 1], coefficient: r });
+  }
+  return out;
+}

--- a/src/lib/gold-crypto-correlation.js
+++ b/src/lib/gold-crypto-correlation.js
@@ -1,0 +1,143 @@
+/**
+ * lib/gold-crypto-correlation.js — descriptive gold-vs-crypto correlation view model.
+ *
+ * Phase 37. Turns two dated price series (gold history + a normalised crypto series from
+ * `crypto-history.js`) into a *view model* the UI can render: an overall coefficient, a plain-word
+ * strength/direction label (EN + AR), and an optional rolling-correlation series — all built on the
+ * pure math in `correlation.js`. There is NO live fetch and NO chart here; this is the model layer.
+ *
+ * `buildCorrelationView` is the public entry and is gated behind `CRYPTO_PILOT_ENABLED`: until the
+ * owner adds a crypto feed and a UI phase flips the flag, it returns a `disabled` state and the
+ * module tree-shakes out (it is unimported). `computeCorrelationModel` is the flag-independent core
+ * (kept separate so the math/assembly is unit-testable without touching the pilot switch). Gold is
+ * untouched.
+ *
+ * Framing rule (non-negotiable): correlation is descriptive only. It is never a prediction, a
+ * forecast, a causal claim, or an investment signal. Both the `disclaimer` and `framing` fields
+ * carry that wording so no caller can render a coefficient without it.
+ */
+
+import { alignSeriesByDate, pearson, rollingCorrelation } from './correlation.js';
+import { CRYPTO_PILOT_ENABLED, PRIMARY_CRYPTO, getCryptoAsset } from '../config/crypto-assets.js';
+
+/** Minimum aligned points before a coefficient is meaningful enough to show. */
+export const MIN_CORRELATION_POINTS = 3;
+
+/** Default rolling window (in aligned points). */
+export const DEFAULT_ROLLING_WINDOW = 12;
+
+const STRENGTH = [
+  { key: 'negligible', max: 0.2, en: 'negligible', ar: 'لا تُذكر' },
+  { key: 'weak', max: 0.4, en: 'weak', ar: 'ضعيفة' },
+  { key: 'moderate', max: 0.6, en: 'moderate', ar: 'متوسطة' },
+  { key: 'strong', max: 0.8, en: 'strong', ar: 'قوية' },
+  { key: 'very-strong', max: Infinity, en: 'very strong', ar: 'قوية جدًا' },
+];
+
+const DIRECTION = {
+  positive: { key: 'positive', en: 'move together', ar: 'يتحركان معًا' },
+  inverse: { key: 'inverse', en: 'move inversely', ar: 'يتحركان عكسيًا' },
+  none: { key: 'none', en: 'show no clear link', ar: 'بلا علاقة واضحة' },
+};
+
+const DISCLAIMER = {
+  en: 'Descriptive correlation over the shared dates only — not a prediction, forecast, or investment signal. Correlation does not imply causation.',
+  ar: 'ارتباط وصفي على التواريخ المشتركة فقط — وليس تنبؤًا أو توقعًا أو إشارة استثمارية. الارتباط لا يعني السببية.',
+};
+
+function classifyStrength(coefficient) {
+  const magnitude = Math.abs(coefficient);
+  return STRENGTH.find((band) => magnitude < band.max) || STRENGTH[STRENGTH.length - 1];
+}
+
+function classifyDirection(coefficient) {
+  const strength = classifyStrength(coefficient);
+  if (strength.key === 'negligible') return DIRECTION.none;
+  return coefficient > 0 ? DIRECTION.positive : DIRECTION.inverse;
+}
+
+function pickLang(lang) {
+  return lang === 'ar' ? 'ar' : 'en';
+}
+
+/**
+ * Flag-independent core: align the two series and build the descriptive model, or an empty state.
+ * Statuses: `unavailable` (unknown asset), `insufficient-data` (too few points / no variance),
+ * or `ok`. Never returns `disabled` — that is the pilot gate's job (see {@link buildCorrelationView}).
+ *
+ * @param {Array<{date:string, price:number}>} goldRecords
+ * @param {Array<{date:string, price:number}>} cryptoRecords
+ * @param {{assetKey?:string, lang?:'en'|'ar', window?:number}} [options]
+ */
+export function computeCorrelationModel(goldRecords, cryptoRecords, options = {}) {
+  const lang = pickLang(options.lang);
+  const disclaimer = DISCLAIMER[lang];
+
+  const assetKey = options.assetKey || PRIMARY_CRYPTO;
+  const asset = getCryptoAsset(assetKey);
+  if (!asset) {
+    return { status: 'unavailable', reason: 'unknown-asset', disclaimer };
+  }
+
+  const { dates, a, b } = alignSeriesByDate(goldRecords, cryptoRecords);
+  if (dates.length < MIN_CORRELATION_POINTS) {
+    return { status: 'insufficient-data', assetKey, sampleSize: dates.length, disclaimer };
+  }
+
+  const coefficient = pearson(a, b);
+  if (coefficient === null) {
+    // Aligned but no variance (e.g. a flat series) — undefined correlation, not zero.
+    return { status: 'insufficient-data', assetKey, sampleSize: dates.length, disclaimer };
+  }
+
+  const strengthBand = classifyStrength(coefficient);
+  const directionBand = classifyDirection(coefficient);
+  const window = Number.isFinite(options.window) ? options.window : DEFAULT_ROLLING_WINDOW;
+
+  return {
+    status: 'ok',
+    assetKey,
+    sampleSize: dates.length,
+    coefficient,
+    strength: { key: strengthBand.key, label: strengthBand[lang] },
+    direction: { key: directionBand.key, label: directionBand[lang] },
+    rolling: rollingCorrelation(dates, a, b, window),
+    framing: describeCorrelation(coefficient, asset, lang),
+    disclaimer,
+  };
+}
+
+/**
+ * Public entry: gated by the pilot flag. Returns a `disabled` state until a crypto feed and a UI
+ * phase turn the pilot on; otherwise delegates to {@link computeCorrelationModel}.
+ *
+ * @param {Array<{date:string, price:number}>} goldRecords
+ * @param {Array<{date:string, price:number}>} cryptoRecords
+ * @param {{assetKey?:string, lang?:'en'|'ar', window?:number}} [options]
+ */
+export function buildCorrelationView(goldRecords, cryptoRecords, options = {}) {
+  if (!CRYPTO_PILOT_ENABLED) {
+    return {
+      status: 'disabled',
+      reason: 'pilot-disabled',
+      disclaimer: DISCLAIMER[pickLang(options.lang)],
+    };
+  }
+  return computeCorrelationModel(goldRecords, cryptoRecords, options);
+}
+
+/**
+ * One-line plain-language summary, e.g. "Gold and Bitcoin showed a moderate correlation — they move
+ * together (r = 0.52)." Descriptive only — the disclaimer still travels with the model.
+ */
+export function describeCorrelation(coefficient, asset, lang = 'en') {
+  const l = pickLang(lang);
+  const strength = classifyStrength(coefficient);
+  const direction = classifyDirection(coefficient);
+  const name = l === 'ar' ? asset.nameAr : asset.nameEn;
+  const r = coefficient.toFixed(2);
+  if (l === 'ar') {
+    return `أظهر الذهب و${name} علاقة ${strength.ar} (${direction.ar}) بمعامل ارتباط r = ${r}.`;
+  }
+  return `Gold and ${name} showed a ${strength.en} correlation — they ${direction.en} (r = ${r}).`;
+}

--- a/tests/correlation.test.js
+++ b/tests/correlation.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/**
+ * Correlation math — deterministic proofs (no live data): perfect +/- correlation, zero-variance
+ * guard, date alignment on the shared intersection, and rolling windows.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const CORR = new URL('../src/lib/correlation.js', `file://${__filename}`).href;
+
+test('pearson: perfectly correlated series → +1', async () => {
+  const { pearson } = await import(CORR);
+  assert.equal(pearson([1, 2, 3, 4], [2, 4, 6, 8]), 1);
+});
+
+test('pearson: perfectly anti-correlated series → -1', async () => {
+  const { pearson } = await import(CORR);
+  assert.equal(pearson([1, 2, 3, 4], [8, 6, 4, 2]), -1);
+});
+
+test('pearson: known value matches hand calculation', async () => {
+  const { pearson } = await import(CORR);
+  // xs=[1,2,3,5], ys=[2,1,4,3]: cov=3.5, varX=8.75, varY=5 → r = 3.5/sqrt(43.75) = 0.5292.
+  assert.equal(Number(pearson([1, 2, 3, 5], [2, 1, 4, 3]).toFixed(4)), 0.5292);
+});
+
+test('pearson: undefined cases return null (not 0)', async () => {
+  const { pearson } = await import(CORR);
+  assert.equal(pearson([1], [1]), null); // too few points
+  assert.equal(pearson([1, 2, 3], [1, 2]), null); // length mismatch
+  assert.equal(pearson([5, 5, 5], [1, 2, 3]), null); // zero variance in x
+  assert.equal(pearson([1, 2, 3], [7, 7, 7]), null); // zero variance in y
+});
+
+test('pearson: result is clamped into [-1, 1]', async () => {
+  const { pearson } = await import(CORR);
+  const r = pearson([0.1, 0.2, 0.3, 0.4, 0.5], [10, 20, 30, 40, 50]);
+  assert.ok(r <= 1 && r >= -1);
+  assert.equal(r, 1);
+});
+
+test('alignSeriesByDate: keeps only shared dates, ascending, drops junk', async () => {
+  const { alignSeriesByDate } = await import(CORR);
+  const gold = [
+    { date: '2026-03-01', price: 4200 },
+    { date: '2026-01-01', price: 4000 },
+    { date: '2026-02-01', price: 4100 },
+    { date: '2026-04-01', price: 0 }, // dropped (non-positive)
+  ];
+  const crypto = [
+    { date: '2026-01-01', price: 42000 },
+    { date: '2026-02-01', price: 50000 },
+    { date: '2026-04-01', price: 60000 }, // no gold match
+  ];
+  const { dates, a, b } = alignSeriesByDate(gold, crypto);
+  assert.deepEqual(dates, ['2026-01-01', '2026-02-01']);
+  assert.deepEqual(a, [4000, 4100]);
+  assert.deepEqual(b, [42000, 50000]);
+});
+
+test('rollingCorrelation: one entry per full window, anchored to window end', async () => {
+  const { rollingCorrelation } = await import(CORR);
+  const dates = ['d1', 'd2', 'd3', 'd4'];
+  const a = [1, 2, 3, 4];
+  const b = [1, 2, 3, 4];
+  const rolling = rollingCorrelation(dates, a, b, 3);
+  assert.deepEqual(
+    rolling.map((r) => r.date),
+    ['d3', 'd4']
+  );
+  assert.ok(rolling.every((r) => r.coefficient === 1));
+});
+
+test('rollingCorrelation: skips zero-variance windows instead of reporting 0', async () => {
+  const { rollingCorrelation } = await import(CORR);
+  const dates = ['d1', 'd2', 'd3'];
+  const rolling = rollingCorrelation(dates, [5, 5, 5], [1, 2, 3], 2);
+  assert.deepEqual(rolling, []);
+});

--- a/tests/gold-crypto-correlation.test.js
+++ b/tests/gold-crypto-correlation.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+/**
+ * Gold-crypto correlation view model. Proves the pilot ships gated OFF, that the flag-independent
+ * core assembles ok / insufficient-data / unknown-asset states from real records, that the strength
+ * and direction bands classify correctly, and that the descriptive-only disclaimer always travels.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const MOD = new URL('../src/lib/gold-crypto-correlation.js', `file://${__filename}`).href;
+
+const NOT_A_PREDICTION = /not a prediction/i;
+
+// A small pair of series with a known-positive relationship.
+const GOLD = [
+  { date: '2026-01-01', price: 4000 },
+  { date: '2026-02-01', price: 4100 },
+  { date: '2026-03-01', price: 4200 },
+  { date: '2026-04-01', price: 4300 },
+];
+const CRYPTO_UP = [
+  { date: '2026-01-01', price: 40000 },
+  { date: '2026-02-01', price: 44000 },
+  { date: '2026-03-01', price: 48000 },
+  { date: '2026-04-01', price: 52000 },
+];
+
+test('correlation: pilot ships gated OFF (buildCorrelationView → disabled)', async () => {
+  const { buildCorrelationView } = await import(MOD);
+  const view = buildCorrelationView(GOLD, CRYPTO_UP);
+  assert.equal(view.status, 'disabled');
+  assert.equal(view.reason, 'pilot-disabled');
+  assert.match(view.disclaimer, NOT_A_PREDICTION);
+});
+
+test('correlation: core builds an ok model with a perfect positive coefficient', async () => {
+  const { computeCorrelationModel } = await import(MOD);
+  const model = computeCorrelationModel(GOLD, CRYPTO_UP, { assetKey: 'btc' });
+  assert.equal(model.status, 'ok');
+  assert.equal(model.assetKey, 'btc');
+  assert.equal(model.sampleSize, 4);
+  assert.equal(model.coefficient, 1);
+  assert.equal(model.strength.key, 'very-strong');
+  assert.equal(model.direction.key, 'positive');
+  assert.match(model.framing, /Bitcoin/);
+  assert.match(model.disclaimer, NOT_A_PREDICTION);
+});
+
+test('correlation: inverse series classify as inverse direction', async () => {
+  const { computeCorrelationModel } = await import(MOD);
+  const cryptoDown = [
+    { date: '2026-01-01', price: 52000 },
+    { date: '2026-02-01', price: 48000 },
+    { date: '2026-03-01', price: 44000 },
+    { date: '2026-04-01', price: 40000 },
+  ];
+  const model = computeCorrelationModel(GOLD, cryptoDown, { assetKey: 'btc' });
+  assert.equal(model.coefficient, -1);
+  assert.equal(model.direction.key, 'inverse');
+  assert.equal(model.strength.key, 'very-strong');
+});
+
+test('correlation: too few shared dates → insufficient-data', async () => {
+  const { computeCorrelationModel } = await import(MOD);
+  const model = computeCorrelationModel(
+    GOLD,
+    [{ date: '2026-01-01', price: 40000 }], // only 1 shared date
+    { assetKey: 'btc' }
+  );
+  assert.equal(model.status, 'insufficient-data');
+  assert.equal(model.sampleSize, 1);
+  assert.match(model.disclaimer, NOT_A_PREDICTION);
+});
+
+test('correlation: flat crypto series (no variance) → insufficient-data, not r=0', async () => {
+  const { computeCorrelationModel } = await import(MOD);
+  const flat = GOLD.map((g) => ({ date: g.date, price: 45000 }));
+  const model = computeCorrelationModel(GOLD, flat, { assetKey: 'btc' });
+  assert.equal(model.status, 'insufficient-data');
+});
+
+test('correlation: unknown asset → unavailable', async () => {
+  const { computeCorrelationModel } = await import(MOD);
+  const model = computeCorrelationModel(GOLD, CRYPTO_UP, { assetKey: 'doge' });
+  assert.equal(model.status, 'unavailable');
+  assert.equal(model.reason, 'unknown-asset');
+});
+
+test('correlation: Arabic model localises strength, direction, and disclaimer', async () => {
+  const { computeCorrelationModel } = await import(MOD);
+  const model = computeCorrelationModel(GOLD, CRYPTO_UP, { assetKey: 'btc', lang: 'ar' });
+  assert.equal(model.status, 'ok');
+  assert.equal(model.strength.label, 'قوية جدًا');
+  assert.equal(model.direction.label, 'يتحركان معًا');
+  assert.match(model.framing, /بيتكوين/);
+  assert.match(model.disclaimer, /الارتباط لا يعني السببية/);
+});
+
+test('correlation: rolling series present and defaults to a 12-point window', async () => {
+  const { computeCorrelationModel, DEFAULT_ROLLING_WINDOW } = await import(MOD);
+  assert.equal(DEFAULT_ROLLING_WINDOW, 12);
+  const model = computeCorrelationModel(GOLD, CRYPTO_UP, { assetKey: 'btc', window: 3 });
+  assert.ok(Array.isArray(model.rolling));
+  // 4 aligned points, window 3 → 2 rolling entries, both perfectly correlated.
+  assert.equal(model.rolling.length, 2);
+  assert.ok(model.rolling.every((r) => r.coefficient === 1));
+});


### PR DESCRIPTION
… OFF)

Layer the computation + presentation model for a descriptive gold-vs-crypto correlation on top of the Phase 36 crypto plumbing. No live fetch, no chart, no owner-gated files; public entry gated OFF until a crypto feed exists.

- src/lib/correlation.js: pure asset-generic math over {date,price} records — alignSeriesByDate, pearson (null on undefined/zero-variance, [-1,1] clamped), rollingCorrelation (skips zero-variance windows)
- src/lib/gold-crypto-correlation.js: computeCorrelationModel (flag-independent core → ok/insufficient-data/unavailable with strength+direction bands and a bilingual framing) and buildCorrelationView (gated by CRYPTO_PILOT_ENABLED). Every returned model carries the descriptive-only disclaimer (EN+AR).
- tests: correlation.test.js (8) + gold-crypto-correlation.test.js (8)

Correlation is descriptive only — never a prediction, forecast, causal claim, or investment signal. Both modules unimported → tree-shaken. Gold untouched. Gate: build + validate + test (1307 pass, +16) + lint all green.


Claude-Session: https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1

## Summary

Describe the purpose of this PR and the high-level changes.

## Implementation notes

- Phase commits are grouped and labeled `phx/NN:` where `NN` is the phase number.
- Include link-check, smoke tests, and server fallback changes.

## Checklist
- [ ] Run `npm ci` and `npm run quality`
- [ ] Run `npm run build` and `node scripts/node/check-links.js --dir dist`
- [ ] Playwright smoke tests: `npm run test:playwright`

## Gold provider bakeoff checklist

Only applies to PRs that touch the gold provider adapters, bakeoff scripts, X duplicate-post
guard, or production gold-price workflows. See
[`docs/OWNER_ACTIONS_REQUIRED_GOLD_BAKEOFF.md`](../docs/OWNER_ACTIONS_REQUIRED_GOLD_BAKEOFF.md)
for the full owner-side checklist.

- [ ] This PR is **Draft** until bakeoff results exist
- [ ] No production cutover unless explicitly approved
- [ ] Provider secrets added (≥ 2 candidates)
- [ ] Provider smoke test run (`test-gold-providers.yml`)
- [ ] 24h+ bakeoff complete (`gold-provider-bakeoff.yml`)
- [ ] Scorecard reviewed (`data/provider_scorecard.json`)
- [ ] Winning provider selected
- [ ] Backup provider selected
- [ ] Operator checklist filled (`docs/operator-inputs-gold-provider-bakeoff.md`)
- [ ] Dry-run tweet tested with real data (`DRY_RUN_TWEET=true`)
- [ ] Rollback path confirmed (legacy `post_gold.yml` can be re-enabled)
- [ ] `python scripts/python/gold_bakeoff_readiness.py --strict` passes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated library code with no production imports; pilot flag keeps the public entry disabled and gold paths are untouched.
> 
> **Overview**
> Adds **Phase 37** model-layer support for a descriptive gold-vs-crypto correlation view on top of Phase 36 plumbing—**no UI, fetch, or gold changes**, and nothing wires these modules in yet (they stay tree-shaken).
> 
> **`correlation.js`** introduces pure math on `{ date, price }` series: date alignment on shared dates, Pearson *r* (returns `null` when undefined, not `0`), and rolling correlation with zero-variance windows omitted.
> 
> **`gold-crypto-correlation.js`** builds the presentation model via `computeCorrelationModel` (`ok` / `insufficient-data` / `unavailable`) with strength/direction bands, rolling series, bilingual framing, and a mandatory descriptive disclaimer on every status. **`buildCorrelationView`** is gated on **`CRYPTO_PILOT_ENABLED`** and returns `disabled` while the pilot is off.
> 
> Sixteen new unit tests plus a phase report document the scope and owner-only feed dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 565934eda194f4be93310265a80b808e15f198b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->