### PR TITLE
feat(nav): inert background behind open mobile drawer (a11y hardening)

### DIFF
--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -685,6 +685,29 @@ ${spriteMarkupIfAbsent()}
   }
 
   // ── Drawer helpers ──────────────────────────────────────────────────────────
+  // Make everything behind the open drawer `inert` so keyboard Tab order and AT
+  // virtual-cursor cannot escape into the page while the mobile menu is open.
+  // The existing hand-rolled focus trap only wraps Tab; `inert` also removes the
+  // background from the accessibility tree and blocks pointer/AT reach. The nav
+  // host (the header, which contains the nav, drawer + backdrop) stays
+  // interactive; every other top-level body child is marked only if we added it,
+  // so any pre-existing `inert` elsewhere on the page is left untouched.
+  const _navHost = navEl.closest('header') || navEl.parentElement || navEl;
+  function setBackgroundInert(on) {
+    Array.from(document.body.children).forEach((el) => {
+      if (el === _navHost || el.contains(_navHost) || _navHost.contains(el)) return;
+      if (on) {
+        if (!el.hasAttribute('inert')) {
+          el.setAttribute('inert', '');
+          el.setAttribute('data-nav-inert', '');
+        }
+      } else if (el.hasAttribute('data-nav-inert')) {
+        el.removeAttribute('inert');
+        el.removeAttribute('data-nav-inert');
+      }
+    });
+  }
+
   function setDrawerState(isOpen) {
     const d = NAV_DATA[_currentLang] || NAV_DATA.en;
     navEl.classList.toggle('nav--open', isOpen);
@@ -696,7 +719,12 @@ ${spriteMarkupIfAbsent()}
     burger.setAttribute('aria-label', isOpen ? d.closeMenu : d.openMenu);
     burger.classList.toggle('is-open', isOpen);
     if (drawerCloseBtn) drawerCloseBtn.setAttribute('aria-label', d.closeMenu);
+    // `<body>` is the scroll container on this site (html,body{height:100%;
+    // overflow:auto}); toggling its overflow locks the background scroller and
+    // preserves scrollTop on reopen. (A position:fixed lock would be wrong here —
+    // it is for window-scroller layouts, not this body-scroller one.)
     document.body.style.overflow = isOpen ? 'hidden' : '';
+    setBackgroundInert(isOpen);
     const moreBtn = document.querySelector('[data-mobile-nav="menu"]');
     if (moreBtn) moreBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
   }


### PR DESCRIPTION
## What
Make everything behind the mobile nav drawer `inert` while it's open, so keyboard Tab order **and** AT virtual-cursor / screen-reader navigation cannot escape into the page content behind the overlay.

## Why
Audit of the shared shell (`src/components/nav.js`) found the drawer already:
- traps **Tab** focus (hand-rolled wrap),
- handles **Escape**,
- locks **background scroll** via `body { overflow:hidden }` — which is the *correct* lock for this site's layout (`html,body{height:100%; overflow:auto}` makes `<body>` the scroll container, not the window; a `position:fixed` lock would be wrong here and was explicitly avoided).

The one genuine gap: the hand-rolled Tab trap left the background in the **accessibility tree**, so a screen-reader swipe / virtual cursor could still reach page content behind the open drawer. `inert` closes that gap and hardens the trap.

## How
-  marks every top-level `document.body` child **except the nav host** (the `<header>`, which contains the nav, drawer + backdrop) with `inert`.
- Only attributes we add (tagged `data-nav-inert`) are removed on close, so any pre-existing `inert` on the page is preserved.
- Wired into the existing `setDrawerState()`. Scroll-lock behavior is unchanged.

28-line addition to `nav.js`; no CSS, no data, no other files.

## Verification (Playwright, 390px mobile, EN + AR)
- Background wheel-scroll stays locked while open; `scrollTop` preserved across open→close.
- 15× Tab never leaves `#nav-drawer` (never lands on an `[inert]` element).
- Escape closes the drawer and returns focus to the hamburger (not stranded on inert).
- `inert`/markers fully cleaned up on close.
- No console errors across home / calculator / learn / shops.

**Gates:** `npm test` 1586 pass · `eslint` clean · `npm run build` exit 0 (no HTML mutations) · `npm run validate` exit 0.

_Note: a pre-existing `stylelint` error in `styles/pages/shops-redesign.css:14` (unrelated to this change) is tracked separately._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to mobile drawer open/close in `nav.js`; no auth, data, or API impact, with explicit cleanup to avoid clobbering other `inert` usage.
> 
> **Overview**
> While the mobile nav drawer is open, **all top-level `body` children except the header/nav host** are now marked **`inert`**, so screen readers and virtual cursors cannot reach page content behind the overlay. The existing Tab focus trap and **`body { overflow: hidden }`** scroll lock are unchanged; this closes the gap where background nodes stayed in the accessibility tree.
> 
> **`setBackgroundInert`** only adds `inert` when absent and tags those nodes with **`data-nav-inert`** so close removes only what nav added—pre-existing `inert` elsewhere is left alone. It runs from **`setDrawerState`** on every open/close (hamburger, backdrop, Escape, resize, link clicks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91e1617e7e1efa58de723c41a340b990e7fa0bc3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->