### PR TITLE
fix(calculator): tracker handoff visible on desktop after a result (Part III fix 2, P1)

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -292,32 +292,36 @@
             </div>
           </div>
 
-          <div class="calc-tracker-handoff" id="calc-tracker-handoff" hidden>
-            <div class="calc-tracker-handoff__copy">
-              <span class="section-kicker" id="calc-tracker-kicker">Tracker handoff</span>
-              <h3 class="calc-tracker-handoff__title" id="calc-tracker-title">Compare this in the live tracker</h3>
-              <p class="calc-tracker-handoff__text" id="calc-tracker-copy">
-                Open the tracker with the same karat and currency so you can compare the current
-                reference move, historical range, and market context.
-              </p>
-              <p class="calc-tracker-handoff__note" id="calc-live-tracker-note">
-                Live tracker price helper will appear here when spot data is loaded.
-              </p>
-            </div>
-            <div class="calc-tracker-handoff__actions">
-              <a href="tracker.html" class="btn btn-primary" id="calc-tracker-link"
-                >Compare this in tracker</a
-              >
-              <a href="compare.html" class="btn btn-outline" id="calc-country-link"
-                >Open country page</a
-              >
-              <a href="methodology.html" class="btn btn-outline" id="calc-tracker-methodology"
-                >Methodology note</a
-              >
-            </div>
-          </div>
         </div>
       </section>
+
+      <!-- Tracker handoff — revealed after a result. Kept OUTSIDE .calc-flow (which is
+           display:none on desktop as a mobile-only onboarding primer) so the CTA is visible
+           on every viewport, not just mobile. -->
+      <div class="calc-tracker-handoff" id="calc-tracker-handoff" hidden>
+        <div class="calc-tracker-handoff__copy">
+          <span class="section-kicker" id="calc-tracker-kicker">Tracker handoff</span>
+          <h3 class="calc-tracker-handoff__title" id="calc-tracker-title">Compare this in the live tracker</h3>
+          <p class="calc-tracker-handoff__text" id="calc-tracker-copy">
+            Open the tracker with the same karat and currency so you can compare the current
+            reference move, historical range, and market context.
+          </p>
+          <p class="calc-tracker-handoff__note" id="calc-live-tracker-note">
+            Live tracker price helper will appear here when spot data is loaded.
+          </p>
+        </div>
+        <div class="calc-tracker-handoff__actions">
+          <a href="tracker.html" class="btn btn-primary" id="calc-tracker-link"
+            >Compare this in tracker</a
+          >
+          <a href="compare.html" class="btn btn-outline" id="calc-country-link"
+            >Open country page</a
+          >
+          <a href="methodology.html" class="btn btn-outline" id="calc-tracker-methodology"
+            >Methodology note</a
+          >
+        </div>
+      </div>
 
       <!-- ── Calculator panels (crossfade) ── -->
       <div class="tab-panels--crossfade calc-tab-panels">


### PR DESCRIPTION
## The bug (pre-existing P1)
After computing a result, the calculator's handoff CTA — **"Compare this in tracker" / "Open country page"** (`#calc-tracker-handoff`, `#calc-tracker-link`) — was **invisible on desktop**. Root cause: it was mis-nested as the last child of `section.calc-flow`, the *"Mobile flow"* onboarding primer that is `display:none` on viewports ≥641px. The reveal logic ran (`handoff.hidden=false`), but the element was `0×0` because its ancestor was `display:none`. Desktop users never saw the post-result CTA.

Diagnosed by walking the ancestor chain: `#calc-tracker-link` (flex, "visible", **0×0**) → `.calc-tracker-handoff__actions` → `#calc-tracker-handoff` → `.calc-flow-inner` → **`section.calc-flow` (display:none)**.

## Fix
Move the `#calc-tracker-handoff` block **out of `.calc-flow`** to a viewport-agnostic sibling. The genuinely mobile-only pieces (3-step primer, `.mobile-result-dock`) stay mobile-only. **No JS/CSS logic change** — `updateTrackerHandoff()` and CSS untouched.

## Verification (chromium)
- `calculator.spec.js` → **8/8 pass** (was failing on `:54`).
- Handoff link now **240×44 @1280px** and **332×44 @390px** (was 0×0); **zero horizontal overflow** at both.
- `npm run lint` clean · `npm test` **1574/0** · `prettier --check` clean · production build ✓.

## Provenance
Pre-existing (fails identically on `pre-pr-convergence-2026-07-10`); **not a convergence regression.** Second of two Part III e2e fixes.

## Rollback
Revert this commit (moves the block back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> HTML-only DOM move with unchanged element IDs; reveal logic and styles are untouched, so risk is limited to layout/order on the calculator page.
> 
> **Overview**
> **Moves the post-result tracker handoff block** (`#calc-tracker-handoff`) out of `section.calc-flow` so it is no longer hidden on desktop.
> 
> That section is the mobile-only onboarding primer and is **`display: none` at ≥641px**, so when JS set `hidden=false` on the handoff, desktop users still saw a **0×0** CTA. The block is now a **sibling** between `.calc-flow` and the calculator tab panels, with the same markup and IDs; **no JS or CSS changes**.
> 
> Mobile flow pieces (3-step primer, mobile result dock) stay inside `.calc-flow`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f506d11dbe5e40ed70722367de5203d90c6a67b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->