### PR TITLE
test(e2e): fix stale shops spot-vs-retail assertion (Part III fix 1)

### DIFF
--- a/tests/e2e/shops-search.spec.js
+++ b/tests/e2e/shops-search.spec.js
@@ -131,13 +131,28 @@ test.describe('Shops directory page', () => {
     await expect(resultsArea.first()).toBeAttached();
   });
 
-  test('methodology and spot-vs-retail links are present', async ({ page }) => {
-    // Both internal links should appear on the page somewhere
+  test('methodology link + spot-vs-retail guidance are present', async ({ page }) => {
+    // The methodology explainer is a real internal link.
     const methodologyLink = page.locator('a[href*="methodology"]');
     await expect(methodologyLink.first()).toBeAttached();
 
-    const spotVsRetailLink = page.locator('a[href*="spot-vs-retail"]');
-    await expect(spotVsRetailLink.first()).toBeAttached();
+    // Spot-vs-retail is conveyed as trust *guidance in the disclaimer text* (there is no dedicated
+    // "spot-vs-retail" page/link — the site explains the distinction inline). Assert the guidance is
+    // present where it actually lives rather than asserting a link that does not exist.
+    await page
+      .waitForFunction(
+        () => {
+          const el = document.getElementById('shops-price-disclaimer');
+          return el && el.textContent && el.textContent.length > 50;
+        },
+        { timeout: 5000 }
+      )
+      .catch(() => null);
+    const disclaimerText = (
+      (await page.locator('#shops-price-disclaimer').textContent()) || ''
+    ).toLowerCase();
+    expect(disclaimerText).toMatch(/spot|reference|estimate/);
+    expect(disclaimerText).toMatch(/retail|shop|confirm|verify|making charge/);
   });
 
   test('listing tabs render and sponsored disclosure is visible on sponsored tab', async ({


### PR DESCRIPTION
## What & why
`shops-search.spec.js:134` asserted `a[href*="spot-vs-retail"]` — a dedicated link that **does not exist** anywhere in the repo. The site conveys the spot-vs-retail distinction as **trust guidance in the `#shops-price-disclaimer` text** (the sibling test at line 68 already verifies exactly this). The old assertion was stale.

## Fix
Assert the **methodology link** (which is real) + the **spot-vs-retail guidance in the disclaimer** (where it actually lives) — mirroring line 68. **No link invented to satisfy the test.**

## Provenance
Pre-existing failure — fails identically on the `pre-pr-convergence-2026-07-10` baseline tag. **Not a convergence regression.** First of two Part III e2e fixes.

## Verification
`npx playwright test tests/e2e/shops-search.spec.js --project=chromium` → **12/12 pass** (was 11/1). eslint + prettier clean.

## Rollback
Revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production code or runtime behavior affected.
> 
> **Overview**
> Fixes a **stale Playwright assertion** in `shops-search.spec.js` that expected an internal `spot-vs-retail` link the app does not ship.
> 
> The test still checks the real **methodology** link, but now validates **spot-vs-retail trust copy** in `#shops-price-disclaimer` (wait for hydration, then regex on disclaimer text), aligned with the existing disclaimer test elsewhere in the same file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60a51253c722fdf674066425bcb38402943b0948. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->