### PR TITLE
Phase 64 — Karat purity-map regression lock (test-only, mergeable now)

### DIFF
--- a/reports/PHASE-64-karat-purity-map-tests.md
+++ b/reports/PHASE-64-karat-purity-map-tests.md
@@ -1,0 +1,53 @@
+# Phase 64 — Karat purity-map regression lock (shippable-now)
+
+A regression lock on `src/lib/karatPurity.js` — the pricing-critical karat-code→purity lookup, which
+was **untested**. Immediately mergeable: test-only, no source change, no feed, no flag, no
+dependency on any open PR.
+
+## Why this
+
+Continuing the shippable-now shift (19 tested PRs open and unmerged; more flagged-OFF-pending-feed
+modules would just add to the pile). `karatPurity.js` derives `KARAT_PURITY_MAP` (karat code →
+purity) from the canonical `KARATS` array — a lookup on the pricing hot path — yet had no test. This
+locks it down.
+
+## What it guards
+
+`src/lib/karatPurity.js` is tiny but load-bearing:
+
+```js
+export { KARATS } from '../config/karats.js';
+export const KARAT_PURITY_MAP = Object.fromEntries(KARATS.map((k) => [k.code, k.purity]));
+```
+
+The suite pins:
+
+- **One entry per karat**, each purity **exactly `code / 24`** (24K = 1.0), every value in `(0, 1]`.
+- **Single source of truth** — the re-exported `KARATS` is the _same reference_ as
+  `config/karats.js` (a re-export, not a copy), so the map can't silently diverge from the canonical
+  table.
+- **No stray keys** beyond the canonical karat codes.
+
+## What shipped
+
+- **`tests/karatPurity.test.js`** — 4 tests importing the real modules.
+
+Test-only — no source change; the module was already correct, this makes any future regression in
+the purity lookup **loud**. Complements Phase 54's karat-formula lock (which pinned the pricing
+math); this pins the code→purity map that feeds it. Peg / troy-oz / framing untouched.
+
+## Verification
+
+- `node --test tests/karatPurity.test.js` → 4/4 pass
+- `npm test` → 1396/1396 pass
+- `npm run lint` → clean
+- `npm run build` → success
+- `npm run validate` → exit 0
+
+## ⚠️ Owner: 19 revamp PRs are open and unmerged
+
+#589–#607 and #609 are all green. Reviewing/merging a batch — **especially the metals view-model
+stack #601–#606** — unblocks the multi-metal orchestrator + real page wiring and reduces stack risk.
+Also: please **re-authorize the GitHub connector** (it dropped briefly this session). Feeds still
+needed: non-gold spot feeds (Theme B), crypto feed (Theme C); plus the 11 monthly gold averages for
+the history backfill (#589) and the French-content review (Phase 41).

--- a/tests/karatPurity.test.js
+++ b/tests/karatPurity.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Karat purity-map regression lock (Phase 64, shippable-now).
+ *
+ * `src/lib/karatPurity.js` re-exports `KARATS` and derives `KARAT_PURITY_MAP` (karat code → purity),
+ * a pricing-critical lookup — and it was untested. This suite pins that the map stays the single
+ * source of truth: one entry per karat, each purity exactly `code / 24`, coupled to the canonical
+ * `config/karats.js`, with no stray keys. Imports the REAL modules (no inline copy).
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const MOD = new URL('../src/lib/karatPurity.js', `file://${__filename}`).href;
+const KARATS_CFG = new URL('../src/config/karats.js', `file://${__filename}`).href;
+
+test('karatPurity: map has one entry per KARATS code, each purity = code/24', async () => {
+  const { KARAT_PURITY_MAP, KARATS } = await import(MOD);
+  assert.ok(KARATS.length >= 5, 'expected the full karat set');
+  assert.equal(Object.keys(KARAT_PURITY_MAP).length, KARATS.length);
+  for (const k of KARATS) {
+    assert.equal(KARAT_PURITY_MAP[k.code], k.purity, `map value drift for ${k.code}`);
+    assert.equal(KARAT_PURITY_MAP[k.code], Number(k.code) / 24, `purity != code/24 for ${k.code}`);
+  }
+});
+
+test('karatPurity: 24K is pure gold (1.0) and every purity is in (0, 1]', async () => {
+  const { KARAT_PURITY_MAP } = await import(MOD);
+  assert.equal(KARAT_PURITY_MAP['24'], 1.0);
+  for (const [code, purity] of Object.entries(KARAT_PURITY_MAP)) {
+    assert.equal(typeof code, 'string');
+    assert.ok(purity > 0 && purity <= 1, `purity out of range for ${code}: ${purity}`);
+  }
+});
+
+test('karatPurity: re-exported KARATS is the canonical config array (coupling lock)', async () => {
+  const { KARATS } = await import(MOD);
+  const { KARATS: CANONICAL } = await import(KARATS_CFG);
+  assert.equal(KARATS, CANONICAL); // same reference — re-export, not a copy
+});
+
+test('karatPurity: no stray keys beyond the canonical karat codes', async () => {
+  const { KARAT_PURITY_MAP } = await import(MOD);
+  const { KARATS: CANONICAL } = await import(KARATS_CFG);
+  const canonicalCodes = new Set(CANONICAL.map((k) => k.code));
+  for (const code of Object.keys(KARAT_PURITY_MAP)) {
+    assert.ok(canonicalCodes.has(code), `unexpected key in purity map: ${code}`);
+  }
+});


### PR DESCRIPTION
## Phase 64 — Karat purity-map regression lock (shippable-now)

A regression lock on `src/lib/karatPurity.js` — the **pricing-critical karat-code→purity lookup**, which was **untested**. Immediately mergeable: test-only, no source change, no feed, no flag, no dependency on any open PR.

### What it guards
`karatPurity.js` derives `KARAT_PURITY_MAP` (code → purity) from the canonical `KARATS` array — a lookup on the pricing hot path. The suite pins:
- **One entry per karat**, each purity **exactly `code / 24`** (24K = 1.0), every value in `(0, 1]`.
- **Single source of truth** — the re-exported `KARATS` is the *same reference* as `config/karats.js` (a re-export, not a copy), so the map can't silently diverge.
- **No stray keys** beyond the canonical karat codes.

Complements Phase 54's karat-formula lock (which pinned the pricing *math*); this pins the code→purity *map* that feeds it.

### What shipped
- **`tests/karatPurity.test.js`** — 4 tests importing the real modules. Test-only; makes any future regression in the purity lookup loud. Peg/troy/framing untouched.

### Verification
- `node --test tests/karatPurity.test.js` → 4/4 pass
- `npm test` → 1396/1396 pass · `npm run lint` clean · `npm run build` success · `npm run validate` exit 0

### ⚠️ Owner: 19 revamp PRs (#589–#607, #609) are open and unmerged
All green. Reviewing/merging a batch — **especially the metals view-model stack #601–#606** — unblocks the multi-metal orchestrator + real page wiring. (Also: the GitHub connector dropped briefly this session — please re-authorize it if PR automation stalls.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXfHAEUzwEy3i8fHmgBtU1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only PR with no runtime or pricing logic changes; risk is limited to CI/test maintenance.
> 
> **Overview**
> Adds **test-only** coverage for the pricing hot-path lookup in `src/lib/karatPurity.js` (`KARAT_PURITY_MAP`), which had no tests before.
> 
> **`tests/karatPurity.test.js`** imports the real `karatPurity.js` and `config/karats.js` modules and runs four Node tests: map size matches `KARATS`, each purity equals `code/24` (24K → 1.0) with values in `(0, 1]`, `KARATS` is the same reference as the canonical config re-export, and the map has no extra keys beyond canonical codes.
> 
> A **`reports/PHASE-64-karat-purity-map-tests.md`** note documents scope, verification commands, and merge context. **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc84512eea1db223dd92b43d91eb741bd93423c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->