### PR TITLE
fix(freshness): apply market-closed overlay on every price surface

### DIFF
--- a/docs/price-flow-map.md
+++ b/docs/price-flow-map.md
@@ -60,6 +60,17 @@ Mandatory disclosure per block: **state label + source label + UTC timestamp**.
 Trust invariants: reference estimates are never shown as retail quotes; a closed market reads
 `closed` even with recent data; cached/fallback stays visibly non-live; AED peg stays 3.6725.
 
+**Market-closed overlay is mandatory on every price surface.** `classifyFreshness` and
+`getLiveFreshness` are pure data-freshness signals — neither emits `closed`. Any surface that
+renders a freshness pill MUST wrap its resolved state key in `applyMarketClosedOverlay(key)`
+(from `live-status.js`) before mapping to a label/dot, so a freshly-fetched quote during a
+closed market never reads "Live". The shared ticker + spot bar, home, compare, and portfolio
+did this; an audit (2026-07-11) found market/dubai/shops/heatmap/invest and the calculator's
+inline note derived their pill from the raw state without the overlay — they could show "Live"
+while the same page's ticker read "Closed". Fixed so all nine non-Tracker surfaces apply the
+overlay (guarded by `tests/market-closed-overlay-coverage.test.js`). Each surface's freshness
+label map now carries a bilingual `closed` entry ("Closed"/"مغلق").
+
 ## 3. Per-surface map
 
 All "canonical" surfaces below call `getCanonicalSpot()` for the initial paint and

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -1300,8 +1300,14 @@ function updateSpotBadge() {
         hour: '2-digit',
         minute: '2-digit',
       });
-      const sourceLabel =
-        STATE.spotSource === 'live'
+      // Honor the market-closed overlay here too — the parallel FreshnessBadge
+      // already does, so without this the note could read "Live" while the badge
+      // beside it reads "Closed" (freshness contract).
+      const sourceLabel = !getMarketStatus().isOpen
+        ? STATE.lang === 'ar'
+          ? 'مغلق'
+          : 'Closed'
+        : STATE.spotSource === 'live'
           ? STATE.lang === 'ar'
             ? 'مباشر'
             : 'Live'

--- a/src/pages/dubai-gold-price.js
+++ b/src/pages/dubai-gold-price.js
@@ -18,6 +18,7 @@ import { injectBreadcrumbs } from '../components/breadcrumbs.js';
 import * as cache from '../lib/cache.js';
 import { initPageEnter } from '../lib/page-enter.js';
 import { getCanonicalSpot } from '../lib/spot-resolver.js';
+import { applyMarketClosedOverlay } from '../lib/live-status.js';
 import { startVisibilityAwareRefresh } from '../lib/visibility-refresh.js';
 import { CONSTANTS } from '../config/index.js';
 import { formatNumber, formatCurrency, formatTimestampShort } from '../lib/formatter.js';
@@ -39,6 +40,7 @@ const T = {
     freshDelayed: 'Delayed',
     freshCached: 'Cached',
     freshStale: 'Stale',
+    freshClosed: 'Closed',
     updated: 'Updated',
   },
   ar: {
@@ -52,6 +54,7 @@ const T = {
     freshDelayed: 'متأخر',
     freshCached: 'مخزّن',
     freshStale: 'قديم',
+    freshClosed: 'مغلق',
     updated: 'آخر تحديث',
   },
 };
@@ -66,6 +69,7 @@ const FRESH_KEY = {
   cached: 'freshCached',
   fallback: 'freshStale',
   unavailable: 'freshStale',
+  closed: 'freshClosed',
 };
 
 function aedCell(id, value) {
@@ -110,9 +114,12 @@ function renderLive() {
   const pill = document.getElementById('dubai-fresh');
   const dot = document.getElementById('dubai-fresh-dot');
   const text = document.getElementById('dubai-fresh-text');
-  const key = FRESH_KEY[fresh.state];
+  // Apply the market-closed overlay so a closed-market quote never reads "Live"
+  // (freshness contract) — mirrors home/compare/portfolio and the shared ticker.
+  const displayState = applyMarketClosedOverlay(fresh.state || 'unavailable');
+  const key = FRESH_KEY[displayState];
   if (pill && dot && text && key) {
-    dot.className = `dubai-fresh-dot dubai-fresh-dot--${fresh.state}`;
+    dot.className = `dubai-fresh-dot dubai-fresh-dot--${displayState}`;
     const stamp = fresh.updatedAt ? formatTimestampShort(fresh.updatedAt, STATE.lang) : '';
     text.textContent = stamp ? `${t(key)} · ${t('updated')}: ${stamp}` : t(key);
     pill.hidden = false;

--- a/src/pages/heatmap.js
+++ b/src/pages/heatmap.js
@@ -29,7 +29,7 @@ import { updateSpotBar } from '../components/spotBar.js';
 import { el, clear } from '../lib/safe-dom.js';
 import { flagSymbolForCountry, iconUseElement } from '../components/icon-sprite.js';
 import { track, EVENTS } from '../lib/analytics.js';
-import { getLiveFreshness } from '../lib/live-status.js';
+import { getLiveFreshness, applyMarketClosedOverlay } from '../lib/live-status.js';
 import { initPageEnter } from '../lib/page-enter.js';
 import {
   HEATMAP_KARATS,
@@ -876,11 +876,15 @@ function renderSpotBadge() {
       hasLiveFailure: STATE.spotSource !== 'live',
     });
     const dict = t();
+    // Apply the market-closed overlay so a closed-market quote never reads "Live"
+    // (freshness contract). getLiveFreshness stays a pure data-freshness signal;
+    // the `closed` entry in the freshness dict is now reachable (was dead).
+    const key = applyMarketClosedOverlay(f.key);
     clear(freshNode);
-    freshNode.dataset.state = f.key;
+    freshNode.dataset.state = key;
     freshNode.appendChild(el('span', { class: 'heatmap-fresh-dot', 'aria-hidden': 'true' }));
     freshNode.appendChild(
-      el('span', {}, [`${dict.freshness[f.key] || f.key}${f.ageText ? ` · ${f.ageText}` : ''}`])
+      el('span', {}, [`${dict.freshness[key] || key}${f.ageText ? ` · ${f.ageText}` : ''}`])
     );
   }
 }

--- a/src/pages/invest.js
+++ b/src/pages/invest.js
@@ -1,6 +1,7 @@
 import { CONSTANTS, KARATS, TRANSLATIONS } from '../config/index.js';
 import * as api from '../lib/api.js';
 import { getCanonicalSpot } from '../lib/spot-resolver.js';
+import { applyMarketClosedOverlay } from '../lib/live-status.js';
 import { startVisibilityAwareRefresh } from '../lib/visibility-refresh.js';
 import * as cache from '../lib/cache.js';
 import { mountSkeleton } from '../components/skeleton.js';
@@ -58,6 +59,7 @@ const I18N = {
     freshDelayed: 'Delayed',
     freshCached: 'Cached',
     freshStale: 'Stale',
+    freshClosed: 'Closed',
     marketOpen: 'Market open',
     marketClosed: 'Market closed',
     openTracker: 'Open full tracker →',
@@ -152,6 +154,7 @@ const I18N = {
     freshDelayed: 'متأخر',
     freshCached: 'مخزّن',
     freshStale: 'قديم',
+    freshClosed: 'مغلق',
     marketOpen: 'السوق مفتوح',
     marketClosed: 'السوق مغلق',
     openTracker: 'افتح المتتبع الكامل ←',
@@ -1115,13 +1118,18 @@ function renderLiveCard() {
       // nothing about how old the pipeline snapshot actually is. Prefix with the
       // honest freshness state (live / delayed / cached / stale) from the
       // canonical snapshot, never faked.
+      // Apply the market-closed overlay so the freshness dot never reads "Live"
+      // while the adjacent market-status chip reads "Market closed" (they were
+      // derived from different clocks — a visible self-contradiction).
+      const displayState = applyMarketClosedOverlay(state.freshnessState || 'unavailable');
       const freshKey = {
         live: 'freshLive',
         delayed: 'freshDelayed',
         cached: 'freshCached',
         fallback: 'freshStale',
         unavailable: 'freshStale',
-      }[state.freshnessState];
+        closed: 'freshClosed',
+      }[displayState];
       const freshLabel = freshKey ? tx(freshKey) : null;
       clear(updatedEl);
       if (freshLabel) {
@@ -1129,7 +1137,7 @@ function renderLiveCard() {
           el(
             'span',
             {
-              class: `invest-fresh-dot invest-fresh-dot--${state.freshnessState}`,
+              class: `invest-fresh-dot invest-fresh-dot--${displayState}`,
               'aria-hidden': 'true',
             },
             ''

--- a/src/pages/market.js
+++ b/src/pages/market.js
@@ -20,6 +20,7 @@ import { injectBreadcrumbs } from '../components/breadcrumbs.js';
 import * as cache from '../lib/cache.js';
 import { initPageEnter } from '../lib/page-enter.js';
 import { getCanonicalSpot } from '../lib/spot-resolver.js';
+import { applyMarketClosedOverlay } from '../lib/live-status.js';
 import { startVisibilityAwareRefresh } from '../lib/visibility-refresh.js';
 import { CONSTANTS } from '../config/index.js';
 import { formatNumber, formatCurrency, formatTimestampShort } from '../lib/formatter.js';
@@ -37,6 +38,7 @@ const T = {
     freshDelayed: 'Delayed',
     freshCached: 'Cached',
     freshStale: 'Stale',
+    freshClosed: 'Closed',
     updated: 'Updated',
   },
   ar: {
@@ -49,6 +51,7 @@ const T = {
     freshDelayed: 'متأخر',
     freshCached: 'مخزّن',
     freshStale: 'قديم',
+    freshClosed: 'مغلق',
     updated: 'آخر تحديث',
   },
 };
@@ -59,6 +62,7 @@ const FRESH_KEY = {
   cached: 'freshCached',
   fallback: 'freshStale',
   unavailable: 'freshStale',
+  closed: 'freshClosed',
 };
 
 function t(key) {
@@ -91,9 +95,12 @@ function renderWorked() {
   const pill = document.getElementById('mkt-worked-fresh');
   const dot = document.getElementById('mkt-worked-dot');
   const text = document.getElementById('mkt-worked-fresh-text');
-  const key = FRESH_KEY[fresh.state];
+  // Apply the market-closed overlay so a closed-market quote never reads "Live"
+  // (freshness contract) — mirrors home/compare/portfolio and the shared ticker.
+  const displayState = applyMarketClosedOverlay(fresh.state || 'unavailable');
+  const key = FRESH_KEY[displayState];
   if (pill && dot && text && key) {
-    dot.className = `mkt-worked-dot mkt-worked-dot--${fresh.state}`;
+    dot.className = `mkt-worked-dot mkt-worked-dot--${displayState}`;
     const stamp = fresh.updatedAt ? formatTimestampShort(fresh.updatedAt, STATE.lang) : '';
     text.textContent = stamp ? `${t(key)} · ${t('updated')}: ${stamp}` : t(key);
     pill.hidden = false;

--- a/src/pages/shops.js
+++ b/src/pages/shops.js
@@ -4,6 +4,7 @@ import { fetchShops as fetchSupabaseShops } from '../lib/supabase-data.js';
 import { updateTicker } from '../components/ticker.js';
 import { updateSpotBar } from '../components/spotBar.js';
 import { getCanonicalSpot } from '../lib/spot-resolver.js';
+import { applyMarketClosedOverlay } from '../lib/live-status.js';
 import { startVisibilityAwareRefresh } from '../lib/visibility-refresh.js';
 import { mountSharedShell } from '../components/site-shell.js';
 import { injectBreadcrumbs } from '../components/breadcrumbs.js';
@@ -119,6 +120,7 @@ const TXT = {
     refDelayed: 'Delayed',
     refCached: 'Cached',
     refStale: 'Stale',
+    refClosed: 'Closed',
     featuredNote:
       'Featured: editorially selected markets for this region. Not a paid placement and not an endorsement of any individual shop inside the market.',
     statListings: 'Shops & markets',
@@ -284,6 +286,7 @@ const TXT = {
     refDelayed: 'متأخر',
     refCached: 'مخزّن',
     refStale: 'قديم',
+    refClosed: 'مغلق',
     featuredNote:
       'مختارة: أسواق مختارة تحريرياً لهذه المنطقة. ليست إعلاناً مدفوعاً ولا تزكية لأي محل بعينه داخل السوق.',
     statListings: 'محلات وأسواق',
@@ -2249,6 +2252,7 @@ const REF_FRESH_KEY = {
   cached: 'refCached',
   fallback: 'refStale',
   unavailable: 'refStale',
+  closed: 'refClosed',
 };
 
 function renderReferenceChip() {
@@ -2275,8 +2279,11 @@ function renderReferenceChip() {
   }
 
   const fresh = snap.freshness || {};
-  const key = REF_FRESH_KEY[fresh.state];
-  if (dot) dot.className = `shops-ref-dot shops-ref-dot--${fresh.state || 'unavailable'}`;
+  // Apply the market-closed overlay so a closed-market reference never reads
+  // "Live" (freshness contract) — mirrors the shared ticker/spot bar.
+  const displayState = applyMarketClosedOverlay(fresh.state || 'unavailable');
+  const key = REF_FRESH_KEY[displayState];
+  if (dot) dot.className = `shops-ref-dot shops-ref-dot--${displayState}`;
   if (freshEl && key) {
     let stamp = '';
     if (fresh.updatedAt) {

--- a/styles/pages/dubai-gold-price-redesign.css
+++ b/styles/pages/dubai-gold-price-redesign.css
@@ -105,7 +105,8 @@
 }
 .dubai-fresh-dot--cached,
 .dubai-fresh-dot--fallback,
-.dubai-fresh-dot--unavailable {
+.dubai-fresh-dot--unavailable,
+.dubai-fresh-dot--closed {
   background: #b06a1f;
   box-shadow: 0 0 0 3px rgb(176 106 31 / 16%);
 }

--- a/styles/pages/heatmap.css
+++ b/styles/pages/heatmap.css
@@ -114,7 +114,8 @@
 
 .heatmap-fresh[data-state='stale'] .heatmap-fresh-dot,
 .heatmap-fresh[data-state='fallback'] .heatmap-fresh-dot,
-.heatmap-fresh[data-state='unavailable'] .heatmap-fresh-dot {
+.heatmap-fresh[data-state='unavailable'] .heatmap-fresh-dot,
+.heatmap-fresh[data-state='closed'] .heatmap-fresh-dot {
   background: var(--color-down);
 }
 

--- a/styles/pages/learn-redesign.css
+++ b/styles/pages/learn-redesign.css
@@ -317,7 +317,8 @@ html[dir='rtl'] .learn-reading-progress__bar {
 }
 .invest-fresh-dot--cached,
 .invest-fresh-dot--fallback,
-.invest-fresh-dot--unavailable {
+.invest-fresh-dot--unavailable,
+.invest-fresh-dot--closed {
   background: #b06a1f;
   box-shadow: 0 0 0 3px rgb(176 106 31 / 16%);
 }

--- a/styles/pages/market-redesign.css
+++ b/styles/pages/market-redesign.css
@@ -102,7 +102,8 @@
 }
 .mkt-worked-dot--cached,
 .mkt-worked-dot--fallback,
-.mkt-worked-dot--unavailable {
+.mkt-worked-dot--unavailable,
+.mkt-worked-dot--closed {
   background: #b06a1f;
   box-shadow: 0 0 0 3px rgb(176 106 31 / 16%);
 }

--- a/styles/pages/shops-redesign.css
+++ b/styles/pages/shops-redesign.css
@@ -10,8 +10,8 @@
    Light theme only; dark deferred site-wide (owner-gated).
    ========================================================================== */
 
-/* ── Hero: serif headline (dark hero background untouched) ─────────────────── */
-/* Serif treatment only — the dark hero's carefully-tuned near-white text
+/* ── Hero: serif headline (dark hero background untouched) ───────────────────
+   Serif treatment only — the dark hero's carefully-tuned near-white text
    colours (#fff8ea title, light-cream kicker/lead) are preserved for contrast. */
 .shops-hero #shops-title {
   font-family: var(--gtl-serif);
@@ -56,7 +56,8 @@
 }
 .shops-ref-dot--cached,
 .shops-ref-dot--fallback,
-.shops-ref-dot--unavailable {
+.shops-ref-dot--unavailable,
+.shops-ref-dot--closed {
   background: #e0a253;
   box-shadow: 0 0 0 3px rgb(224 162 83 / 20%);
 }

--- a/tests/market-closed-overlay-coverage.test.js
+++ b/tests/market-closed-overlay-coverage.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * Guard: every in-page price freshness surface must apply the market-closed
+ * overlay, so no surface can label a closed-market quote "Live" while the shared
+ * ticker/spot-bar on the same page correctly reads "Closed"
+ * (docs/freshness-contract.md — "If market is closed, state must be `closed`").
+ *
+ * These five pages plus the calculator note previously derived their pill from
+ * the raw snapshot state / getLiveFreshness key WITHOUT the overlay (audit
+ * 2026-07-11). This static guard locks the fix so the overlay can't be dropped
+ * again silently. The overlay function itself is behaviourally tested in
+ * freshness-badge-guard.test.js ("applyMarketClosedOverlay forces closed").
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function read(rel) {
+  return fs.readFileSync(path.resolve(__dirname, '..', rel), 'utf8');
+}
+
+// Pages that derive an in-page freshness pill from the canonical snapshot and
+// must route it through applyMarketClosedOverlay + carry a `closed` label.
+const OVERLAY_SURFACES = [
+  { file: 'src/pages/market.js', closedLabel: 'freshClosed' },
+  { file: 'src/pages/dubai-gold-price.js', closedLabel: 'freshClosed' },
+  { file: 'src/pages/shops.js', closedLabel: 'refClosed' },
+  { file: 'src/pages/heatmap.js', closedLabel: null }, // uses shared freshness dict incl. `closed`
+  { file: 'src/pages/invest.js', closedLabel: 'freshClosed' },
+];
+
+for (const { file, closedLabel } of OVERLAY_SURFACES) {
+  test(`${file} applies applyMarketClosedOverlay to its freshness pill`, () => {
+    const src = read(file);
+    assert.match(
+      src,
+      /import\s*\{[^}]*applyMarketClosedOverlay[^}]*\}\s*from\s*['"][^'"]*live-status\.js['"]/,
+      `${file} must import applyMarketClosedOverlay from live-status.js`
+    );
+    assert.match(
+      src,
+      /applyMarketClosedOverlay\s*\(/,
+      `${file} must call applyMarketClosedOverlay() when deriving the pill state`
+    );
+    if (closedLabel) {
+      assert.ok(
+        src.includes(closedLabel),
+        `${file} must define a "${closedLabel}" label so the overlaid closed state renders`
+      );
+    }
+  });
+}
+
+test('calculator.js freshness note honors the market-closed overlay', () => {
+  const src = read('src/pages/calculator.js');
+  assert.match(
+    src,
+    /!\s*getMarketStatus\(\)\.isOpen/,
+    'calculator note must branch on getMarketStatus().isOpen to show "Closed"'
+  );
+  // The note must show a Closed label in both languages.
+  assert.ok(src.includes("'Closed'") && src.includes("'مغلق'"), 'note needs EN+AR closed label');
+});
+
+test('all overlaid surfaces still expose a bilingual closed label where they own one', () => {
+  // AR "مغلق" must accompany EN "Closed" on the surfaces that own their label map.
+  for (const file of ['src/pages/market.js', 'src/pages/dubai-gold-price.js', 'src/pages/shops.js', 'src/pages/invest.js']) {
+    const src = read(file);
+    assert.ok(src.includes("'Closed'"), `${file} missing EN closed label`);
+    assert.ok(src.includes("'مغلق'"), `${file} missing AR closed label`);
+  }
+});


### PR DESCRIPTION
## Mission 2 — honest-freshness consistency (S1 bug)

A per-surface audit found five in-page freshness pills — **market**, **dubai**, **shops**, **heatmap**, **invest** — plus the **calculator's inline note** derived their state from the raw canonical snapshot / `getLiveFreshness` key **without `applyMarketClosedOverlay`**.

`classifyFreshness` and `getLiveFreshness` are pure data-freshness signals — neither emits `closed`. So on a closed market these surfaces could render **"Live"** while the shared ticker/spot bar (and home/compare/portfolio, which do apply the overlay) on the **same page** correctly read **"Closed."** That violates the freshness-contract hard invariant ("if market is closed, state must be `closed` even with recent data"). `invest` was worst: its freshness dot (raw state) directly contradicted its own adjacent market-status chip already reading "Market closed."

This is currently **active** (the market is closed as I write this — the live ticker reads "Closed").

### Fix
Route each surface's pill state through `applyMarketClosedOverlay()` before mapping to label/dot — the same guard the correct surfaces use. Each label map gains a bilingual `closed` entry (**"Closed" / "مغلق"**) and a neutral `closed` dot colour (grouped with cached/fallback). No change to the canonical resolver, the snapshot vocabulary, or the Tracker's own live engine.

### Guard + docs
- `tests/market-closed-overlay-coverage.test.js` — regression guard: asserts all six surfaces import + apply the overlay and carry a bilingual closed label. (`applyMarketClosedOverlay` behaviour itself is already covered by `freshness-badge-guard.test.js`.)
- `docs/price-flow-map.md` — documents the overlay as a **mandatory per-surface rule**.
- Opportunistic: fixed the pre-existing `shops-redesign.css:14` stylelint error (file already touched).

## Verification
- `npm test` → **1613 pass** (7 new) · `npx eslint` → 0 · `npx stylelint` (changed) → 0 · `npm run build` → exit 0, **no HTML mutations** · `npm run validate` → exit 0

Will live-verify each surface's pill reads "Closed" (consistent with the ticker) EN/AR after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-layer freshness labeling only; behavior is guarded by tests and matches patterns already used on home/compare/portfolio/ticker.
> 
> **Overview**
> Fixes **honest-freshness** violations where several pages could show **"Live"** on in-page freshness pills while the shared ticker/spot bar on the same page correctly showed **"Closed"** when the market was closed.
> 
> **market**, **dubai**, **shops** (reference chip), **heatmap**, and **invest** now route pill state through `applyMarketClosedOverlay()` before label/dot mapping; each adds bilingual **Closed / مغلق** and `closed` dot styling (grouped with cached/fallback). **Calculator**’s inline freshness note branches on `getMarketStatus().isOpen` so it stays aligned with `FreshnessBadge`.
> 
> Adds `tests/market-closed-overlay-coverage.test.js` to lock imports/calls and closed labels; documents the mandatory overlay rule in `docs/price-flow-map.md`. No changes to the canonical resolver or snapshot vocabulary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28850b286ab18fd2d94c1a7a79ccb9fc06e764d9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->