### PR TITLE
Phase 63 — Freshness-badge metadata regression lock (test-only, mergeable now)

### DIFF
--- a/reports/PHASE-63-freshness-badge-tests.md
+++ b/reports/PHASE-63-freshness-badge-tests.md
@@ -1,0 +1,50 @@
+# Phase 63 — Freshness-badge metadata regression lock (shippable-now)
+
+A regression lock on `src/lib/freshness.js` — the user-facing freshness-badge metadata layer, which
+was **untested**. Immediately mergeable: test-only, no source change, no feed, no flag, no
+dependency on any open PR.
+
+## Why this (direction shift)
+
+I've shipped 18 tested PRs (#589–#607); **none are merged yet**, and Theme B/C's remaining work is
+blocked on those merges + owner feeds. Rather than pile up more dormant flagged-OFF modules, I'm
+shifting to **immediately-mergeable, genuinely-additive** work. This phase locks down a user-visible
+module that had zero test coverage.
+
+## What it guards
+
+`src/lib/freshness.js` decides what the freshness **badge** shows (the "Live / Cached / Delayed / …"
+pill users see) and how the "updated at" timestamp is formatted — none of it tested until now
+(distinct from the already-tested age→state engine in `freshness-policy.js`):
+
+- **`FRESHNESS_CONFIG`** — every state (`live`/`cached`/`delayed`/`estimated`/`fallback`/`closed`/
+  `stale`/`unavailable`) has a tone + `freshness.badge.*` translation key; `stale`/`unavailable`
+  degrade to the `fallback` tone.
+- **`normalizeFreshnessState`** — known states pass through; unknown → `estimated`; a **closed
+  market overrides even `live`** (truth-first).
+- **`getFreshnessMeta`** — maps tone/key, defaults the source to "Gold Ticker Live", preserves an
+  explicit source and `updatedAt`, and downgrades to the closed badge when the market is closed.
+- **`formatUtcTimestamp`** — renders UTC in 24-hour form (never AM/PM), and returns `—` for
+  empty/invalid input; still renders a real string under the Arabic locale.
+
+## What shipped
+
+- **`tests/freshness.test.js`** — 4 tests importing the real module.
+
+Test-only — no source change; the module was already correct, this makes any future regression in
+the badge users see **loud**. Peg / troy-oz / framing untouched.
+
+## Verification
+
+- `node --test tests/freshness.test.js` → 4/4 pass
+- `npm test` → 1396/1396 pass
+- `npm run lint` → clean
+- `npm run build` → success
+- `npm run validate` → exit 0
+
+## ⚠️ Owner: 18 revamp PRs are open and unmerged
+
+#589–#607 are all green. Reviewing/merging a batch — **especially the metals view-model stack
+#601–#606** — unblocks the multi-metal orchestrator + real page wiring and reduces stack risk. Feeds
+still needed: non-gold spot feeds (Theme B), crypto feed (Theme C); plus the 11 monthly gold
+averages for the history backfill (#589) and the French-content review (Phase 41).

--- a/tests/freshness.test.js
+++ b/tests/freshness.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/**
+ * Freshness-badge metadata regression lock (Phase 63, shippable-now).
+ *
+ * `src/lib/freshness.js` maps a freshness state to the user-facing badge (tone + translation key),
+ * normalizes unknown / market-closed states, and formats the UTC "updated at" timestamp — all
+ * user-visible and, until now, untested. This suite pins that behaviour so the badges users see can't
+ * silently regress. Imports the REAL module (no inline copy).
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const MOD = new URL('../src/lib/freshness.js', `file://${__filename}`).href;
+
+test('freshness: config covers every state with a tone + translation key', async () => {
+  const { FRESHNESS_CONFIG } = await import(MOD);
+  for (const state of [
+    'live',
+    'cached',
+    'delayed',
+    'estimated',
+    'fallback',
+    'closed',
+    'stale',
+    'unavailable',
+  ]) {
+    assert.ok(FRESHNESS_CONFIG[state], `missing config for ${state}`);
+    assert.equal(typeof FRESHNESS_CONFIG[state].tone, 'string');
+    assert.match(FRESHNESS_CONFIG[state].translationKey, /^freshness\.badge\./);
+  }
+  // stale / unavailable degrade to the fallback tone.
+  assert.equal(FRESHNESS_CONFIG.stale.tone, 'fallback');
+  assert.equal(FRESHNESS_CONFIG.unavailable.tone, 'fallback');
+});
+
+test('freshness: normalizeFreshnessState — known passes, unknown → estimated, closed market wins', async () => {
+  const { normalizeFreshnessState } = await import(MOD);
+  assert.equal(normalizeFreshnessState('live'), 'live');
+  assert.equal(normalizeFreshnessState('cached'), 'cached');
+  assert.equal(normalizeFreshnessState('nonsense'), 'estimated');
+  assert.equal(normalizeFreshnessState(undefined), 'estimated');
+  // A closed market overrides even a "live" state — truth-first.
+  assert.equal(normalizeFreshnessState('live', { marketOpen: false }), 'closed');
+  assert.equal(normalizeFreshnessState('nonsense', { marketOpen: false }), 'closed');
+});
+
+test('freshness: getFreshnessMeta maps tone/key, defaults source, and honours market-closed', async () => {
+  const { getFreshnessMeta, FRESHNESS_CONFIG } = await import(MOD);
+  const live = getFreshnessMeta({ state: 'live', updatedAt: '2026-07-08T13:05:00Z' });
+  assert.equal(live.state, 'live');
+  assert.equal(live.tone, FRESHNESS_CONFIG.live.tone);
+  assert.equal(live.translationKey, FRESHNESS_CONFIG.live.translationKey);
+  assert.equal(live.updatedAt, '2026-07-08T13:05:00Z');
+  assert.equal(live.source, 'Gold Ticker Live'); // default when source omitted
+
+  // Explicit source is preserved.
+  assert.equal(
+    getFreshnessMeta({ state: 'cached', source: 'gold-api.com' }).source,
+    'gold-api.com'
+  );
+
+  // Unknown state → estimated; defaults with no args → estimated.
+  assert.equal(getFreshnessMeta({ state: 'bogus' }).state, 'estimated');
+  assert.equal(getFreshnessMeta().state, 'estimated');
+
+  // Market closed downgrades to the closed badge regardless of the incoming state.
+  const closed = getFreshnessMeta({ state: 'live', marketOpen: false });
+  assert.equal(closed.state, 'closed');
+  assert.equal(closed.tone, FRESHNESS_CONFIG.closed.tone);
+});
+
+test('freshness: formatUtcTimestamp renders UTC 24h, and guards empty/invalid input', async () => {
+  const { formatUtcTimestamp } = await import(MOD);
+  assert.equal(formatUtcTimestamp(null), '—');
+  assert.equal(formatUtcTimestamp(''), '—');
+  assert.equal(formatUtcTimestamp('not-a-date'), '—');
+
+  const out = formatUtcTimestamp('2026-07-08T13:05:00Z'); // en-GB, UTC, 24h
+  assert.notEqual(out, '—');
+  assert.match(out, /2026/);
+  assert.match(out, /13:05/); // UTC hour:minute, 24-hour (not 1:05 PM)
+  assert.doesNotMatch(out, /AM|PM/i);
+
+  // Arabic locale still renders a real (non-dash) string for a valid date.
+  const ar = formatUtcTimestamp('2026-07-08T13:05:00Z', 'ar');
+  assert.notEqual(ar, '—');
+  assert.equal(typeof ar, 'string');
+});


### PR DESCRIPTION
## Phase 63 — Freshness-badge metadata regression lock (shippable-now)

A regression lock on `src/lib/freshness.js` — the **user-facing freshness-badge metadata layer**, which had **zero test coverage**. Immediately mergeable: test-only, no source change, no feed, no flag, no dependency on any open PR.

### Direction shift (honest note)
I've shipped 18 tested PRs (#589–#607); **none are merged yet**, and Theme B/C's remaining work is blocked on those merges + owner feeds. Rather than pile up more dormant flagged-OFF modules, I'm shifting to **immediately-mergeable, genuinely-additive** work — starting by locking down a user-visible module that was untested.

### What it guards
Distinct from the already-tested age→state engine (`freshness-policy.js`), `freshness.js` decides what the freshness **badge** users see shows, and how the "updated at" timestamp is formatted:
- **`FRESHNESS_CONFIG`** — every state has a tone + `freshness.badge.*` key; `stale`/`unavailable` → `fallback` tone.
- **`normalizeFreshnessState`** — unknown → `estimated`; a **closed market overrides even `live`** (truth-first).
- **`getFreshnessMeta`** — tone/key mapping, default source "Gold Ticker Live", preserves explicit source/`updatedAt`, market-closed downgrade.
- **`formatUtcTimestamp`** — UTC 24-hour (never AM/PM), `—` for empty/invalid, real string under the Arabic locale.

### What shipped
- **`tests/freshness.test.js`** — 4 tests importing the real module. Test-only; makes any future badge regression loud.

### Verification
- `node --test tests/freshness.test.js` → 4/4 pass
- `npm test` → 1396/1396 pass · `npm run lint` clean · `npm run build` success · `npm run validate` exit 0

### ⚠️ Owner: 18 revamp PRs (#589–#607) are open and unmerged
All green. Reviewing/merging a batch — **especially the metals view-model stack #601–#606** — unblocks the multi-metal orchestrator + real page wiring and reduces stack risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation additions only; no runtime or API behaviour changes.
> 
> **Overview**
> Adds **test-only** coverage for `src/lib/freshness.js` (badge tone/translation keys, state normalization, meta defaults, UTC timestamp formatting) via **`tests/freshness.test.js`** — four `node:test` cases that import the real module.
> 
> Also adds **`reports/PHASE-63-freshness-badge-tests.md`** documenting scope, what behaviour is pinned, and verification commands. **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb1171bf33a48e1400d9e04f7aa7909a21a479ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->