### PR TITLE
perf(price): visibility-aware refresh (market/dubai/shops/invest) + price-flow map

### DIFF
--- a/docs/price-flow-map.md
+++ b/docs/price-flow-map.md
@@ -1,0 +1,115 @@
+# Price-data flow map
+
+_Single reference for how the gold spot price reaches every public surface: source, fetch
+location, resolver, cache, fallback, timestamp, freshness state, and refresh/visibility
+behaviour. Written for the Stage-2 shared-price-state work; keep in sync when a surface's
+price path changes._
+
+Last mapped: 2026-07-11.
+
+## 1. One canonical source, one resolver (non-Tracker surfaces)
+
+Every non-Tracker surface reads the same value through one memoized read point:
+
+- **Source of truth:** `/data/gold_price.json` — committed by the hourly
+  `gold-price-fetch.yml` workflow (minute :02, market hours). Fields consumed:
+  `xau_usd_per_oz`, `timestamp_utc`, `fetched_at_utc`, `is_fresh`, `is_fallback`,
+  `freshness_seconds`, `max_freshness_seconds`.
+- **Fetch layer:** `src/lib/api.js` → `fetchGold()`.
+  - URL is cache-busted per call: `/data/gold_price.json?t=<Date.now()>`.
+  - Retry with exponential back-off (`retryWithBackoff`, 2 retries, 1s/2s).
+  - Timeout via `fetchWithTimeout` (`CONSTANTS.GOLD_FETCH_TIMEOUT`), abortable via `signal`.
+  - Optional versioned backend (`/api/v1/prices/latest`) is probed **only** when
+    `CONSTANTS.API_BACKEND_ENABLED` (false on static Pages, so no guaranteed 404).
+  - **Fallback:** on total fetch failure, `getFallbackGoldPrice()` returns the last
+    `localStorage` cache with `source: 'cache-fallback'`. If that too is empty, `fetchGold`
+    throws `NetworkError` (offline with no cache → surface shows its error/unavailable state,
+    never a fabricated number).
+- **Resolver:** `src/lib/spot-resolver.js` → `getCanonicalSpot()`.
+  - Single-flight memoization: concurrent callers share ONE in-flight fetch and ONE
+    `_snapshot`, so surfaces cannot diverge within a render.
+  - `_snapshot` has **no TTL** — it is cached until `getCanonicalSpot({ force: true })` is
+    called. Periodic refreshers therefore pass `force: true`; the initial paint uses the
+    memoized read.
+  - `deriveFromSpot(spot)` applies the immutable invariants (troy-oz 31.1035, AED peg 3.6725,
+    karat purity = code/24) — never re-derived anywhere else.
+  - `buildSnapshot()` returns `{ ok, spotUsdPerOz, usdPerGram24k, aedPerGram24k, karats[],
+    freshness }`.
+
+## 2. Freshness vocabulary (the authoritative state set)
+
+Per `docs/freshness-contract.md`, the full state set is:
+`live · cached · delayed · estimated · stale · fallback · closed · unavailable`.
+
+Three modules emit subsets of it — no surface should branch on raw age itself:
+
+| Module | Function | States it emits | Used by |
+| --- | --- | --- | --- |
+| `spot-resolver.js` | `classifyFreshness(gold)` | live, delayed, cached, fallback, unavailable | `snapshot.freshness` on every canonical surface |
+| `live-status.js` | `getLiveFreshness(opts)` | live, delayed, cached, stale, fallback, unavailable | ticker + label layer; adds the age-based `stale` |
+| `live-status.js` | `applyMarketClosedOverlay(key)` | overlays `closed` | ticker, hero, tracker |
+| `freshness-policy.js` | `evaluateFreshnessState(opts)` | closed, live, cached, delayed, estimated, fallback | policy/engine-side evaluation |
+
+Note the split: `classifyFreshness` (what the snapshot carries) does **not** itself emit
+`stale`, `estimated`, or `closed` — those are added by the label layer
+(`getLiveFreshness` + `applyMarketClosedOverlay`) at render time. Surfaces feed the snapshot's
+`freshness.updatedAt` / `isFallback` / (`state !== 'live'` → `hasLiveFailure`) into the label
+layer so the displayed state is honest and market-closed-aware.
+
+Mandatory disclosure per block: **state label + source label + UTC timestamp**.
+Trust invariants: reference estimates are never shown as retail quotes; a closed market reads
+`closed` even with recent data; cached/fallback stays visibly non-live; AED peg stays 3.6725.
+
+## 3. Per-surface map
+
+All "canonical" surfaces below call `getCanonicalSpot()` for the initial paint and
+`getCanonicalSpot({ force: true })` on refresh. Timestamp source = `snapshot.freshness.updatedAt`
+(the committed `timestamp_utc`/`fetched_at_utc`).
+
+| Surface | Controller | Price path | Refresh (every `GOLD_REFRESH_MS`=90s) | Visibility-aware? |
+| --- | --- | --- | --- | --- |
+| Global bottom ticker | `components/ticker.js` + `site-shell.js` `feedTickerBaseline()` | canonical baseline, **guarded** — only writes while `data-freshness==='unavailable'` so any page that fed real data first wins | fed once at mount; tool controllers re-feed via `updateTicker` | n/a (event-driven) |
+| Homepage | `pages/home.js` | **dual**: realtime engine (`createPrimaryQuoteProvider`) for the live-updating spot + `getCanonicalSpot` for static hero/ladder | realtime engine + `_refreshTimer`/`_freshnessTimer` | ✅ engine `setVisibility` |
+| Calculator | `pages/calculator.js` | canonical | interval | ✅ inline guard |
+| Compare | `pages/compare.js` | canonical | interval | ✅ inline guard |
+| Portfolio | `pages/portfolio.js` | canonical | interval | ✅ inline guard |
+| Heatmap / world map | `pages/heatmap.js` | canonical | interval | ✅ inline guard |
+| Dubai country landing | `pages/dubai-gold-price.js` | canonical | interval | ✅ shared helper _(added 2026-07-11)_ |
+| Shops directory | `pages/shops.js` | canonical (`refreshLiveReference`) feeds spot bar + ticker + hero chip | interval | ✅ shared helper _(added 2026-07-11)_ |
+| Market explainer | `pages/market.js` | canonical (worked example) | interval | ✅ shared helper _(added 2026-07-11)_ |
+| Learn / invest planner | `pages/invest.js` | canonical | interval | ✅ shared helper _(added 2026-07-11)_ |
+| Content pages (learn/methodology/glossary) | `site-shell.js` baseline only | canonical baseline via ticker | none (static) | n/a |
+
+`market.js` also uses `showDataStatusBanner`/`hideDataStatusBanner` (invest too) for a
+page-level offline/degraded banner.
+
+### Visibility-aware refresh
+
+`src/lib/visibility-refresh.js` → `startVisibilityAwareRefresh(refresh, { intervalMs })`
+is the one tested implementation: it polls only while the tab is visible, pauses on
+`document.hidden`, runs an immediate catch-up `refresh` when the tab returns to visible, and
+tears down on `pagehide`. It mirrors the inline pattern the homepage-family pages
+(compare/portfolio/heatmap/calculator) already use; `market/dubai/shops/invest` were migrated
+to it (2026-07-11) — before that they polled `/data/gold_price.json` every 90s even in a
+background tab (and `shops` never captured its interval handle, so it could never be cleared).
+
+## 4. The Tracker exception (do not migrate)
+
+`tracker.html` (`pages/tracker-pro.js`) runs a **separate, deliberately superior multi-tier
+live pricing engine** (`createRealtimePricingEngine` + `createPrimaryQuoteProvider`:
+gold-api.com → minted-metal → committed `gold_price.json` → `last_gold_price.json`). It does
+NOT read `getCanonicalSpot()` (which is committed-JSON-only); migrating it would be a
+regression (live polling → committed-only). Consistency holds anyway because every tier traces
+to the same gold-api.com / committed snapshot. The Tracker uses the realtime engine's own
+`setVisibility()` for background throttling and its own inline freshness overlay
+(`src/tracker/freshness.js`). Leave it untouched.
+
+## 5. Known follow-ups
+
+- Trust/provenance ("about this price") progressive-disclosure layer is not yet a shared
+  component — freshness dots + source attribution exist per-surface (footer via
+  `data-attribution.js`); a unified compact badge + expandable basis (USD/AED, karat/weight,
+  spot-vs-retail, Methodology link) is Stage-2C.
+- `classifyFreshness` never emits `estimated`; only `evaluateFreshnessState` does. If a surface
+  needs to distinguish "provider unavailable, value estimated" from "cached", it must go through
+  the policy evaluator, not the snapshot's `freshness.state`.

--- a/src/lib/visibility-refresh.js
+++ b/src/lib/visibility-refresh.js
@@ -1,0 +1,90 @@
+/**
+ * visibility-refresh.js — one tested implementation of visibility-aware price
+ * polling for the non-Tracker surfaces.
+ *
+ * Problem it solves: several tool/content pages refresh the canonical snapshot
+ * on a fixed `setInterval`, which keeps hitting `/data/gold_price.json` every
+ * `GOLD_REFRESH_MS` even while the tab is hidden — wasteful background traffic
+ * that never reaches a user's eyes. The homepage-family pages (compare,
+ * portfolio, heatmap, calculator) already guard this inline; this helper
+ * extracts that proven pattern so market / dubai / shops / invest share ONE
+ * implementation instead of four hand-rolled copies.
+ *
+ * Behaviour (matches the inline pattern in calculator.js):
+ *   - Start: begin the interval only if the tab is currently visible.
+ *   - Tab hidden  → clear the interval (stop polling).
+ *   - Tab visible → run an immediate catch-up refresh, then restart the interval.
+ *   - `pagehide`  → tear the interval down.
+ *
+ * It never performs an initial refresh on `start()` — callers already fetch
+ * once before starting the loop, so a start-time fetch would double up. The
+ * catch-up refresh happens only when a hidden tab returns to visible.
+ *
+ * The Tracker is intentionally NOT a caller: it runs its own multi-tier
+ * realtime engine with `setVisibility()`; this helper is for the snapshot-based
+ * surfaces only.
+ *
+ * @param {() => (void | Promise<void>)} refresh  invoked on each tick and on re-show
+ * @param {{
+ *   intervalMs: number,
+ *   doc?: Document,
+ *   win?: Window,
+ * }} opts  `intervalMs` is required (callers pass `CONSTANTS.GOLD_REFRESH_MS`).
+ *   `doc`/`win` are injectable for tests.
+ * @returns {{ stop: () => void, isRunning: () => boolean }}
+ */
+export function startVisibilityAwareRefresh(refresh, { intervalMs, doc, win } = {}) {
+  const documentRef = doc || (typeof document !== 'undefined' ? document : null);
+  const windowRef = win || (typeof window !== 'undefined' ? window : null);
+
+  if (typeof refresh !== 'function' || !Number.isFinite(intervalMs) || intervalMs <= 0) {
+    // Nothing sane to schedule — return an inert controller so callers never
+    // need to null-check.
+    return { stop() {}, isRunning: () => false };
+  }
+
+  let timer = null;
+
+  const isHidden = () => documentRef?.hidden === true;
+
+  const startTimer = () => {
+    if (timer == null) timer = setInterval(refresh, intervalMs);
+  };
+
+  const stopTimer = () => {
+    if (timer != null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+
+  const onVisibilityChange = () => {
+    if (isHidden()) {
+      stopTimer();
+    } else if (timer == null) {
+      // Returned to a visible tab after being paused — catch up immediately so
+      // the user never stares at a value that went stale while hidden, then
+      // resume the cadence.
+      refresh();
+      startTimer();
+    }
+  };
+
+  const onPageHide = () => teardown();
+
+  function teardown() {
+    stopTimer();
+    documentRef?.removeEventListener?.('visibilitychange', onVisibilityChange);
+    windowRef?.removeEventListener?.('pagehide', onPageHide);
+  }
+
+  // Start paused if the page loaded in a hidden tab; otherwise begin polling.
+  if (!isHidden()) startTimer();
+  documentRef?.addEventListener?.('visibilitychange', onVisibilityChange);
+  windowRef?.addEventListener?.('pagehide', onPageHide);
+
+  return {
+    stop: teardown,
+    isRunning: () => timer != null,
+  };
+}

--- a/src/pages/dubai-gold-price.js
+++ b/src/pages/dubai-gold-price.js
@@ -18,6 +18,7 @@ import { injectBreadcrumbs } from '../components/breadcrumbs.js';
 import * as cache from '../lib/cache.js';
 import { initPageEnter } from '../lib/page-enter.js';
 import { getCanonicalSpot } from '../lib/spot-resolver.js';
+import { startVisibilityAwareRefresh } from '../lib/visibility-refresh.js';
 import { CONSTANTS } from '../config/index.js';
 import { formatNumber, formatCurrency, formatTimestampShort } from '../lib/formatter.js';
 
@@ -169,8 +170,12 @@ function init() {
   applyLang();
 
   fetchLive();
-  if (STATE.timer) clearInterval(STATE.timer);
-  STATE.timer = setInterval(fetchLive, CONSTANTS.GOLD_REFRESH_MS);
+  // Visibility-aware refresh: pause polling while the tab is hidden, catch up
+  // on re-show. Replaces a bare setInterval that polled even in a background tab.
+  if (STATE.refreshCtrl) STATE.refreshCtrl.stop();
+  STATE.refreshCtrl = startVisibilityAwareRefresh(fetchLive, {
+    intervalMs: CONSTANTS.GOLD_REFRESH_MS,
+  });
 }
 
 init();

--- a/src/pages/invest.js
+++ b/src/pages/invest.js
@@ -1,6 +1,7 @@
 import { CONSTANTS, KARATS, TRANSLATIONS } from '../config/index.js';
 import * as api from '../lib/api.js';
 import { getCanonicalSpot } from '../lib/spot-resolver.js';
+import { startVisibilityAwareRefresh } from '../lib/visibility-refresh.js';
 import * as cache from '../lib/cache.js';
 import { mountSkeleton } from '../components/skeleton.js';
 import { showDataStatusBanner, hideDataStatusBanner } from '../lib/data-status-banner.js';
@@ -1288,8 +1289,12 @@ async function init() {
   renderPlanner();
   await fetchLiveData();
 
-  if (state.timer) clearInterval(state.timer);
-  state.timer = setInterval(fetchLiveData, CONSTANTS.GOLD_REFRESH_MS);
+  // Visibility-aware refresh: pause polling while the tab is hidden, catch up
+  // on re-show. Replaces a bare setInterval that polled even in a background tab.
+  if (state.refreshCtrl) state.refreshCtrl.stop();
+  state.refreshCtrl = startVisibilityAwareRefresh(fetchLiveData, {
+    intervalMs: CONSTANTS.GOLD_REFRESH_MS,
+  });
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/src/pages/market.js
+++ b/src/pages/market.js
@@ -20,6 +20,7 @@ import { injectBreadcrumbs } from '../components/breadcrumbs.js';
 import * as cache from '../lib/cache.js';
 import { initPageEnter } from '../lib/page-enter.js';
 import { getCanonicalSpot } from '../lib/spot-resolver.js';
+import { startVisibilityAwareRefresh } from '../lib/visibility-refresh.js';
 import { CONSTANTS } from '../config/index.js';
 import { formatNumber, formatCurrency, formatTimestampShort } from '../lib/formatter.js';
 
@@ -149,8 +150,12 @@ function init() {
   applyLang();
 
   fetchWorked();
-  if (STATE.timer) clearInterval(STATE.timer);
-  STATE.timer = setInterval(fetchWorked, CONSTANTS.GOLD_REFRESH_MS);
+  // Visibility-aware refresh: pause polling while the tab is hidden, catch up
+  // on re-show. Replaces a bare setInterval that polled even in a background tab.
+  if (STATE.refreshCtrl) STATE.refreshCtrl.stop();
+  STATE.refreshCtrl = startVisibilityAwareRefresh(fetchWorked, {
+    intervalMs: CONSTANTS.GOLD_REFRESH_MS,
+  });
 }
 
 init();

--- a/src/pages/shops.js
+++ b/src/pages/shops.js
@@ -4,6 +4,7 @@ import { fetchShops as fetchSupabaseShops } from '../lib/supabase-data.js';
 import { updateTicker } from '../components/ticker.js';
 import { updateSpotBar } from '../components/spotBar.js';
 import { getCanonicalSpot } from '../lib/spot-resolver.js';
+import { startVisibilityAwareRefresh } from '../lib/visibility-refresh.js';
 import { mountSharedShell } from '../components/site-shell.js';
 import { injectBreadcrumbs } from '../components/breadcrumbs.js';
 import * as cache from '../lib/cache.js';
@@ -2474,7 +2475,12 @@ function init() {
   // memoized read as homepage / calculator / compare / portfolio / learn / dubai
   // — so the spot bar, ticker, and hero reference chip go live and never diverge.
   refreshLiveReference();
-  setInterval(refreshLiveReference, CONSTANTS.GOLD_REFRESH_MS);
+  // Visibility-aware refresh: pause polling while the tab is hidden, catch up on
+  // re-show. Was a bare setInterval — polled every tab, and its handle was never
+  // captured so it could never be cleared.
+  STATE.refreshCtrl = startVisibilityAwareRefresh(refreshLiveReference, {
+    intervalMs: CONSTANTS.GOLD_REFRESH_MS,
+  });
 
   navResult.getLangToggleButtons().forEach((button) => {
     button.addEventListener('click', () => {

--- a/tests/visibility-refresh.test.js
+++ b/tests/visibility-refresh.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function load() {
+  const url = new URL(
+    'file://' + path.resolve(__dirname, '..', 'src', 'lib', 'visibility-refresh.js')
+  );
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+/** Minimal EventTarget stub capturing listeners so tests can fire events. */
+function makeEmitter(extra = {}) {
+  const listeners = new Map();
+  return {
+    ...extra,
+    addEventListener(type, fn) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type).add(fn);
+    },
+    removeEventListener(type, fn) {
+      listeners.get(type)?.delete(fn);
+    },
+    emit(type) {
+      for (const fn of listeners.get(type) || []) fn();
+    },
+    listenerCount(type) {
+      return listeners.get(type)?.size || 0;
+    },
+  };
+}
+
+const INTERVAL = 90_000;
+
+test('visibility-refresh: starts polling when the tab is visible', async () => {
+  const { startVisibilityAwareRefresh } = await load();
+  const doc = makeEmitter({ hidden: false });
+  const win = makeEmitter();
+  let calls = 0;
+  const ctrl = startVisibilityAwareRefresh(() => calls++, { intervalMs: INTERVAL, doc, win });
+
+  assert.equal(ctrl.isRunning(), true, 'interval active on a visible tab');
+  assert.equal(calls, 0, 'no start-time refresh (caller already fetched once)');
+  ctrl.stop();
+});
+
+test('visibility-refresh: starts paused when the tab loads hidden', async () => {
+  const { startVisibilityAwareRefresh } = await load();
+  const doc = makeEmitter({ hidden: true });
+  const win = makeEmitter();
+  const ctrl = startVisibilityAwareRefresh(() => {}, { intervalMs: INTERVAL, doc, win });
+
+  assert.equal(ctrl.isRunning(), false, 'no polling on a hidden tab');
+  ctrl.stop();
+});
+
+test('visibility-refresh: pauses on hide, catches up + resumes on show', async () => {
+  const { startVisibilityAwareRefresh } = await load();
+  const doc = makeEmitter({ hidden: false });
+  const win = makeEmitter();
+  let calls = 0;
+  const ctrl = startVisibilityAwareRefresh(() => calls++, { intervalMs: INTERVAL, doc, win });
+
+  // Hide → stop polling, no extra refresh.
+  doc.hidden = true;
+  doc.emit('visibilitychange');
+  assert.equal(ctrl.isRunning(), false, 'polling paused while hidden');
+  assert.equal(calls, 0, 'no refresh fired on hide');
+
+  // Show → immediate catch-up refresh + resumed interval.
+  doc.hidden = false;
+  doc.emit('visibilitychange');
+  assert.equal(calls, 1, 'exactly one catch-up refresh on re-show');
+  assert.equal(ctrl.isRunning(), true, 'polling resumed on re-show');
+
+  ctrl.stop();
+});
+
+test('visibility-refresh: repeated show events do not stack intervals or double-fetch', async () => {
+  const { startVisibilityAwareRefresh } = await load();
+  const doc = makeEmitter({ hidden: false });
+  const win = makeEmitter();
+  let calls = 0;
+  const ctrl = startVisibilityAwareRefresh(() => calls++, { intervalMs: INTERVAL, doc, win });
+
+  // Already visible — a spurious visibilitychange must not add a second interval
+  // or trigger a refresh (guarded by the `timer == null` check).
+  doc.emit('visibilitychange');
+  doc.emit('visibilitychange');
+  assert.equal(calls, 0, 'no refresh while already visible');
+  assert.equal(ctrl.isRunning(), true);
+  ctrl.stop();
+});
+
+test('visibility-refresh: pagehide tears down interval and removes listeners', async () => {
+  const { startVisibilityAwareRefresh } = await load();
+  const doc = makeEmitter({ hidden: false });
+  const win = makeEmitter();
+  const ctrl = startVisibilityAwareRefresh(() => {}, { intervalMs: INTERVAL, doc, win });
+
+  assert.equal(doc.listenerCount('visibilitychange'), 1);
+  assert.equal(win.listenerCount('pagehide'), 1);
+
+  win.emit('pagehide');
+  assert.equal(ctrl.isRunning(), false, 'interval cleared on pagehide');
+  assert.equal(doc.listenerCount('visibilitychange'), 0, 'visibility listener removed');
+  assert.equal(win.listenerCount('pagehide'), 0, 'pagehide listener removed');
+});
+
+test('visibility-refresh: stop() is idempotent and clears everything', async () => {
+  const { startVisibilityAwareRefresh } = await load();
+  const doc = makeEmitter({ hidden: false });
+  const win = makeEmitter();
+  const ctrl = startVisibilityAwareRefresh(() => {}, { intervalMs: INTERVAL, doc, win });
+  ctrl.stop();
+  ctrl.stop();
+  assert.equal(ctrl.isRunning(), false);
+});
+
+test('visibility-refresh: invalid args yield an inert controller', async () => {
+  const { startVisibilityAwareRefresh } = await load();
+  const doc = makeEmitter({ hidden: false });
+  const win = makeEmitter();
+
+  const noFn = startVisibilityAwareRefresh(null, { intervalMs: INTERVAL, doc, win });
+  assert.equal(noFn.isRunning(), false);
+  assert.equal(doc.listenerCount('visibilitychange'), 0, 'no listeners wired for a bad refresh fn');
+
+  const badInterval = startVisibilityAwareRefresh(() => {}, { intervalMs: 0, doc, win });
+  assert.equal(badInterval.isRunning(), false);
+  noFn.stop();
+  badInterval.stop();
+});


### PR DESCRIPTION
## What

Stage-2 price-state hardening, plus the mapping deliverable.

**1. Visibility-aware polling (Mission 3).** `market`, `dubai`, `shops`, and `invest` refreshed the canonical snapshot on a bare `setInterval(fn, 90s)` that kept hitting `/data/gold_price.json` **even while the tab was hidden** — wasteful background traffic no user sees. `shops.js` never captured its interval handle, so it could never be cleared at all.

The homepage-family pages (`compare`/`portfolio`/`heatmap`/`calculator`) already guard this inline. This PR extracts that proven pattern into one tested helper — `src/lib/visibility-refresh.js` `startVisibilityAwareRefresh()` — and migrates the four unguarded surfaces to it:
- polls only while the tab is visible,
- pauses on `document.hidden`,
- runs an **immediate catch-up refresh** when the tab returns to visible (no staring at a value that went stale while hidden),
- tears down on `pagehide`.

The four already-guarded pages are left untouched (verify-don't-rebuild). No change to the canonical resolver, the freshness vocabulary, or the Tracker's separate multi-tier live engine.

**2. Price-flow map (Mission 1).** `docs/price-flow-map.md` documents how the spot price reaches every surface: source (`/data/gold_price.json`), fetch layer (`api.js fetchGold` — cache-bust, retry, localStorage fallback, throw-on-empty), resolver (`getCanonicalSpot`, single-flight, no-TTL memo), the three freshness modules and the authoritative 8-state vocabulary, a per-surface table, refresh/visibility behaviour, and the Tracker exception.

## Invariants
Untouched: peg 3.6725, troy 31.1035, karat÷24, spot≠retail, honest freshness. Deterministic calcs. Tracker engine protected.

## Verification
- `npm test` → **1593 pass** (7 new, DOM-free via injectable `doc`/`win`)
- `npx eslint` (changed files) → 0
- `npm run build` → exit 0, **zero HTML mutations**
- `npm run validate` → exit 0

Will live-verify EN/AR + hidden-tab pause after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to when background tabs poll gold JSON; visible-tab refresh and pricing logic are unchanged, with tests covering the new helper.
> 
> **Overview**
> Adds **`startVisibilityAwareRefresh`** in `visibility-refresh.js` so canonical gold snapshot polling matches the calculator/compare pattern: poll only while the tab is visible, pause on hide, **catch-up refresh** when the tab returns, and tear down on `pagehide`. **Market**, **Dubai**, **shops**, and **invest** swap bare `setInterval` (90s) for this helper; **shops** also gets a storable controller so the loop can be stopped (it previously never held the interval handle).
> 
> Adds **`docs/price-flow-map.md`** as the Stage-2 reference for how spot price flows from `/data/gold_price.json` through `fetchGold` / `getCanonicalSpot`, freshness modules, per-surface refresh behavior, and the Tracker exception. Seven DOM-free tests cover the helper via injectable `doc`/`win`.
> 
> Canonical resolver, freshness vocabulary, and pages that already guarded visibility inline are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcd925b40aa3374509d3d18854e3727b8c967cc0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->