### PR TITLE
refactor(compare): canonical resolver + shared formula (F-1 correctness increment)

### DIFF
--- a/src/pages/compare.js
+++ b/src/pages/compare.js
@@ -19,6 +19,7 @@ import { CONSTANTS, COUNTRIES, KARATS } from '../config/index.js';
 import { getMarketIntel } from '../config/market-intel.js';
 import * as api from '../lib/api.js';
 import * as cache from '../lib/cache.js';
+import { getCanonicalSpot } from '../lib/spot-resolver.js';
 import { formatPrice } from '../lib/formatter.js';
 import { mountSharedShell } from '../components/site-shell.js';
 import { injectBreadcrumbs } from '../components/breadcrumbs.js';
@@ -205,13 +206,19 @@ function fmtPct(value) {
 // ── Live data ─────────────────────────────────────────────────────────────────
 async function fetchLiveData() {
   try {
-    const [goldRes, fxRes] = await Promise.allSettled([api.fetchGold(), api.fetchFX()]);
-    if (goldRes.status === 'fulfilled') {
-      STATE.spotUsdPerOz = goldRes.value.price;
-      STATE.goldPriceUsdPerOz = goldRes.value.price;
-      STATE.freshness.goldUpdatedAt = goldRes.value.updatedAt || new Date().toISOString();
-      STATE.spotSource = goldRes.value.source === 'cache-fallback' ? 'cached/fallback' : 'live';
-      cache.saveGoldPrice(goldRes.value.price, goldRes.value.updatedAt);
+    // F-1: read spot from the SAME canonical resolver the homepage + calculator
+    // use, so all three surfaces derive from one snapshot and cannot diverge.
+    const [snapRes, fxRes] = await Promise.allSettled([
+      getCanonicalSpot({ force: true }),
+      api.fetchFX(),
+    ]);
+    if (snapRes.status === 'fulfilled' && snapRes.value?.ok) {
+      const snap = snapRes.value;
+      STATE.spotUsdPerOz = snap.spotUsdPerOz;
+      STATE.goldPriceUsdPerOz = snap.spotUsdPerOz;
+      STATE.freshness.goldUpdatedAt = snap.freshness.updatedAt || new Date().toISOString();
+      STATE.spotSource = snap.freshness.state === 'live' ? 'live' : 'cached/fallback';
+      cache.saveGoldPrice(snap.spotUsdPerOz, snap.freshness.updatedAt);
     } else if (STATE.spotUsdPerOz) {
       STATE.spotSource = 'cached/fallback';
     }

--- a/src/pages/compare/compare-core.js
+++ b/src/pages/compare/compare-core.js
@@ -14,6 +14,7 @@
  */
 
 import { CONSTANTS } from '../../config/index.js';
+import { usdPerGram as metalUsdPerGram } from '../../lib/price-calculator.js';
 
 export const DEFAULT_COMPARE_CODES = ['AE', 'SA', 'KW', 'QA'];
 export const MAX_COMPARE = 6;
@@ -58,7 +59,9 @@ export function fxRateFor(country, rates) {
  */
 export function buildComparisonRows({ spotUsdPerOz, rates, countries, karat, getIntel }) {
   const purity = karatPurity(karat);
-  const usdPerGram = spotUsdPerOz && purity ? (spotUsdPerOz / CONSTANTS.TROY_OZ_GRAMS) * purity : 0;
+  // Use the shared canonical formula (not an inline copy) so Compare's spot-linked
+  // gold value stays byte-identical to the homepage/calculator derivation (F-1).
+  const usdPerGram = metalUsdPerGram(spotUsdPerOz, purity);
 
   return (countries || []).map((country) => {
     const intel = (getIntel && getIntel(country.code)) || {};


### PR DESCRIPTION
## Compare — F-1 canonical pricing increment

Brings the Compare page onto the same canonical pricing discipline as the shipped homepage (#642) and calculator (#643).

**Changes**
- `compare.js` reads spot via `getCanonicalSpot()` (shared memoized snapshot) instead of its own `fetchGold`, with honest snapshot-derived freshness.
- `compare-core.buildComparisonRows` uses the shared `price-calculator.usdPerGram()` instead of an inline formula copy → Compare's spot-linked value is now covered by the homepage↔calculator parity lock and can't drift.

**Invariants / honesty:** peg 3.6725, troy 31.1035, purity karat/24; the all-in retail estimate (median making charge + VAT) stays explicitly reference-only — no fabricated retail, no advice/"cheapest" claims beyond the existing labelled callout.

**Validation:** 1586/1586 tests, lint/build/validate green; browser-verified — spot 4,121.40 → 486.63 AED/g 24K matches homepage+calculator; 74 rows render; 0 console errors.

**Scope note (honest):** this is the **F-1 correctness increment** for Compare, not the full visual V2 rebuild (intuitive setup, length-encoded bars, difference markers, mobile bottom-sheet, RTL bar-direction) described in the broader plan — that visual rebuild is the next increment on this branch. Shipping the correctness foundation first keeps price integrity consistent across all three surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted pricing-path refactor with no auth or data-model changes; behavior should match other surfaces more closely, with parity tests as the main safety net.
> 
> **Overview**
> Aligns the **Compare** page with homepage and calculator pricing so all three surfaces share one spot snapshot and one gram formula.
> 
> **`compare.js`** now loads XAU/USD via **`getCanonicalSpot({ force: true })`** instead of **`api.fetchGold()`**, mapping snapshot freshness into state and cache the same way other surfaces do.
> 
> **`compare-core.buildComparisonRows`** derives spot-linked USD/gram through **`price-calculator.usdPerGram()`** instead of duplicating `(spot / troy oz) × purity`, so Compare participates in the existing parity lock and cannot drift on its own copy of the math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94f6550867776bc896bd27e49bdc2e5c9267de31. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->