### PR TITLE
feat(glossary): premium interactive bilingual reference

### DIFF
--- a/glossary.html
+++ b/glossary.html
@@ -75,6 +75,11 @@
     <link rel="stylesheet" href="./styles/critical.css" />
     <link rel="stylesheet" href="./styles/global.css" />
     <link rel="stylesheet" href="./styles/pages/glossary.css" />
+    <!-- design-system.css = shared gtl-* tokens (Playfair serif, spacing scale);
+         glossary-redesign.css builds on it and must load last. -->
+    <link rel="stylesheet" href="./styles/design-system.css" />
+    <link rel="preload" as="style" href="./styles/pages/glossary-redesign.css" />
+    <link rel="stylesheet" href="./styles/pages/glossary-redesign.css" />
     <link rel="apple-touch-icon" href="assets/apple-touch-icon.png" />
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png" />

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -3,8 +3,12 @@
  *
  * The glossary content is authored as static, bilingual HTML in glossary.html
  * (twin `data-lang-block` en/ar blocks toggled purely by CSS on `html[lang]`),
- * so it renders with zero JavaScript. This entry only mounts the shared shell,
- * breadcrumbs, and the language toggle, and localizes the hero + jump-nav.
+ * so it renders fully with zero JavaScript. This entry mounts the shared shell,
+ * breadcrumbs and language toggle, localizes the hero + jump-nav, and layers on
+ * a progressive-enhancement toolbar: a bilingual, Arabic-normalized search
+ * filter, an A–Z index built from the live DOM, and an honest result count.
+ * Filtering only toggles CSS classes — no term is ever removed from the DOM, so
+ * the DefinedTermSet schema and the static term list stay intact.
  */
 
 import { mountSharedShell } from '../components/site-shell.js';
@@ -13,7 +17,7 @@ import { syncGlossarySchema } from '../seo/glossary-schema.js';
 import * as cache from '../lib/cache.js';
 import { initPageEnter } from '../lib/page-enter.js';
 
-const STATE = { lang: 'en' };
+const STATE = { lang: 'en', query: '', letter: null };
 
 const T = {
   en: {
@@ -22,6 +26,16 @@ const T = {
       'Plain-English definitions of the gold pricing, purity, product and market terms used across Gold Ticker Live.',
     'glossary-jump-label': 'Jump to a section',
     docTitle: 'Gold Glossary — Key Terms Explained | Gold Ticker Live',
+    eyebrow: 'Reference',
+    searchPlaceholder: 'Search terms — e.g. spot, karat, tola',
+    searchLabel: 'Search glossary terms',
+    clearLabel: 'Clear search',
+    azLabel: 'Filter by first letter',
+    azAll: 'All',
+    noResults: 'No terms match your search. Try another word.',
+    unitTerm: 'term',
+    unitTerms: 'terms',
+    ofWord: 'of',
   },
   ar: {
     'glossary-h1': 'مسرد مصطلحات الذهب',
@@ -29,11 +43,228 @@ const T = {
       'تعريفات مبسّطة لمصطلحات تسعير الذهب ونقاوته ومنتجاته وأسواقه المستخدمة في Gold Ticker Live.',
     'glossary-jump-label': 'الانتقال إلى قسم',
     docTitle: 'مسرد مصطلحات الذهب — شرح المصطلحات الرئيسية | Gold Ticker Live',
+    eyebrow: 'مرجع',
+    searchPlaceholder: 'ابحث في المصطلحات — مثل: فوري، عيار، تولة',
+    searchLabel: 'ابحث في مصطلحات المسرد',
+    clearLabel: 'مسح البحث',
+    azLabel: 'التصفية بالحرف الأول',
+    azAll: 'الكل',
+    noResults: 'لا توجد مصطلحات تطابق بحثك. جرّب كلمة أخرى.',
+    unitTerm: 'مصطلح',
+    unitTerms: 'مصطلحاً',
+    ofWord: 'من',
   },
 };
 
 function t(key) {
   return T[STATE.lang]?.[key] ?? T.en[key] ?? key;
+}
+
+/**
+ * Arabic-aware normalization for search + A–Z (mirrors the site search engine):
+ * lowercase, strip tatweel + harakat, unify alef/hamza carriers, taa-marbuta,
+ * and alef-maqsura, and collapse whitespace. Deterministic + side-effect free.
+ * @param {string} s
+ */
+function normalize(s) {
+  return String(s || '')
+    .toLowerCase()
+    .replace(/[ـ]/g, '') // tatweel
+    .replace(/[ً-ْٰ]/g, '') // harakat / superscript alef
+    .replace(/[آأإٱ]/g, 'ا') // آأإٱ → ا
+    .replace(/ة/g, 'ه') // ة → ه
+    .replace(/ى/g, 'ي') // ى → ي
+    .replace(/[ؤئ]/g, '') // ؤئ hamza carriers → drop hamza
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** First significant grapheme of a term name, normalized + uppercased (Latin). */
+function initialOf(name) {
+  const n = normalize(name).replace(/^[^\p{L}\p{N}]+/u, '');
+  return n ? n[0].toUpperCase() : '';
+}
+
+function el(tag, attrs = {}, children = []) {
+  const node = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v == null) continue;
+    if (k === 'class') node.className = v;
+    else node.setAttribute(k, v);
+  }
+  for (const c of [].concat(children)) {
+    if (c == null) continue;
+    node.append(c.nodeType ? c : document.createTextNode(String(c)));
+  }
+  return node;
+}
+
+// SVG magnifier built without innerHTML (repo forbids trusted-HTML sinks).
+function magnifier() {
+  const NS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(NS, 'svg');
+  svg.setAttribute('class', 'gloss-search-ico');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('aria-hidden', 'true');
+  const circle = document.createElementNS(NS, 'circle');
+  circle.setAttribute('cx', '11');
+  circle.setAttribute('cy', '11');
+  circle.setAttribute('r', '7');
+  const line = document.createElementNS(NS, 'line');
+  line.setAttribute('x1', '21');
+  line.setAttribute('y1', '21');
+  line.setAttribute('x2', '16.65');
+  line.setAttribute('y2', '16.65');
+  svg.append(circle, line);
+  return svg;
+}
+
+let ui = null; // cached toolbar element refs
+
+function buildToolbar() {
+  const hero = document.querySelector('.glossary-hero');
+  const main = document.getElementById('main-content');
+  if (!hero || !main || document.querySelector('.gloss-toolbar')) return;
+
+  // Hero eyebrow (kept out of static HTML so the no-JS hero stays minimal).
+  const inner = hero.querySelector('.glossary-hero-inner');
+  const h1 = document.getElementById('glossary-h1');
+  if (inner && h1 && !inner.querySelector('.glossary-eyebrow')) {
+    inner.insertBefore(el('p', { class: 'glossary-eyebrow', id: 'glossary-eyebrow' }), h1);
+  }
+
+  const input = el('input', {
+    type: 'search',
+    class: 'gloss-search-input',
+    id: 'gloss-search-input',
+    autocomplete: 'off',
+    autocapitalize: 'none',
+    spellcheck: 'false',
+    'aria-controls': 'main-content',
+  });
+  const clearBtn = el('button', { type: 'button', class: 'gloss-search-clear', 'aria-label': '' }, '×');
+  const field = el('div', { class: 'gloss-search-field' }, [magnifier(), input]);
+  const search = el('div', { class: 'gloss-search' }, [field, clearBtn]);
+  const count = el('p', { class: 'gloss-count', id: 'gloss-count', role: 'status', 'aria-live': 'polite' });
+  const az = el('div', { class: 'gloss-az', id: 'gloss-az', role: 'group', 'aria-label': '' });
+  const toolbar = el('div', { class: 'gloss-toolbar', role: 'search' }, [search, count, az]);
+
+  hero.after(toolbar);
+
+  // Honest empty state, before the footer.
+  const foot = document.querySelector('.glossary-foot');
+  const empty = el('p', { class: 'gloss-empty', id: 'gloss-empty', role: 'status', 'aria-live': 'polite' });
+  if (foot) foot.before(empty);
+  else main.append(empty);
+
+  input.addEventListener('input', () => {
+    STATE.query = input.value;
+    STATE.letter = null;
+    applyFilter();
+  });
+  clearBtn.addEventListener('click', () => {
+    STATE.query = '';
+    STATE.letter = null;
+    input.value = '';
+    applyFilter();
+    input.focus();
+  });
+
+  ui = { toolbar, input, clearBtn, count, az, empty };
+  localizeToolbar();
+  applyFilter();
+}
+
+function localizeToolbar() {
+  if (!ui) return;
+  const eye = document.getElementById('glossary-eyebrow');
+  if (eye) eye.textContent = t('eyebrow');
+  ui.input.setAttribute('placeholder', t('searchPlaceholder'));
+  ui.input.setAttribute('aria-label', t('searchLabel'));
+  ui.clearBtn.setAttribute('aria-label', t('clearLabel'));
+  ui.az.setAttribute('aria-label', t('azLabel'));
+  ui.empty.textContent = t('noResults');
+  buildAzRail();
+}
+
+function activeTerms() {
+  return [...document.querySelectorAll(`[data-lang-block="${STATE.lang}"] .gloss-term`)];
+}
+
+function buildAzRail() {
+  if (!ui) return;
+  const letters = [...new Set(activeTerms().map((n) => initialOf(n.querySelector('.gloss-term-name')?.textContent)))]
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b, STATE.lang === 'ar' ? 'ar' : 'en'));
+
+  ui.az.replaceChildren();
+  const all = el('button', { type: 'button', class: 'gloss-az-btn', 'data-letter': '' }, t('azAll'));
+  all.addEventListener('click', () => {
+    STATE.letter = null;
+    STATE.query = '';
+    ui.input.value = '';
+    applyFilter();
+  });
+  ui.az.append(all);
+  for (const L of letters) {
+    const b = el('button', { type: 'button', class: 'gloss-az-btn', 'data-letter': L }, L);
+    b.addEventListener('click', () => {
+      STATE.letter = STATE.letter === L ? null : L;
+      STATE.query = '';
+      ui.input.value = '';
+      applyFilter();
+    });
+    ui.az.append(b);
+  }
+}
+
+function makeCount(shown, total) {
+  const frag = document.createDocumentFragment();
+  const strong = (n) => el('strong', {}, String(n));
+  if (shown === total) {
+    frag.append(strong(total), ' ', total === 1 ? t('unitTerm') : t('unitTerms'));
+  } else {
+    frag.append(strong(shown), ' ', t('ofWord'), ' ', strong(total), ' ', t('unitTerms'));
+  }
+  return frag;
+}
+
+function applyFilter() {
+  if (!ui) return;
+  const nq = normalize(STATE.query);
+  const terms = activeTerms();
+  const total = terms.length;
+  let shown = 0;
+
+  for (const term of terms) {
+    const name = term.querySelector('.gloss-term-name')?.textContent || '';
+    const def = term.querySelector('.gloss-term-def')?.textContent || '';
+    const hay = normalize(`${name} ${def}`);
+    let match = true;
+    if (nq) match = hay.includes(nq);
+    if (match && STATE.letter) match = initialOf(name) === STATE.letter;
+    term.classList.toggle('is-filtered', !match);
+    if (match) shown += 1;
+  }
+
+  // Hide a group only when its ACTIVE-language terms are all filtered out.
+  for (const group of document.querySelectorAll('.gloss-group')) {
+    const groupTerms = group.querySelectorAll(`[data-lang-block="${STATE.lang}"] .gloss-term`);
+    const anyVisible = [...groupTerms].some((tn) => !tn.classList.contains('is-filtered'));
+    group.classList.toggle('is-empty', groupTerms.length > 0 && !anyVisible);
+  }
+
+  const filtering = !!nq || !!STATE.letter;
+  ui.clearBtn.classList.toggle('is-shown', filtering);
+  ui.empty.classList.toggle('is-shown', shown === 0);
+  ui.count.replaceChildren(makeCount(shown, total));
+
+  for (const btn of ui.az.querySelectorAll('.gloss-az-btn')) {
+    const isAll = btn.getAttribute('data-letter') === '';
+    btn.setAttribute('aria-pressed', String(isAll ? !filtering : btn.getAttribute('data-letter') === STATE.letter));
+  }
 }
 
 function applyLang() {
@@ -44,6 +275,13 @@ function applyLang() {
     if (node) node.textContent = t(id);
   });
   document.title = t('docTitle');
+
+  // Re-localize + rebuild the toolbar/A–Z for the new language, preserving the
+  // query, then re-run the filter so counts and visibility stay in sync.
+  if (ui) {
+    localizeToolbar();
+    applyFilter();
+  }
 
   // Emit DefinedTermSet JSON-LD for the ACTIVE locale, built from the same DOM
   // terms the reader sees, so EN and AR stay in parity. Idempotent by id, so a
@@ -76,6 +314,7 @@ function init() {
     });
   });
 
+  buildToolbar();
   applyLang();
 }
 

--- a/styles/pages/glossary-redesign.css
+++ b/styles/pages/glossary-redesign.css
@@ -1,0 +1,298 @@
+/* ============================================================================
+   Gold Glossary — premium interactive bilingual reference (redesign/glossary)
+   ----------------------------------------------------------------------------
+   Loaded AFTER glossary.css so these rules win by source order. Pure
+   presentation over the existing static bilingual DOM plus the JS-injected
+   toolbar (search + A–Z index + live count). Brings the glossary into the
+   Stage-2 editorial family: Playfair serif headings in antique gold, gold-glow
+   term cards, gold focus rings, :target deep-link highlight, honest empty
+   state. Built on shared tokens (tokens.css + design-system.css); theme-aware
+   (light + dark both correct); reduced-motion safe. The page stays fully usable
+   with zero JS — the toolbar is progressive enhancement.
+   ========================================================================== */
+
+/* ── Editorial hero ───────────────────────────────────────────────────────── */
+.glossary-hero {
+  background:
+    radial-gradient(ellipse 60% 70% at 50% -20%, var(--color-gold-glow) 0%, transparent 60%),
+    transparent;
+  padding-block: var(--gtl-7, 48px) var(--gtl-4, 16px);
+}
+.glossary-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: var(--gtl-3, 12px);
+  font-family: var(--gtl-sans);
+  font-size: var(--gtl-meta, 0.8125rem);
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-gold-dark);
+}
+.glossary-eyebrow::before {
+  content: '';
+  inline-size: 6px;
+  block-size: 6px;
+  border-radius: 50%;
+  background: var(--color-gold);
+  box-shadow: 0 0 0 3px var(--color-gold-glow);
+}
+.glossary-hero-title {
+  font-family: var(--gtl-serif);
+  font-size: clamp(2.1rem, 1.4rem + 3vw, 3.25rem);
+  letter-spacing: -0.015em;
+  color: var(--color-gold-antique);
+}
+.glossary-hero-sub {
+  font-size: clamp(1.02rem, 0.97rem + 0.35vw, 1.15rem);
+  line-height: 1.62;
+}
+
+/* ── Toolbar: search + live count (JS-injected, sticky) ───────────────────── */
+.gloss-toolbar {
+  position: sticky;
+  inset-block-start: calc(var(--nav-height, 56px) + var(--spot-bar-height, 0px));
+  z-index: 20;
+  max-width: 1000px;
+  margin: var(--gtl-4, 16px) auto 0;
+  padding: var(--gtl-3, 12px) var(--gtl-4, 16px);
+  background: color-mix(in srgb, var(--color-bg) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--gtl-r-lg, 18px);
+  box-shadow: var(--gtl-shadow-1);
+}
+.gloss-search {
+  display: flex;
+  align-items: center;
+  gap: var(--gtl-2, 8px);
+}
+.gloss-search-field {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+.gloss-search-ico {
+  position: absolute;
+  inset-inline-start: 0.85em;
+  inline-size: 1.05em;
+  block-size: 1.05em;
+  color: var(--color-text-faint);
+  pointer-events: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.gloss-search-input {
+  inline-size: 100%;
+  font-family: var(--gtl-sans);
+  font-size: 1rem;
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--gtl-r-pill, 999px);
+  padding: 0.62em 1em 0.62em 2.6em;
+}
+html[dir='rtl'] .gloss-search-input {
+  padding: 0.62em 2.6em 0.62em 1em;
+}
+.gloss-search-input::placeholder {
+  color: var(--color-text-faint);
+}
+.gloss-search-input:focus-visible {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 1px;
+  border-color: var(--color-gold);
+}
+.gloss-search-clear {
+  flex: none;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  inline-size: 2.2em;
+  block-size: 2.2em;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  font-size: 1rem;
+  cursor: pointer;
+}
+.gloss-search-clear.is-shown {
+  display: inline-flex;
+}
+.gloss-search-clear:focus-visible {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 2px;
+}
+.gloss-count {
+  margin-block-start: var(--gtl-2, 8px);
+  font-size: var(--gtl-meta, 0.8125rem);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
+}
+.gloss-count strong {
+  color: var(--color-text);
+  font-weight: 700;
+}
+
+/* ── A–Z index rail ───────────────────────────────────────────────────────── */
+.gloss-az {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-block-start: var(--gtl-3, 12px);
+  padding-block-start: var(--gtl-3, 12px);
+  border-block-start: 1px solid var(--color-border-subtle);
+}
+.gloss-az-btn {
+  min-inline-size: 2em;
+  padding: 0.28em 0.5em;
+  font-family: var(--gtl-num, var(--gtl-sans));
+  font-size: 0.82rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--gtl-r-sm, 10px);
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+.gloss-az-btn:hover {
+  color: var(--color-gold-dark);
+  background: var(--color-gold-tint);
+}
+.gloss-az-btn[aria-pressed='true'] {
+  color: var(--color-gold-dark);
+  background: var(--color-gold-tint);
+  border-color: var(--color-gold);
+}
+.gloss-az-btn:focus-visible {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 1px;
+}
+
+/* ── Jump nav (premium pills) ─────────────────────────────────────────────── */
+.glossary-jump a {
+  color: var(--color-gold-dark);
+  border-color: var(--color-border);
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+.glossary-jump a:hover {
+  background: var(--color-gold-tint);
+  border-color: var(--color-gold);
+}
+.glossary-jump a:focus-visible {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 2px;
+}
+
+/* ── Group titles ─────────────────────────────────────────────────────────── */
+.gloss-group {
+  scroll-margin-block-start: calc(var(--nav-height, 56px) + 5.5rem);
+}
+.gloss-group-title {
+  font-family: var(--gtl-serif);
+  letter-spacing: -0.01em;
+  color: var(--color-gold-antique);
+}
+
+/* ── Term cards ───────────────────────────────────────────────────────────── */
+.gloss-term {
+  scroll-margin-block-start: calc(var(--nav-height, 56px) + 6rem);
+  transition:
+    border-color 0.18s ease,
+    box-shadow 0.18s ease,
+    transform 0.18s ease;
+}
+.gloss-term:hover {
+  border-color: var(--color-gold);
+  box-shadow: var(--gtl-shadow-2);
+  transform: translateY(-2px);
+}
+.gloss-term-name {
+  font-family: var(--gtl-serif);
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+.gloss-term-abbr {
+  font-family: var(--gtl-sans);
+  color: var(--color-gold-dark);
+}
+.gloss-term-def {
+  font-variant-numeric: tabular-nums lining-nums;
+}
+
+/* Deep-link :target highlight — a term linked via #term-… lands with a gold ring. */
+.gloss-term:target {
+  border-color: var(--color-gold);
+  box-shadow: 0 0 0 3px var(--color-gold-glow);
+  background:
+    radial-gradient(130% 130% at 0 0, var(--color-gold-tint) 0%, transparent 55%),
+    var(--color-surface-1);
+}
+
+/* Search-hidden terms + emptied groups (JS toggles). */
+.gloss-term.is-filtered {
+  display: none;
+}
+.gloss-group.is-empty {
+  display: none;
+}
+
+/* ── Empty state (no matches) ─────────────────────────────────────────────── */
+.gloss-empty {
+  display: none;
+  max-width: 1000px;
+  margin: var(--gtl-6, 32px) auto;
+  padding: var(--gtl-6, 32px) var(--gtl-4, 16px);
+  text-align: center;
+  color: var(--color-text-muted);
+}
+.gloss-empty.is-shown {
+  display: block;
+}
+.gloss-empty strong {
+  color: var(--color-text);
+}
+
+/* ── Foot ─────────────────────────────────────────────────────────────────── */
+.glossary-related a {
+  color: var(--color-gold-dark);
+}
+.glossary-related a:focus-visible {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 2px;
+}
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .gloss-toolbar {
+    border-radius: var(--gtl-r-md, 14px);
+  }
+  .gloss-az {
+    gap: 3px;
+  }
+}
+
+/* ── Motion / a11y ────────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .gloss-term,
+  .gloss-az-btn,
+  .glossary-jump a {
+    transition: none;
+  }
+  .gloss-term:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
Transforms the **glossary** from a static bilingual list into the Stage-2 premium editorial identity **plus a progressive-enhancement interactive layer**. The 26 terms (EN/AR twin-blocks) are preserved verbatim — no fabricated terms.

## Visual (`styles/pages/glossary-redesign.css`, loaded last after `design-system.css`)
- Editorial hero: Playfair serif H1 in `--color-gold-antique`, gold-glow eyebrow.
- Premium term cards (gold-glow border + hover lift, serif term names), gold focus rings, `:target` deep-link highlight (a `#term-…` link lands with a gold ring), premium jump-nav pills. Token-driven — light **and** dark correct.

## Interactive (`src/pages/glossary.js`)
Progressive enhancement — the page still works with zero JS. **Filtering only toggles CSS classes**, so no term ever leaves the DOM: the `DefinedTermSet` schema and the static term list stay intact.
- **Live bilingual search** with Arabic normalization (tatweel/harakat, alef/hamza/taa-marbuta/alef-maqsura) matching term name + definition; honest live result count, empty state, clear button — all EN/AR.
- **A–Z index rail** built from the live DOM per active language (Latin initials in EN, Arabic initials in AR), `aria-pressed`, mutually exclusive with search.
- Rebuilds + re-filters on language toggle; local `T` dict keeps en/ar parity. Safe DOM only (`createElement`/`createElementNS`) — no innerHTML.

## Invariants
Peg **3.6725** / troy **31.1035** in term copy, spot ≠ retail framing intact. Content unchanged.

## Verification
- `stylelint` / `eslint` / `build` / `validate` → exit 0
- `npm test` → **1586 pass** (incl. `glossary-schema` + `i18n-local-dict-parity`)
- Playwright **64/64**: EN/AR × light/dark × desktop/mobile — search (EN "karat"→2, AR "عيار"→4), A–Z (EN "B"→1, AR "ا"→16), empty state, clear, deep-link `:target`, `DefinedTermSet` schema, shared shell intact, console clean
- axe (wcag2a/aa): **0 serious/critical** in light **and** dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side glossary UX and CSS only; term copy and schema collection from the full DOM are unchanged, with no backend or auth impact.
> 
> **Overview**
> Adds **Stage-2 editorial styling** for the glossary via `design-system.css` and a new `glossary-redesign.css` (hero eyebrow, serif headings, sticky blurred search toolbar, term-card hover, `:target` deep-link ring, light/dark tokens).
> 
> **`glossary.js`** grows from shell-only localization into progressive enhancement: it injects a hero eyebrow plus a toolbar with **bilingual search** (Arabic-normalized matching on name + definition), an **A–Z rail** built from the active locale’s terms, live result count, clear control, and empty state. Filtering toggles `is-filtered` / `is-empty` classes only—terms stay in the DOM so static content and `DefinedTermSet` JSON-LD remain complete without JS. Toolbar strings and A–Z rebuild on EN/AR toggle; DOM is built with `createElement` / SVG APIs (no `innerHTML`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 559f2f0c5332112886cdac64ddec1c56604773ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->