### PR TITLE
ci(deploy): post-deploy smoke — verify the new commit is actually live

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,6 +121,21 @@ jobs:
             exit 1
           fi
 
+      - name: Write build-info marker
+        # A tiny deploy fingerprint the post-deploy smoke reads back from the live
+        # site to prove the NEW commit is actually serving (merged ≠ deployed until
+        # verified live). Safe: only writes one JSON file into dist/ before upload.
+        run: |
+          cat > dist/build-info.json <<EOF
+          {
+            "commit": "${{ github.sha }}",
+            "ref": "${{ github.ref_name }}",
+            "run_id": "${{ github.run_id }}",
+            "built_at_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          echo "build-info.json:" && cat dist/build-info.json
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -1,0 +1,79 @@
+# ------------------------------------------------------------------
+# Post-deploy smoke — runs AFTER "Deploy to GitHub Pages" finishes and
+# verifies the NEW commit is actually live and healthy. Fails loudly
+# (red run + optional Telegram/Discord alert) so a silently-failed deploy
+# can't keep serving a stale build unnoticed (see PR #641/#652).
+#
+# Not a merge gate: it runs post-hoc against production. workflow_run
+# workflows execute from the default branch's copy of this file.
+# ------------------------------------------------------------------
+name: Post-deploy smoke
+
+on:
+  workflow_run:
+    workflows: ['Deploy to GitHub Pages']
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: 'Commit SHA that should be live (blank = skip commit-match)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: post-deploy-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Verify live deploy
+    # Only run for a SUCCESSFUL deploy (or a manual dispatch). A failed deploy is
+    # already red; this guards the happy-path "deployed but stale/broken" case.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+
+      - name: Run post-deploy smoke (propagation-tolerant retry)
+        env:
+          SITE_URL: 'https://goldtickerlive.com'
+          # For a real deploy, the head_sha of the deploy run is what should be
+          # live. For manual dispatch, use the provided input (may be blank).
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha || github.event.inputs.expected_sha }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHANNEL_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          # Pages CDN can lag a few seconds behind a completed deploy. Retry the
+          # smoke a few times before treating a commit mismatch as a real failure,
+          # so we never cry wolf on propagation delay. The script only alerts on
+          # its final run (we suppress alerts on intermediate attempts).
+          attempts=4
+          for i in $(seq 1 $attempts); do
+            echo "── smoke attempt $i/$attempts ──"
+            if [ "$i" -lt "$attempts" ]; then
+              # Intermediate attempt: don't fire the external alert yet.
+              if env TELEGRAM_BOT_TOKEN= TELEGRAM_CHANNEL_ID= DISCORD_WEBHOOK_URL= \
+                   node scripts/node/post-deploy-smoke.js; then
+                echo "smoke passed on attempt $i"
+                exit 0
+              fi
+              echo "attempt $i failed; waiting 20s for CDN propagation…"
+              sleep 20
+            else
+              # Final attempt: alerts enabled, its exit code is the job result.
+              node scripts/node/post-deploy-smoke.js
+            fi
+          done

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "preview": "vite preview",
     "start": "node server.js",
     "test": "node --test --test-concurrency=1 tests/*.test.js",
+    "smoke": "node scripts/node/post-deploy-smoke.js",
     "test:watch": "node --test --test-concurrency=1 --watch tests/*.test.js",
     "test:coverage": "node --test --test-concurrency=1 --experimental-test-coverage tests/*.test.js",
     "test:playwright": "npx playwright test",

--- a/scripts/node/post-deploy-smoke.js
+++ b/scripts/node/post-deploy-smoke.js
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/**
+ * scripts/node/post-deploy-smoke.js
+ *
+ * Post-deploy smoke test for the live GitHub Pages site. Runs AFTER
+ * `deploy.yml` finishes and answers one question the deploy job itself cannot:
+ * "is the new commit actually live and healthy, or is the site silently serving
+ * a stale build?"
+ *
+ * Motivation: on 2026-07-11 a broken `npm run validate` made every deploy fail
+ * for hours (PR #641), but nothing alerted — the old build kept serving. The
+ * mantra is **merged ≠ deployed until verified live**. This script is the
+ * verification, and it fails LOUDLY (non-zero exit + optional Telegram/Discord
+ * alert) so a silent deploy failure can't hide again.
+ *
+ * Hard gates (any failure → exit 1):
+ *   1. Representative EN + AR routes return 200 and carry an expected marker
+ *      (a 200 that serves a blank/error page is caught by the marker check).
+ *   2. `/data/gold_price.json` parses and carries a sane `xau_usd_per_oz`.
+ *   3. When a build-info marker + EXPECTED_SHA are both available, the deployed
+ *      commit must match — this is the definitive "the new build is live" proof.
+ *
+ * Soft signals (reported, never fail the run — avoids weekend/3rd-party noise):
+ *   - Snapshot age (the fetch cron pauses on weekends, so a large age is normal).
+ *   - Service worker presence.
+ *
+ * No new dependencies: uses Node's global `fetch` (Node 24). The pure helpers
+ * are exported and unit-tested; `fetchImpl`/`now` are injectable.
+ *
+ * Env:
+ *   SITE_URL             default https://goldtickerlive.com
+ *   EXPECTED_SHA         commit that should be live (CI passes the deploy head)
+ *   SNAPSHOT_WARN_AGE_MS default 50h (a full weekend market close + margin)
+ *   TELEGRAM_BOT_TOKEN / TELEGRAM_CHANNEL_ID / DISCORD_WEBHOOK_URL  optional
+ */
+
+'use strict';
+
+const DEFAULT_SITE = 'https://goldtickerlive.com';
+const DEFAULT_WARN_AGE_MS = 50 * 60 * 60 * 1000; // ~one weekend market close + margin
+
+/**
+ * Representative routes. Each has a `marker` substring that must appear in the
+ * served HTML — proves the page rendered its real content, not a 200'd error
+ * shell. `ar` runs the same path with `?lang=ar`.
+ */
+const DEFAULT_ROUTES = [
+  { path: '/', marker: '<title', langs: ['en', 'ar'] },
+  { path: '/tracker.html', marker: '<title', langs: ['en'] },
+  { path: '/calculator.html', marker: '<title', langs: ['en', 'ar'] },
+  { path: '/market.html', marker: '<title', langs: ['en'] },
+  { path: '/methodology.html', marker: '<title', langs: ['en'] },
+];
+
+// ── Pure helpers (unit-tested) ────────────────────────────────────────────────
+
+/** A 200 whose body contains the marker passes. */
+function classifyRoute({ status, body, marker }) {
+  if (status !== 200) return { ok: false, reason: `HTTP ${status}` };
+  if (marker && !(body || '').includes(marker)) {
+    return { ok: false, reason: `marker "${marker}" missing (blank/error shell?)` };
+  }
+  return { ok: true, reason: 'ok' };
+}
+
+/** Validate the snapshot JSON. Hard-fails only on invalid/insane data. */
+function evaluateSnapshot(json, { now = Date.now(), warnAgeMs = DEFAULT_WARN_AGE_MS } = {}) {
+  if (!json || typeof json !== 'object') {
+    return { ok: false, reason: 'gold_price.json did not parse as an object', spot: null };
+  }
+  const spot = Number(json.xau_usd_per_oz);
+  if (!Number.isFinite(spot) || spot <= 0) {
+    return { ok: false, reason: `insane xau_usd_per_oz: ${json.xau_usd_per_oz}`, spot: null };
+  }
+  const stamp = json.fetched_at_utc || json.timestamp_utc || null;
+  const t = stamp ? Date.parse(stamp) : NaN;
+  const ageMs = Number.isFinite(t) ? Math.max(0, now - t) : null;
+  const warnings = [];
+  if (ageMs == null) warnings.push('snapshot timestamp missing/unparseable');
+  else if (ageMs > warnAgeMs) {
+    warnings.push(`snapshot age ${(ageMs / 3.6e6).toFixed(1)}h exceeds ${(warnAgeMs / 3.6e6).toFixed(0)}h`);
+  }
+  return { ok: true, reason: 'ok', spot, ageMs, warnings };
+}
+
+/**
+ * Compare the deployed commit to what CI expected.
+ * Absent marker or absent expectedSha → skipped (soft), never a hard failure.
+ */
+function checkCommitMatch(buildInfo, expectedSha) {
+  if (!expectedSha) return { ok: true, skipped: true, reason: 'no EXPECTED_SHA provided' };
+  if (!buildInfo || !buildInfo.commit) {
+    return { ok: true, skipped: true, reason: 'no build-info marker on site (older build?)' };
+  }
+  const live = String(buildInfo.commit);
+  const want = String(expectedSha);
+  // Accept short/long SHA either direction.
+  const match = live === want || live.startsWith(want) || want.startsWith(live);
+  return match
+    ? { ok: true, skipped: false, reason: `commit ${live.slice(0, 8)} live` }
+    : {
+        ok: false,
+        skipped: false,
+        reason: `deployed commit ${live.slice(0, 8)} != expected ${want.slice(0, 8)} — STALE DEPLOY`,
+      };
+}
+
+// ── Orchestrator ──────────────────────────────────────────────────────────────
+
+function routeUrl(siteUrl, path, lang) {
+  const u = new URL(path, siteUrl);
+  if (lang === 'ar') u.searchParams.set('lang', 'ar');
+  u.searchParams.set('cb', String(Date.now()));
+  return u.toString();
+}
+
+async function runSmoke({
+  siteUrl = DEFAULT_SITE,
+  routes = DEFAULT_ROUTES,
+  expectedSha = '',
+  fetchImpl = fetch,
+  now = Date.now(),
+  warnAgeMs = DEFAULT_WARN_AGE_MS,
+} = {}) {
+  const results = [];
+  const warnings = [];
+  const fail = (name, reason) => results.push({ name, ok: false, reason });
+  const pass = (name, reason) => results.push({ name, ok: true, reason });
+
+  // 1. Routes
+  for (const route of routes) {
+    for (const lang of route.langs) {
+      const url = routeUrl(siteUrl, route.path, lang);
+      const name = `route ${route.path} [${lang}]`;
+      try {
+        const res = await fetchImpl(url, { redirect: 'follow' });
+        const body = await res.text();
+        const verdict = classifyRoute({ status: res.status, body, marker: route.marker });
+        verdict.ok ? pass(name, verdict.reason) : fail(name, verdict.reason);
+      } catch (e) {
+        fail(name, `fetch error: ${e.message}`);
+      }
+    }
+  }
+
+  // 2. Snapshot
+  try {
+    const res = await fetchImpl(`${siteUrl.replace(/\/$/, '')}/data/gold_price.json?cb=${Date.now()}`);
+    const json = await res.json().catch(() => null);
+    const snap = evaluateSnapshot(json, { now, warnAgeMs });
+    snap.ok ? pass('snapshot', `spot=${snap.spot}`) : fail('snapshot', snap.reason);
+    (snap.warnings || []).forEach((w) => warnings.push(`snapshot: ${w}`));
+  } catch (e) {
+    fail('snapshot', `fetch error: ${e.message}`);
+  }
+
+  // 3. Commit match (build-info marker)
+  try {
+    const res = await fetchImpl(`${siteUrl.replace(/\/$/, '')}/build-info.json?cb=${Date.now()}`);
+    const info = res.status === 200 ? await res.json().catch(() => null) : null;
+    const verdict = checkCommitMatch(info, expectedSha);
+    if (verdict.skipped) warnings.push(`commit-match skipped: ${verdict.reason}`);
+    else verdict.ok ? pass('commit-match', verdict.reason) : fail('commit-match', verdict.reason);
+  } catch (e) {
+    warnings.push(`commit-match skipped: ${e.message}`);
+  }
+
+  // Soft: service worker present
+  try {
+    const res = await fetchImpl(`${siteUrl.replace(/\/$/, '')}/sw.js?cb=${Date.now()}`);
+    if (res.status !== 200) warnings.push(`sw.js returned HTTP ${res.status}`);
+  } catch (e) {
+    warnings.push(`sw.js check skipped: ${e.message}`);
+  }
+
+  const ok = results.every((r) => r.ok);
+  return { ok, results, warnings };
+}
+
+// ── Alerting + CLI ────────────────────────────────────────────────────────────
+
+async function sendAlert(text) {
+  const tgToken = process.env.TELEGRAM_BOT_TOKEN;
+  const tgChan = process.env.TELEGRAM_CHANNEL_ID;
+  const discord = process.env.DISCORD_WEBHOOK_URL;
+  const jobs = [];
+  if (tgToken && tgChan) {
+    jobs.push(
+      fetch(`https://api.telegram.org/bot${tgToken}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: tgChan, text, disable_web_page_preview: true }),
+      }).catch(() => {})
+    );
+  }
+  if (discord) {
+    jobs.push(
+      fetch(discord, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: text }),
+      }).catch(() => {})
+    );
+  }
+  await Promise.allSettled(jobs);
+}
+
+async function main() {
+  const siteUrl = process.env.SITE_URL || DEFAULT_SITE;
+  const expectedSha = process.env.EXPECTED_SHA || '';
+  const warnAgeMs = Number(process.env.SNAPSHOT_WARN_AGE_MS) || DEFAULT_WARN_AGE_MS;
+
+  console.log(`Post-deploy smoke → ${siteUrl}${expectedSha ? ` (expect ${expectedSha.slice(0, 8)})` : ''}`);
+  const { ok, results, warnings } = await runSmoke({ siteUrl, expectedSha, warnAgeMs });
+
+  for (const r of results) console.log(`  ${r.ok ? '✓' : '✗'} ${r.name} — ${r.reason}`);
+  for (const w of warnings) console.log(`  ⚠ ${w}`);
+
+  if (ok) {
+    console.log('\n✅ Post-deploy smoke passed.');
+    return 0;
+  }
+  const failed = results.filter((r) => !r.ok).map((r) => `${r.name}: ${r.reason}`);
+  const msg = `🚨 GoldTickerLive post-deploy smoke FAILED for ${siteUrl}\n` + failed.map((f) => `• ${f}`).join('\n');
+  console.error('\n' + msg);
+  await sendAlert(msg);
+  return 1;
+}
+
+module.exports = { classifyRoute, evaluateSnapshot, checkCommitMatch, runSmoke, routeUrl };
+
+if (require.main === module) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((e) => {
+      console.error('post-deploy-smoke crashed:', e);
+      process.exit(1);
+    });
+}

--- a/tests/post-deploy-smoke.test.js
+++ b/tests/post-deploy-smoke.test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  classifyRoute,
+  evaluateSnapshot,
+  checkCommitMatch,
+  runSmoke,
+} = require(path.resolve(__dirname, '..', 'scripts', 'node', 'post-deploy-smoke.js'));
+
+// ── classifyRoute ─────────────────────────────────────────────────────────────
+test('classifyRoute: 200 with marker passes', () => {
+  assert.equal(classifyRoute({ status: 200, body: '<html><title>x</title>', marker: '<title' }).ok, true);
+});
+test('classifyRoute: 200 without marker fails (blank/error shell)', () => {
+  const v = classifyRoute({ status: 200, body: 'oops', marker: '<title' });
+  assert.equal(v.ok, false);
+  assert.match(v.reason, /marker/);
+});
+test('classifyRoute: non-200 fails', () => {
+  assert.equal(classifyRoute({ status: 404, body: '', marker: '<title' }).ok, false);
+});
+
+// ── evaluateSnapshot ──────────────────────────────────────────────────────────
+test('evaluateSnapshot: sane fresh snapshot passes', () => {
+  const now = Date.parse('2026-07-11T09:00:00Z');
+  const v = evaluateSnapshot(
+    { xau_usd_per_oz: 4121.4, fetched_at_utc: '2026-07-11T08:30:00Z' },
+    { now }
+  );
+  assert.equal(v.ok, true);
+  assert.equal(v.spot, 4121.4);
+  assert.deepEqual(v.warnings, []);
+});
+test('evaluateSnapshot: insane spot hard-fails', () => {
+  assert.equal(evaluateSnapshot({ xau_usd_per_oz: 0 }).ok, false);
+  assert.equal(evaluateSnapshot({ xau_usd_per_oz: 'nope' }).ok, false);
+  assert.equal(evaluateSnapshot(null).ok, false);
+});
+test('evaluateSnapshot: old age is a warning, not a failure (weekend cron gap)', () => {
+  const now = Date.parse('2026-07-13T09:00:00Z'); // ~48h later
+  const v = evaluateSnapshot(
+    { xau_usd_per_oz: 4121.4, fetched_at_utc: '2026-07-11T08:30:00Z' },
+    { now, warnAgeMs: 24 * 3.6e6 }
+  );
+  assert.equal(v.ok, true, 'still passes');
+  assert.equal(v.warnings.length, 1, 'but warns about age');
+});
+
+// ── checkCommitMatch ──────────────────────────────────────────────────────────
+test('checkCommitMatch: exact + short/long sha match', () => {
+  assert.equal(checkCommitMatch({ commit: 'abc123def456' }, 'abc123def456').ok, true);
+  assert.equal(checkCommitMatch({ commit: 'abc123def456' }, 'abc123de').ok, true, 'expected short sha');
+  assert.equal(checkCommitMatch({ commit: 'abc123de' }, 'abc123def456').ok, true, 'live short sha');
+});
+test('checkCommitMatch: mismatch is a hard failure (stale deploy)', () => {
+  const v = checkCommitMatch({ commit: 'aaaaaaaa' }, 'bbbbbbbb');
+  assert.equal(v.ok, false);
+  assert.match(v.reason, /STALE DEPLOY/);
+});
+test('checkCommitMatch: missing marker or sha is skipped, not failed', () => {
+  assert.equal(checkCommitMatch(null, 'abc').skipped, true);
+  assert.equal(checkCommitMatch({ commit: 'abc' }, '').skipped, true);
+});
+
+// ── runSmoke (fake fetch) ─────────────────────────────────────────────────────
+function fakeFetch(map) {
+  return async (url) => {
+    for (const [frag, resp] of Object.entries(map)) {
+      if (url.includes(frag)) {
+        return {
+          status: resp.status ?? 200,
+          async text() {
+            return resp.body ?? '';
+          },
+          async json() {
+            return resp.json ?? null;
+          },
+        };
+      }
+    }
+    return { status: 404, async text() { return 'not found'; }, async json() { return null; } };
+  };
+}
+
+const HAPPY = {
+  '/index': { body: '<title>Gold</title>' },
+  '/?cb': { body: '<title>Gold</title>' },
+  'goldtickerlive.com/?': { body: '<title>Gold</title>' },
+  'tracker.html': { body: '<title>Tracker</title>' },
+  'calculator.html': { body: '<title>Calc</title>' },
+  'market.html': { body: '<title>Market</title>' },
+  'methodology.html': { body: '<title>Method</title>' },
+  'gold_price.json': { json: { xau_usd_per_oz: 4121.4, fetched_at_utc: '2026-07-11T08:30:00Z' } },
+  'build-info.json': { json: { commit: 'deadbeef1234' } },
+  'sw.js': { body: '// sw' },
+};
+
+test('runSmoke: healthy site with matching commit passes', async () => {
+  const now = Date.parse('2026-07-11T09:00:00Z');
+  const r = await runSmoke({ fetchImpl: fakeFetch(HAPPY), expectedSha: 'deadbeef1234', now });
+  assert.equal(r.ok, true, JSON.stringify(r.results.filter((x) => !x.ok)));
+});
+
+test('runSmoke: a stale deployed commit fails loudly', async () => {
+  const now = Date.parse('2026-07-11T09:00:00Z');
+  const r = await runSmoke({ fetchImpl: fakeFetch(HAPPY), expectedSha: 'ffffffff9999', now });
+  assert.equal(r.ok, false);
+  assert.ok(r.results.find((x) => x.name === 'commit-match' && !x.ok));
+});
+
+test('runSmoke: a 404 route fails loudly', async () => {
+  const broken = { ...HAPPY };
+  delete broken['market.html'];
+  const now = Date.parse('2026-07-11T09:00:00Z');
+  const r = await runSmoke({ fetchImpl: fakeFetch(broken), expectedSha: 'deadbeef1234', now });
+  assert.equal(r.ok, false);
+  assert.ok(r.results.find((x) => x.name.includes('market.html') && !x.ok));
+});
+
+test('runSmoke: missing build-info marker is a warning, not a failure', async () => {
+  const noMarker = { ...HAPPY };
+  delete noMarker['build-info.json'];
+  const now = Date.parse('2026-07-11T09:00:00Z');
+  const r = await runSmoke({ fetchImpl: fakeFetch(noMarker), expectedSha: 'deadbeef1234', now });
+  assert.equal(r.ok, true, 'site still healthy without the marker');
+  assert.ok(r.warnings.find((w) => /commit-match skipped/.test(w)));
+});


### PR DESCRIPTION
## What & why (Mission 5 — deploy durability)

A durable guard so a **silently-failed deploy can't hide**. On 2026-07-11 a broken `npm run validate` failed every deploy for hours (PR #641/#652) while production kept serving the old build and nothing alerted. This makes **merged ≠ deployed until verified live** enforceable.

### `scripts/node/post-deploy-smoke.js`
HTTP smoke against production (Node global `fetch`, no new deps).
**Hard gates** (→ exit 1 + alert):
- Representative EN/AR routes return 200 **and** contain a content marker (a 200'd blank/error shell is caught).
- `/data/gold_price.json` parses with a sane `xau_usd_per_oz`.
- When a build-info marker + expected SHA are both present, the **deployed commit must match** — the definitive "new build is live" proof.

**Soft signals** (reported, never fail — so weekend cron gaps and 3rd-party blips don't cry wolf): snapshot age, `sw.js` presence.

Pure helpers (`classifyRoute`/`evaluateSnapshot`/`checkCommitMatch`/`runSmoke`) exported and unit-tested with `fetch`/`now` injected.

### `deploy.yml`
One new step writes `dist/build-info.json` (`commit`/`ref`/`run_id`/`built_at_utc`) before the artifact upload — the fingerprint the smoke reads back. Non-invasive: writes a single JSON file into `dist/`.

### `post-deploy-smoke.yml`
Runs on `workflow_run` after a **successful** "Deploy to GitHub Pages" (+ `workflow_dispatch`). Propagation-tolerant: retries 4×20s and only fires the external alert on the final attempt, so Pages CDN lag never false-alarms. (Takes effect once on `main`, since `workflow_run` uses the default-branch copy.)

### `package.json`
`npm run smoke` for local/ad-hoc runs.

## Verification
- `npm test` → **1606 pass** (13 new)
- `npx eslint` → 0 · `npm run build` → exit 0, **no HTML mutations** · `npm run validate` → exit 0
- Live dry-run (`node scripts/node/post-deploy-smoke.js`) → routes + snapshot pass, commit-match cleanly skipped without a SHA.

Will manually dispatch the workflow after merge to confirm it runs green against the fingerprinted build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and observability only—no app runtime, auth, or data-pipeline logic changes; production impact is a small public JSON fingerprint and HTTP health checks.
> 
> **Overview**
> Adds **post-deploy verification** so a green Pages deploy cannot hide a stale or broken production site.
> 
> The deploy workflow now writes **`dist/build-info.json`** (commit, ref, run id, build time) before artifact upload. A new **`Post-deploy smoke`** workflow runs after a successful **Deploy to GitHub Pages** (or via manual dispatch), hits live routes and data, and compares **`build-info.json`** to the deploy run’s **`head_sha`** when both are present.
> 
> **`post-deploy-smoke.js`** enforces hard checks: representative EN/AR pages return 200 with a content marker, **`gold_price.json`** has a sane spot price, and commit mismatch fails as **STALE DEPLOY**. Snapshot age and **`sw.js`** are warnings only. Failures exit non-zero and can alert via Telegram/Discord; the workflow retries up to four times with alerts suppressed on early attempts to tolerate CDN lag. **`npm run smoke`** runs the same script locally; unit tests cover the pure helpers and orchestration with injected fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42d47590b0fecca719c9ac3fb3635f6742de7988. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->