### PR TITLE
feat(methodology): data-state vocabulary + accessible data-flow + schema polish

### DIFF
--- a/methodology.html
+++ b/methodology.html
@@ -150,7 +150,7 @@
   "description": "How Gold Ticker Live calculates gold prices, sources data, and handles AED fixed peg, karat conversions, and data freshness.",
   "url": "https://goldtickerlive.com/methodology.html",
   "datePublished": "2026-07-04",
-  "dateModified": "2026-07-04",
+  "dateModified": "2026-07-11",
   "author": {
     "@type": "Organization",
     "name": "Gold Ticker Live"
@@ -182,6 +182,14 @@
           <h1 id="method-h1">Data Sources &amp; Methodology</h1>
           <p id="method-sub">
             How we calculate every price you see — step by step, with full source attribution.
+          </p>
+          <p class="method-hero-reviewed" data-lang-block="en">
+            <span class="method-hero-reviewed-dot" aria-hidden="true"></span>
+            Last reviewed <time datetime="2026-07-11">11 July 2026</time>
+          </p>
+          <p class="method-hero-reviewed" data-lang-block="ar" lang="ar" dir="rtl">
+            <span class="method-hero-reviewed-dot" aria-hidden="true"></span>
+            آخر مراجعة <time datetime="2026-07-11">11 يوليو 2026</time>
           </p>
         </div>
       </section>
@@ -318,10 +326,86 @@
           <h2 data-lang-block="en">Live price pipeline</h2>
           <h2 data-lang-block="ar" lang="ar" dir="rtl">مسار السعر المباشر</h2>
           <p data-lang-block="en">
-            A live worked example, built from the current canonical snapshot this page reads through
-            <code>getCanonicalSpot()</code> — the same value the calculator and homepage show at this
-            instant. Watch the international spot price flow through each step to a UAE 22K per-gram
-            reference in dirhams.
+            One chain builds every price, applied identically everywhere — from the global market to
+            a spot-linked reference value for your weight:
+          </p>
+          <p data-lang-block="ar" lang="ar" dir="rtl">
+            سلسلة واحدة تبني كل سعر، وتُطبَّق بالطريقة نفسها في كل مكان — من السوق العالمي إلى قيمة
+            مرجعية مرتبطة بالسعر الفوري لوزنك:
+          </p>
+
+          <figure class="method-dataflow-fig">
+            <ol class="method-dataflow" data-lang-block="en" aria-label="How a gold price is derived, stage by stage">
+              <li class="method-dataflow-stage">
+                <span class="method-dataflow-label">Market</span>
+                <span class="method-dataflow-op">XAU/USD spot · USD per troy ounce</span>
+              </li>
+              <li class="method-dataflow-stage">
+                <span class="method-dataflow-label">Currency</span>
+                <span class="method-dataflow-op">× FX rate · AED uses the 3.6725 peg</span>
+              </li>
+              <li class="method-dataflow-stage">
+                <span class="method-dataflow-label">Troy ounce</span>
+                <span class="method-dataflow-op">÷ 31.1035 · ounce → gram</span>
+              </li>
+              <li class="method-dataflow-stage">
+                <span class="method-dataflow-label">Karat</span>
+                <span class="method-dataflow-op">× (karat ÷ 24) · purity</span>
+              </li>
+              <li class="method-dataflow-stage">
+                <span class="method-dataflow-label">Weight</span>
+                <span class="method-dataflow-op">× grams · your piece</span>
+              </li>
+              <li class="method-dataflow-stage method-dataflow-stage--out">
+                <span class="method-dataflow-label">Reference</span>
+                <span class="method-dataflow-op">spot-linked value — not a shop quote</span>
+              </li>
+            </ol>
+            <ol class="method-dataflow" data-lang-block="ar" lang="ar" dir="rtl" aria-label="كيف يُشتق سعر الذهب مرحلةً بمرحلة">
+              <li class="method-dataflow-stage">
+                <span class="method-dataflow-label">السوق</span>
+                <span class="method-dataflow-op">سعر XAU/USD الفوري · دولار للأوقية التروية</span>
+              </li>
+              <li class="method-dataflow-stage">
+                <span class="method-dataflow-label">العملة</span>
+                <span class="method-dataflow-op">× سعر الصرف · الدرهم يستخدم ربط 3.6725</span>
+              </li>
+              <li class="method-dataflow-stage">
+                <span class="method-dataflow-label">الأوقية التروية</span>
+                <span class="method-dataflow-op">÷ 31.1035 · أوقية ← غرام</span>
+              </li>
+              <li class="method-dataflow-stage">
+                <span class="method-dataflow-label">العيار</span>
+                <span class="method-dataflow-op">× (العيار ÷ 24) · النقاء</span>
+              </li>
+              <li class="method-dataflow-stage">
+                <span class="method-dataflow-label">الوزن</span>
+                <span class="method-dataflow-op">× الغرامات · قطعتك</span>
+              </li>
+              <li class="method-dataflow-stage method-dataflow-stage--out">
+                <span class="method-dataflow-label">المرجع</span>
+                <span class="method-dataflow-op">قيمة مرتبطة بالسعر الفوري — لا سعر محل</span>
+              </li>
+            </ol>
+            <figcaption class="method-dataflow-cap" data-lang-block="en">
+              The reference value is the pure metal at spot. Shops add making charges, VAT and dealer
+              premium on top — see “What our prices are not”.
+            </figcaption>
+            <figcaption class="method-dataflow-cap" data-lang-block="ar" lang="ar" dir="rtl">
+              القيمة المرجعية هي المعدن الخالص بالسعر الفوري. وتضيف المحلات أجور الصياغة وضريبة القيمة
+              المضافة وهامش التاجر فوقها — راجع «ما لا تمثّله أسعارنا».
+            </figcaption>
+          </figure>
+
+          <p data-lang-block="en">
+            And here it is live — a worked example built from the current canonical snapshot this page
+            reads through <code>getCanonicalSpot()</code>, the same value the calculator and homepage
+            show at this instant, resolved to a UAE 22K per-gram reference in dirhams.
+          </p>
+          <p data-lang-block="ar" lang="ar" dir="rtl">
+            وها هي حيّة — مثال مبني على اللقطة المرجعية الحالية التي تقرؤها هذه الصفحة عبر
+            <code>getCanonicalSpot()</code>، القيمة نفسها التي تعرضها الحاسبة والصفحة الرئيسية في هذه
+            اللحظة، محسوبةً إلى سعر مرجعي للغرام من عيار 22 في الإمارات بالدرهم.
           </p>
           <p data-lang-block="ar" lang="ar" dir="rtl">
             مثال حيّ مبني على اللقطة المرجعية الحالية التي تقرؤها هذه الصفحة عبر
@@ -1074,28 +1158,59 @@
         </section>
 
         <section class="method-section" id="freshness-states">
-          <h2 data-lang-block="en">Freshness states</h2>
-          <h2 data-lang-block="ar" lang="ar" dir="rtl">حالات الحداثة</h2>
-          <p data-lang-block="en">Every visible price carries a state label so cached or delayed data is never mistaken for live trading quotes.</p>
-          <p data-lang-block="ar" lang="ar" dir="rtl">كل سعر ظاهر يحمل وسم حالة حتى لا تُخلَط البيانات المخزّنة أو المتأخرة أبداً بأسعار تداول مباشرة.</p>
+          <h2 data-lang-block="en">Data-state vocabulary</h2>
+          <h2 data-lang-block="ar" lang="ar" dir="rtl">مفردات حالة البيانات</h2>
+          <p data-lang-block="en">
+            Every freshness-capable price discloses three things together — the <strong>state
+            label</strong>, the <strong>source</strong>, and the <strong>UTC timestamp</strong> — so a
+            cached or delayed value is never mistaken for a live trading quote. These are the exact
+            states the site can show, from freshest to least certain:
+          </p>
+          <p data-lang-block="ar" lang="ar" dir="rtl">
+            كل سعر قابل للحداثة يُفصح عن ثلاثة أمور معاً — <strong>وسم الحالة</strong>،
+            و<strong>المصدر</strong>، و<strong>الطابع الزمني بتوقيت UTC</strong> — حتى لا تُخلَط قيمة
+            مخزّنة أو متأخرة أبداً بسعر تداول مباشر. وهذه هي الحالات الدقيقة التي قد يعرضها الموقع،
+            من الأحدث إلى الأقل يقيناً:
+          </p>
           <ul class="method-freshness-legend" data-lang-block="en">
-            <li><span class="badge badge--live">Live</span> Fetched within the healthy window</li>
-            <li><span class="badge badge--cached">Cached</span> Browser or service-worker cache</li>
-            <li><span class="badge badge--delayed">Delayed</span> Provider lag (often FX)</li>
-            <li><span class="badge badge--stale">Stale</span> Older than our stale threshold</li>
-            <li><span class="badge badge--fallback">Fallback</span> Last known value after failure</li>
-            <li><span class="badge badge--closed">Closed</span> Market in its scheduled closed window — recent data is still labelled closed</li>
-            <li><span class="badge badge--unavailable">Unavailable</span> Timestamp missing or unreadable</li>
+            <li><span class="badge badge--live">Live</span> Fetched from a healthy provider within the live budget (≤ 5 seconds old). The only state ever shown as live.</li>
+            <li><span class="badge badge--cached">Cached</span> A recent value from the browser / service-worker cache, within the cached budget (≤ 60 seconds).</li>
+            <li><span class="badge badge--delayed">Delayed</span> Older than the cached budget but still recent (≤ 5 minutes), or the FX layer lagging behind gold.</li>
+            <li><span class="badge badge--estimated">Estimated</span> The live provider path is unavailable, so the value is carried forward beyond the delayed budget — shown with cautionary styling, never as live.</li>
+            <li><span class="badge badge--stale">Stale</span> Older than the stale threshold (gold: 75 minutes; FX: 26 hours).</li>
+            <li><span class="badge badge--fallback">Fallback</span> The last known value kept visible after a fetch failure — never blanked, never relabelled live.</li>
+            <li><span class="badge badge--closed">Closed</span> The market is in its scheduled closed window; even recent data reads closed until it reopens.</li>
+            <li><span class="badge badge--unavailable">Unavailable</span> The timestamp is missing or unreadable, so freshness can't be verified.</li>
           </ul>
           <ul class="method-freshness-legend" data-lang-block="ar" lang="ar" dir="rtl">
-            <li><span class="badge badge--live">مباشر</span> مجلوب ضمن النافذة السليمة</li>
-            <li><span class="badge badge--cached">مخزّن</span> ذاكرة المتصفح أو عامل الخدمة</li>
-            <li><span class="badge badge--delayed">متأخر</span> تأخّر المزوّد (غالباً الصرف)</li>
-            <li><span class="badge badge--stale">قديم</span> أقدم من عتبة القِدَم لدينا</li>
-            <li><span class="badge badge--fallback">احتياطي</span> آخر قيمة معروفة بعد الفشل</li>
-            <li><span class="badge badge--closed">مغلق</span> السوق في نافذة إغلاقه المجدول — تبقى البيانات الحديثة موسومة كمغلقة</li>
-            <li><span class="badge badge--unavailable">غير متاح</span> الطابع الزمني مفقود أو غير قابل للقراءة</li>
+            <li><span class="badge badge--live">مباشر</span> مجلوب من مزوّد سليم ضمن نافذة المباشر (أحدث من 5 ثوانٍ). الحالة الوحيدة التي تُعرض على أنها مباشرة.</li>
+            <li><span class="badge badge--cached">مخزّن</span> قيمة حديثة من ذاكرة المتصفح أو عامل الخدمة، ضمن نافذة التخزين (حتى 60 ثانية).</li>
+            <li><span class="badge badge--delayed">متأخر</span> أقدم من نافذة التخزين لكنها لا تزال حديثة (حتى 5 دقائق)، أو طبقة الصرف متأخرة عن الذهب.</li>
+            <li><span class="badge badge--estimated">مُقدَّر</span> مسار المزوّد المباشر غير متاح، فتُحمَل القيمة إلى ما بعد نافذة التأخير — تُعرض بنمط تحذيري، وليست مباشرة أبداً.</li>
+            <li><span class="badge badge--stale">قديم</span> أقدم من عتبة القِدَم (الذهب: 75 دقيقة؛ الصرف: 26 ساعة).</li>
+            <li><span class="badge badge--fallback">احتياطي</span> آخر قيمة معروفة تبقى ظاهرة بعد فشل الجلب — لا تُفرَّغ ولا يُعاد وسمها كمباشرة.</li>
+            <li><span class="badge badge--closed">مغلق</span> السوق في نافذة إغلاقه المجدول؛ حتى البيانات الحديثة تُقرأ كمغلقة حتى يُعاد فتحه.</li>
+            <li><span class="badge badge--unavailable">غير متاح</span> الطابع الزمني مفقود أو غير قابل للقراءة، فلا يمكن التحقق من الحداثة.</li>
           </ul>
+          <div class="method-warning method-warning--info">
+            <strong data-lang-block="en">Offline &amp; recovery</strong>
+            <strong data-lang-block="ar" lang="ar" dir="rtl">عدم الاتصال والتعافي</strong>
+            <p data-lang-block="en">
+              <strong>Offline:</strong> if your device loses its connection, the site keeps serving
+              the last cached value with an offline notice — it never blanks out, and never relabels
+              cached data as live. <strong>Recovery:</strong> after a failed fetch the value stays
+              visible as fallback or cached while the app quietly retries; the moment a fresh value
+              arrives it returns to live. There is no separate "recovering" badge — the honest state
+              you see is always the current one, not an optimistic guess.
+            </p>
+            <p data-lang-block="ar" lang="ar" dir="rtl">
+              <strong>عدم الاتصال:</strong> إذا فقد جهازك الاتصال، يواصل الموقع عرض آخر قيمة مخزّنة مع
+              إشعار بعدم الاتصال — فلا يظهر فراغاً أبداً، ولا يُعيد وسم البيانات المخزّنة كمباشرة.
+              <strong>التعافي:</strong> بعد فشل الجلب تبقى القيمة ظاهرة كاحتياطية أو مخزّنة بينما
+              يعيد التطبيق المحاولة بهدوء؛ وفور وصول قيمة جديدة تعود إلى «مباشر». ولا يوجد وسم منفصل
+              لـ«قيد التعافي» — فالحالة الصادقة التي تراها هي الحالية دائماً، وليست تخميناً متفائلاً.
+            </p>
+          </div>
         </section>
 
         <section class="method-section" id="method-faq">

--- a/src/pages/methodology-live.js
+++ b/src/pages/methodology-live.js
@@ -177,45 +177,6 @@ function renderUnitTable(spotUsd, lang = 'en') {
   );
 }
 
-function injectFaqSchema() {
-  if (document.getElementById('method-faq-schema')) return;
-  const faq = {
-    '@context': 'https://schema.org',
-    '@type': 'FAQPage',
-    mainEntity: [
-      {
-        '@type': 'Question',
-        name: 'Why does my shop quote differ from Gold Ticker Live?',
-        acceptedAnswer: {
-          '@type': 'Answer',
-          text: 'Shop prices add making charges, VAT, design premiums, and dealer margins on top of spot-linked reference metal value.',
-        },
-      },
-      {
-        '@type': 'Question',
-        name: 'How fresh is the gold price data?',
-        acceptedAnswer: {
-          '@type': 'Answer',
-          text: 'Spot is refreshed server-side hourly during market hours and polled by the browser about every 90 seconds. Freshness labels show live, cached, delayed, stale, or fallback states.',
-        },
-      },
-      {
-        '@type': 'Question',
-        name: 'Why is AED different from other currencies?',
-        acceptedAnswer: {
-          '@type': 'Answer',
-          text: 'AED uses the official fixed peg of 3.6725 per USD, so AED gold prices move with XAU/USD without FX spread noise.',
-        },
-      },
-    ],
-  };
-  const script = document.createElement('script');
-  script.type = 'application/ld+json';
-  script.id = 'method-faq-schema';
-  script.textContent = JSON.stringify(faq);
-  document.head.appendChild(script);
-}
-
 function renderHistoricalContext(lang) {
   const el52 = document.getElementById('method-52w-context');
   if (!el52) return;
@@ -240,7 +201,9 @@ function renderHistoricalContext(lang) {
  * @param {'en'|'ar'} lang
  */
 export async function initMethodologyLive(lang = 'en') {
-  injectFaqSchema();
+  // FAQ structured data lives once in the static <head> FAQPage block, matched to
+  // the visible #method-faq Q&A — no runtime-injected duplicate (Google requires
+  // FAQ markup to mirror on-page content, and two FAQPage blocks is invalid).
   renderKaratTable(lang);
   let spot = 0;
   try {

--- a/styles/pages/methodology-redesign.css
+++ b/styles/pages/methodology-redesign.css
@@ -72,6 +72,27 @@ html[lang='ar'] [data-lang-block='en'] {
   line-height: 1.62;
   max-width: 60ch;
 }
+.method-hero p.method-hero-reviewed {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  margin-top: var(--gtl-4, 16px);
+  font-size: var(--gtl-meta, 0.8125rem);
+  font-weight: 600;
+  color: var(--color-text-faint);
+}
+.method-hero-reviewed time {
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.method-hero-reviewed-dot {
+  inline-size: 7px;
+  block-size: 7px;
+  border-radius: 50%;
+  background: var(--color-live, #1f9d55);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-live, #1f9d55) 22%, transparent);
+  flex: none;
+}
 
 /* ── Sticky section nav (TOC) ─────────────────────────────────────────────── */
 .method-toc {
@@ -405,6 +426,104 @@ code.method-formula {
 .related-tool-link:focus-visible {
   outline: 2px solid var(--color-gold);
   outline-offset: 2px;
+}
+
+/* ── Data-flow figure (accessible HTML/CSS, no image) ─────────────────────── */
+.method-dataflow-fig {
+  margin: var(--gtl-5, 24px) 0;
+}
+.method-dataflow {
+  list-style: none;
+  margin: 0 0 var(--gtl-3, 12px);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gtl-4, 16px);
+}
+
+/* `.method-dataflow` sets display:flex, equal specificity to the generic
+   [data-lang-block='ar']{display:none} toggle above but later in source order, so
+   scope the toggle here or the inactive-language flow stays visible (same fix as
+   .glossary-jump). Re-show with flex, not `revert`, to keep the flex layout. */
+.method-dataflow[data-lang-block='ar'] {
+  display: none;
+}
+html[lang='ar'] .method-dataflow[data-lang-block='ar'] {
+  display: flex;
+}
+html[lang='ar'] .method-dataflow[data-lang-block='en'] {
+  display: none;
+}
+.method-dataflow-stage {
+  position: relative;
+  padding: var(--gtl-3, 12px) var(--gtl-4, 16px);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--gtl-r-md, 14px);
+  box-shadow: var(--gtl-shadow-1);
+}
+
+/* Vertical connector (mobile default). Decorative glyph in the gap. */
+.method-dataflow-stage:not(:last-child)::after {
+  content: '↓';
+  position: absolute;
+  inset-block-end: calc(var(--gtl-4, 16px) * -1);
+  inset-inline-start: 50%;
+  transform: translate(-50%, -2px);
+  color: var(--color-gold);
+  font-weight: 700;
+  line-height: 1;
+}
+.method-dataflow-label {
+  display: block;
+  font-family: var(--gtl-serif);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-gold-antique);
+}
+.method-dataflow-op {
+  display: block;
+  margin-top: 2px;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums lining-nums;
+}
+.method-dataflow-stage--out {
+  border-color: var(--color-gold);
+  background:
+    radial-gradient(130% 130% at 0 0, var(--color-gold-tint) 0%, transparent 55%),
+    var(--color-surface);
+}
+.method-dataflow-cap {
+  font-size: var(--gtl-meta, 0.8125rem);
+  line-height: 1.55;
+  color: var(--color-text-faint);
+}
+
+@media (min-width: 640px) {
+  .method-dataflow {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    gap: var(--gtl-5, 24px);
+    overflow-x: auto;
+    padding-bottom: var(--gtl-2, 8px);
+  }
+  .method-dataflow-stage {
+    flex: 1 0 0;
+    min-inline-size: 8.5rem;
+  }
+  .method-dataflow-stage:not(:last-child)::after {
+    content: '→';
+    inset-block-end: auto;
+    inset-block-start: 50%;
+    inset-inline-start: auto;
+    inset-inline-end: calc(var(--gtl-5, 24px) * -1);
+    transform: translate(0, -50%);
+  }
+  html[dir='rtl'] .method-dataflow-stage:not(:last-child)::after {
+    content: '←';
+  }
 }
 
 /* ── Responsive ───────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Follow-up to #658 bringing **Methodology** to the authoritative bilingual-trust standard (my lane stays methodology + glossary — no shared-shell/ticker work).

## Data-state vocabulary (`#freshness-states`)
Documents the full authoritative set from `docs/freshness-contract.md` + `freshness-policy.js`: **live / cached / delayed / estimated / stale / fallback / closed / unavailable**, each with plain-language meaning and the real thresholds (live ≤5s, cached ≤60s, delayed ≤5m; stale gold 75m / FX 26h). Adds the previously-missing **`estimated`** state, states the mandatory disclosure (**state + source + UTC timestamp**), and adds an honest **Offline & recovery** note — explicitly noting there is *no* "recovering" badge (no invented states).

## Accessible data-flow diagram (`#live-formula`)
A semantic `<ol>` figure (**no image**): **market → currency → troy-oz → karat → weight → reference**, plain formula per stage, spot≠retail caption. Pure HTML/CSS connectors; horizontal on desktop (scrolls), vertical on mobile; bilingual twin-block; RTL-correct. Sits above the existing live worked example (`getCanonicalSpot` snapshot).

## Structured data / SEO
- **Removes the runtime-injected duplicate FAQPage** from `methodology-live.js` — the single valid FAQPage is generated by `inject-schema.js` from the visible `<dl>`, so FAQ markup mirrors on-page Q&A (two FAQPage blocks is invalid).
- Bumps Article **`dateModified` → 2026-07-11** (review date; inject-schema preserves it) + a visible **"Last reviewed 11 July 2026"** hero line.
- Canonical + BreadcrumbList + Article already present; inbound links from **calculator (5) / compare / portfolio / footer** verified already in place.

## Bug fixed
`.method-dataflow` set `display:flex` at equal specificity but later source order than the generic `[data-lang-block=ar]{display:none}` toggle, so the inactive-language flow stayed visible → scoped the toggle to `.method-dataflow` (same pattern `.glossary-jump` uses).

## Invariants
Peg 3.6725 / troy 31.1035 / karat÷24, spot≠retail, honest freshness; Tracker engine still documented as a deliberate exception, not migrated.

## Verification
- `stylelint` / `eslint` / `build` / `validate` exit 0 · `npm test` **1586 pass**
- Playwright **56/56** (EN/AR × light/dark × desktop/mobile): data-flow 6 stages + correct-lang toggle, 8 data-state badges incl `estimated`, offline/recovery block, reviewed date, **single FAQPage / no JS dup**, live pipeline, one-visible-H2/section, shell intact, console clean
- axe (wcag2a/aa) **0 serious/critical** light + dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, presentation, and structured-data cleanup on the methodology page only; no pricing or freshness runtime logic changes.
> 
> **Overview**
> **Methodology** trust content is expanded: hero **last reviewed** line (11 July 2026) and Article **`dateModified`** bump; **`#live-formula`** gets a bilingual HTML/CSS **data-flow** figure (market → reference) above the existing live pipeline, with responsive/RTL styling and a fix so only one language’s flow list shows.
> 
> **`#freshness-states`** is renamed to **data-state vocabulary** with fuller badge definitions (including **`estimated`**), real time thresholds, mandatory **state + source + UTC** disclosure, and an **offline & recovery** callout (no invented “recovering” badge).
> 
> **SEO:** runtime **FAQPage** injection is removed from `methodology-live.js` so only the static head FAQ block remains (avoids duplicate invalid schema).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c869aa1da5bbb8802d3e396a36cc8a3c97081ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->