### PR TITLE
fix(dark): close remaining dark-mode gaps — invest cards, karat pill, bottom-nav labels

### DIFF
--- a/styles/pages/compare-redesign.css
+++ b/styles/pages/compare-redesign.css
@@ -55,6 +55,15 @@
   border-color: var(--color-gold);
   color: var(--color-gold-dark);
 }
+
+/* Dark mode: --color-gold-bg is a near-black tint, so the light-mode gold-dark
+   label (further dimmed to near-black by legacy compare.css `--color-on-gold`)
+   renders ~1:1 on it. Restore a legible assay-gold label matching the active
+   bottom-nav pill. Selector outranks `[data-theme='dark'] .compare-karat-btn.is-active`. */
+[data-theme='dark'] .compare-karat button[aria-pressed='true'],
+[data-theme='dark'] .compare-karat button.is-active {
+  color: var(--color-gold-light);
+}
 .compare-karat button:focus-visible,
 .compare-chip:focus-visible,
 .compare-sort-btn:focus-visible {

--- a/styles/pages/invest.css
+++ b/styles/pages/invest.css
@@ -1021,3 +1021,50 @@ body.invest-page {
   stroke-linecap: round;
   stroke-linejoin: round;
 }
+
+/* ── Dark mode ─────────────────────────────────────────────────────────────
+   The investing planner + product-choice cards were authored as light "paper"
+   cards (white/cream surfaces, near-black ink). Every other surface on the
+   embedding learn page follows the tokenised dark palette, so in dark mode
+   these cards read as bright white cut-outs. Flip only the light-locked
+   surfaces to raised dark tokens and lift their ink — the many translucent
+   dark-context surfaces above already render correctly and are left untouched.
+   Scoped to [data-theme='dark'] per the page-level dark convention (the token
+   layer owns the pre-JS OS-preference fallback). */
+[data-theme='dark'] {
+  --invest-card: var(--color-surface); /* raised dark card, matches learn */
+  --invest-card-soft: var(--color-surface-2);
+  --invest-dark: var(--color-text); /* ink used on the flipped cards */
+}
+
+/* Form inputs + chips (hard-coded white bg / near-black ink) */
+[data-theme='dark'] .invest-number {
+  background: var(--color-surface-2);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+[data-theme='dark'] .invest-chip:not(.is-active) {
+  background: var(--color-surface-2);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+[data-theme='dark'] .invest-label {
+  color: var(--color-text);
+}
+
+/* Product-choice compare cards (bg flips via --invest-card; lift the ink) */
+[data-theme='dark'] .invest-compare-title {
+  color: var(--color-text);
+}
+
+[data-theme='dark'] .invest-compare-copy,
+[data-theme='dark'] .invest-compare-list {
+  color: var(--color-text-muted);
+}
+
+[data-theme='dark'] .invest-compare-tag {
+  background: var(--color-gold-bg);
+  color: var(--color-gold-light);
+}

--- a/styles/partials/utilities.css
+++ b/styles/partials/utilities.css
@@ -668,11 +668,12 @@ body > * {
 }
 
 [data-theme='dark'] .mobile-bottom-nav-item {
-  color: rgb(240 237 216 / 38%);
+  /* 62% clears WCAG AA (~6.6:1 on the near-black bar); 38% was ~2.96:1. */
+  color: rgb(240 237 216 / 62%);
 }
 
 [data-theme='dark'] .mobile-bottom-nav-item:hover {
-  color: rgb(240 237 216 / 60%);
+  color: rgb(240 237 216 / 85%);
 }
 
 [data-theme='dark'] .mobile-bottom-nav-item.is-active {
@@ -689,11 +690,12 @@ body > * {
   }
 
   :root:not([data-theme='light']) .mobile-bottom-nav-item {
-    color: rgb(240 237 216 / 38%);
+    /* 62% clears WCAG AA (~6.6:1 on the near-black bar); 38% was ~2.96:1. */
+    color: rgb(240 237 216 / 62%);
   }
 
   :root:not([data-theme='light']) .mobile-bottom-nav-item:hover {
-    color: rgb(240 237 216 / 60%);
+    color: rgb(240 237 216 / 85%);
   }
 
   :root:not([data-theme='light']) .mobile-bottom-nav-item.is-active {


### PR DESCRIPTION
## P6 — Dark-mode cohesion pass

A full per-page dark audit — homepage, calculator, compare, portfolio, learn, shops, heatmap, market, country (dubai), methodology, glossary, tracker × EN+AR × desktop+mobile, with axe `color-contrast` + a light-surface luminance scan — confirmed the shared shell and every redesigned page **already** render a cohesive premium warm-charcoal "night-market terminal" dark theme (token-driven, near-zero hardcoded colour). No rebuild needed. Three genuine defects remained; this PR fixes exactly those.

### Fixes (all strictly `[data-theme='dark']`-scoped → zero light-mode impact)

**1. Learn — investing planner + product-choice cards rendered pure white**
`invest.css` authored those as light "paper" cards (`--invest-card: #fff`, near-black ink) with no dark support, so they read as bright white cut-outs on the otherwise-dark learn page. Flipped only the light-locked surfaces to raised dark tokens and lifted the ink; the many translucent dark-context surfaces already rendered correctly and are untouched.

**2. Compare — active karat pill invisible (~1.05:1)**
The redesign layer set the active pill background to `--color-gold-bg` (a near-black tint in dark) while legacy `compare.css` forced the label to `--color-on-gold` (near-black) → near-black on near-black. Restored a legible assay-gold label (`--color-gold-light`, ~12:1), matching the active bottom-nav pill.

**3. Shell — inactive mobile bottom-nav labels failed WCAG AA**
`rgb(240 237 216 / 38%)` ≈ **2.96:1** on the near-black bar. Raised to 62% (~6.6:1); hover 60%→85%. Both the `[data-theme='dark']` and OS-preference blocks updated.

### Verification
- Before → after (Playwright, dark, mocked fresh price): axe `color-contrast` violations across all pages **5 → 0**; unintended light surfaces on learn **6 → 1** (the 1 is the intentional focus skip-link).
- Compare active karat pill contrast **1.05 → 12.23:1**.
- Light mode unaffected by construction (every rule is dark-scoped).

### Gate
`stylelint` · `eslint` · `npm run validate` (deploy gate, exit 0) · `npm test` **1586/1586** · `npm run build` (exit 0, 0 tracked-file mutations) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS scoped to dark theme and OS dark preference; no logic, auth, or data-path changes.
> 
> **Overview**
> Closes three **dark-mode-only** contrast/cohesion gaps; every rule is `[data-theme='dark']`-scoped (plus matching `prefers-color-scheme: dark` blocks for the shell), so light mode is unchanged.
> 
> **Learn / invest embed** — Planner and product-choice blocks that used light “paper” surfaces (`--invest-card`, hard-coded white inputs/chips) now remap card tokens to raised dark surfaces and retarget labels, inputs, chips, and compare-card copy/tags to theme text/muted/gold tokens so they no longer read as white cut-outs on the dark learn page.
> 
> **Compare** — Active karat pills keep `--color-gold-bg` in dark but label color is overridden to `--color-gold-light` so text is legible against the near-black gold tint (fixes ~1:1 contrast from legacy `--color-on-gold`).
> 
> **Shell** — Inactive mobile bottom-nav label opacity goes **38% → 62%** (hover **60% → 85%**) on the dark bar to meet WCAG AA; active state still uses `--color-gold-light`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 746cd30b35f0d422105c236020820acc53ae0bf3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->