### PR TITLE
fix(shell): feed ticker a canonical baseline so content pages show honest freshness

### DIFF
--- a/src/components/site-shell.js
+++ b/src/components/site-shell.js
@@ -1,8 +1,43 @@
 import { injectNav, updateNavLang } from './nav.js';
 import { injectFooter } from './footer.js';
-import { injectTicker, updateTickerLang } from './ticker.js';
+import { injectTicker, updateTicker, updateTickerLang } from './ticker.js';
 import { injectSpotBar, updateSpotBarLang } from './spotBar.js';
+import { getCanonicalSpot, karatPerGram } from '../lib/spot-resolver.js';
 import { installErrorReporter } from '../lib/error-reporter.js';
+
+/**
+ * Feed the shared price ticker a canonical-snapshot baseline so EVERY page
+ * shows one consistent freshness state — not just the tool pages whose own
+ * controllers call updateTicker(). Content pages (learn, market, methodology,
+ * glossary, country) previously left the ticker stuck at "Unavailable" even
+ * though the exact same snapshot was available elsewhere, contradicting the
+ * honest-freshness promise.
+ *
+ * Guarded so it never regresses richer data: it only writes while the ticker
+ * is still in its initial `unavailable` state, so any page that fed real data
+ * first — above all the Tracker's multi-tier live engine — always wins, and a
+ * late-resolving baseline is skipped. Failures leave the honest "Unavailable"
+ * state untouched.
+ */
+async function feedTickerBaseline() {
+  const bar = document.getElementById('gold-ticker');
+  if (!bar || bar.getAttribute('data-freshness') !== 'unavailable') return;
+  const snap = await getCanonicalSpot();
+  if (!snap || !snap.ok) return;
+  const current = document.getElementById('gold-ticker');
+  // Re-check after the await — a page controller may have fed live data meanwhile.
+  if (!current || current.getAttribute('data-freshness') !== 'unavailable') return;
+  updateTicker({
+    xauUsd: snap.spotUsdPerOz,
+    uae24k: snap.aedPerGram24k,
+    uae22k: karatPerGram(snap, '22', 'aed'),
+    uae21k: karatPerGram(snap, '21', 'aed'),
+    uae18k: karatPerGram(snap, '18', 'aed'),
+    updatedAt: snap.freshness.updatedAt,
+    hasLiveFailure: snap.freshness.state !== 'live',
+    isFallback: snap.freshness.isFallback,
+  });
+}
 
 /**
  * Run a shell-mounting step in isolation. A failure in one surface (e.g. the
@@ -41,6 +76,11 @@ export function mountSharedShell(options = {}) {
   if (withSpotBar) safeMount('spot-bar', () => injectSpotBar(lang, depth));
   safeMount('footer', () => injectFooter(lang, depth));
   safeMount('ticker', () => injectTicker(lang, depth));
+  // Baseline freshness for every page (esp. content pages without their own
+  // price controller). Fire-and-forget; guarded to never clobber live data.
+  feedTickerBaseline().catch((error) => {
+    console.error('[site-shell] ticker baseline feed failed:', error);
+  });
 
   return {
     navCtrl,


### PR DESCRIPTION
## P5 — Consistent trust/freshness state across data-driven pages

### The inconsistency (verified live on production)
The shared shell injects the price ticker on every page but never feeds it — only the seven **tool-page** controllers (tracker, heatmap, calculator, shops, home, compare, portfolio) call `updateTicker()`. **Content pages** (learn, market, methodology, glossary, country) left the ticker stuck at **"Unavailable"** with `—` values.

The same moment, on the same snapshot:
| page | before |
|---|---|
| learn, market, methodology, glossary, dubai | **Unavailable** (no values) |
| compare, heatmap, home, tracker | Closed · $4,121.40 · 12 min ago |

A user on `/learn` was told prices were unavailable while `/compare` showed them fine — a live contradiction of the honest-freshness promise.

### Fix
`mountSharedShell()` now fetches the canonical snapshot (`getCanonicalSpot` — the same resolver the other price surfaces already use) and feeds the ticker a baseline.

**Guarded so it never regresses richer data:** it writes only while the ticker is still in its initial `unavailable` state (re-checked after the await), so any page that fed real data first — above all the **Tracker's multi-tier live engine** — always wins, and a late baseline is skipped. The Tracker is **not** migrated to the snapshot resolver; its `updateTicker()` still overrides. A fetch failure leaves the honest "Unavailable" state untouched.

### Verification
Local render across every page type — learn / market / methodology / glossary / dubai now show **`Closed · $4,121.40`** consistently with compare / tracker; **0 console errors** on any page. Tool pages and the Tracker engine unaffected.

### Gate
`eslint` · `npm run validate` · `npm test` **1586/1586** · `npm run build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only freshness display in the site shell with explicit guards against overwriting non-unavailable ticker state; no auth or data-model changes.
> 
> **Overview**
> **Content pages** (learn, market, methodology, glossary, country) no longer leave the shared bottom ticker stuck at **Unavailable** while tool pages show prices from the same snapshot.
> 
> `mountSharedShell()` now **fire-and-forgets** `feedTickerBaseline()`, which loads **`getCanonicalSpot()`** and calls **`updateTicker()`** with spot and UAE karat gram prices plus freshness metadata. It only runs while `#gold-ticker` still has **`data-freshness="unavailable"`**, and **re-checks after the async fetch** so pages that already fed live or richer data (e.g. the tracker) are not overwritten. Failures are logged and leave the honest unavailable state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9822c8de8256d62f746d4bb737629cdcf19567f4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->