### PR TITLE
fix(deploy): unblock Pages deploy — theme preinit + noindex on design-review mockups

### DIFF
--- a/docs/design/reviews/concepts/homepage-alternatives.html
+++ b/docs/design/reviews/concepts/homepage-alternatives.html
@@ -2,7 +2,40 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
+    <script>
+      (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
+        try {
+          var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
+          var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
+          var resolved =
+            mode === 'light' || mode === 'dark'
+              ? mode
+              : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light';
+          el.setAttribute('data-theme', resolved);
+          el.setAttribute('data-theme-mode', mode);
+        } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
+      })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
     <title>GoldTickerLive — Homepage alternatives B & C (CONCEPT)</title>
     <style>
       :root {

--- a/docs/design/reviews/concepts/homepage-hero-concept.html
+++ b/docs/design/reviews/concepts/homepage-hero-concept.html
@@ -2,7 +2,40 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
+    <script>
+      (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
+        try {
+          var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
+          var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
+          var resolved =
+            mode === 'light' || mode === 'dark'
+              ? mode
+              : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light';
+          el.setAttribute('data-theme', resolved);
+          el.setAttribute('data-theme-mode', mode);
+        } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
+      })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
     <title>GoldTickerLive — Homepage Hero CONCEPT</title>
     <style>
       /* CONCEPT ONLY — demonstrates Visual Direction V2. Fonts here are system fallbacks;

--- a/docs/design/reviews/mockups/homepage-A-synthesis-ar.html
+++ b/docs/design/reviews/mockups/homepage-A-synthesis-ar.html
@@ -2,7 +2,40 @@
 <html lang="ar" dir="rtl">
   <head>
     <meta charset="utf-8" />
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
+    <script>
+      (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
+        try {
+          var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
+          var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
+          var resolved =
+            mode === 'light' || mode === 'dark'
+              ? mode
+              : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light';
+          el.setAttribute('data-theme', resolved);
+          el.setAttribute('data-theme-mode', mode);
+        } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
+      })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
     <title>GoldTickerLive — الصفحة الرئيسية (نموذج تصميم)</title>
     <style>
       /* DESIGN MOCKUP (Arabic/RTL) — illustrative sample values, not live. Production self-hosts a

--- a/docs/design/reviews/mockups/homepage-A-synthesis.html
+++ b/docs/design/reviews/mockups/homepage-A-synthesis.html
@@ -2,7 +2,40 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
+    <script>
+      (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
+        try {
+          var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
+          var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
+          var resolved =
+            mode === 'light' || mode === 'dark'
+              ? mode
+              : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light';
+          el.setAttribute('data-theme', resolved);
+          el.setAttribute('data-theme-mode', mode);
+        } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
+      })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
     <title>GoldTickerLive — Homepage A-synthesis (DESIGN MOCKUP)</title>
     <style>
       /* ============================================================================

--- a/docs/design/reviews/mockups/system-scale.html
+++ b/docs/design/reviews/mockups/system-scale.html
@@ -2,7 +2,40 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <!-- gtl-theme-preinit: theme + reveal arming before first paint; fails open if JS is unavailable -->
+    <script>
+      (function () {
+        var el = document.documentElement;
+        el.classList.add('js');
+        try {
+          var p = JSON.parse(localStorage.getItem('user_prefs') || '{}');
+          var mode = p.theme === 'light' || p.theme === 'dark' || p.theme === 'auto' ? p.theme : 'auto';
+          var resolved =
+            mode === 'light' || mode === 'dark'
+              ? mode
+              : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light';
+          el.setAttribute('data-theme', resolved);
+          el.setAttribute('data-theme-mode', mode);
+        } catch (e) {}
+        window.addEventListener(
+          'load',
+          function () {
+            setTimeout(function () {
+              var vh = window.innerHeight || 0;
+              var nodes = document.querySelectorAll('[data-reveal]:not(.is-in-view)');
+              for (var i = 0; i < nodes.length; i++) {
+                var r = nodes[i].getBoundingClientRect();
+                if (r.top < vh && r.bottom > 0) nodes[i].classList.add('is-in-view');
+              }
+            }, 900);
+          }
+        );
+      })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
     <title>GoldTickerLive — System scale across the product (DESIGN MOCKUPS)</title>
     <style>
       /* DESIGN MOCKUPS — the ONE design language applied across the product to prove it scales.


### PR DESCRIPTION
## P0 hotfix — production deploy blocked

The Pages deploy for the PR #641 merge **failed** (`npm run validate` exit 1), and every push to `main` since has failed the same gate. **Live production is stuck at the #651 deploy** — #641's changes (and subsequent data refreshes) never shipped.

### Root cause
PR #641 added 5 standalone design-review HTML docs:
- `docs/design/reviews/concepts/homepage-alternatives.html`
- `docs/design/reviews/concepts/homepage-hero-concept.html`
- `docs/design/reviews/mockups/homepage-A-synthesis{,-ar}.html`
- `docs/design/reviews/mockups/system-scale.html`

The repo-wide `validate` chain walks all `*.html` and enforces two invariants these files violated:
1. `inject-theme-preinit.js --check` → missing the `gtl-theme-preinit` snippet (first failure; CI stopped here)
2. `check-seo-meta.js` → internal pages missing `<meta name="robots" content="noindex,...">`

### Fix
Stamped the **standard** preinit snippet (byte-identical to the 17 other docs HTML files) via the injector, and added `noindex, nofollow` (matching `styleguide.html`). These are non-deployed design artifacts — deploy.yml copies only `assets src data styles` into `dist`, not `docs/` — so this purely satisfies the invariants.

### Verification
- `npm run validate` → **exit 0** (was exit 1 on `main`)
- Diff is +33 lines/file, snippet-only, no content change

Merging restores green deploys and ships the backlog (#641 + data refreshes) to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Head-only changes to non-deployed docs HTML; no production routes, auth, or data logic affected.
> 
> **Overview**
> Unblocks **`npm run validate`** (and thus Pages deploy) for five **`docs/design/reviews/`** HTML files that were added without passing repo-wide HTML gates.
> 
> Each file gets the **standard `gtl-theme-preinit`** head snippet (same as other docs HTML) so `inject-theme-preinit.js --check` passes, and **`<meta name="robots" content="noindex, nofollow">`** so `check-seo-meta.js` treats them as internal design artifacts. **No mockup body or styling changes** — head-only compliance. These paths are not copied into production **`dist`** by deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e72cc7fac119a9da38c956ef45e3065efb0278be. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->