### PR TITLE
test: extend Arabic mobile regression coverage across public surfaces

### DIFF
--- a/docs/testing/rtl-mobile-coverage.md
+++ b/docs/testing/rtl-mobile-coverage.md
@@ -1,0 +1,79 @@
+# RTL / mobile regression coverage
+
+Arabic (RTL) mobile-layout integrity is a CI invariant, enforced by two complementary Playwright
+specs that run in the `Playwright smoke` job of `.github/workflows/ci.yml` (`--project=chromium`
+against the built `dist/`).
+
+## The two specs
+
+| Spec                                                   | Surfaces                                                            | Status           |
+| ------------------------------------------------------ | ------------------------------------------------------------------- | ---------------- |
+| `tests/e2e/rtl-mobile-overflow.spec.js`                | Core 6: home, tracker, calculator, shops, methodology, compare      | added in PR #662 |
+| `tests/e2e/rtl-mobile-public-surface-coverage.spec.js` | Remaining public families (below) + search overlay + RTL nav drawer | this file's PR   |
+
+Together they cover every standard public page family. They are intentionally non-overlapping —
+extend the second spec's `AR_SURFACES` matrix when a new public page family is added.
+
+## Surfaces & width matrix (public-surface spec)
+
+Each surface loads via its Arabic first-load path (`?lang=ar` — the URL shape the language switcher
+and hreflang alternates link to).
+
+| Surface         | Route                    | 390px | 320px |
+| --------------- | ------------------------ | :---: | :---: |
+| Learn hub       | `/learn.html`            |  ✅   |       |
+| Glossary        | `/glossary.html`         |  ✅   |  ✅   |
+| Market overview | `/market.html`           |  ✅   |  ✅   |
+| Heatmap         | `/heatmap.html`          |  ✅   |  ✅   |
+| Portfolio       | `/portfolio.html`        |  ✅   |  ✅   |
+| Dubai landing   | `/dubai-gold-price.html` |  ✅   |  ✅   |
+| Privacy         | `/privacy.html`          |  ✅   |       |
+| Terms           | `/terms.html`            |  ✅   |       |
+| 404             | `/404.html`              |  ✅   |       |
+
+320px is added for the data/interaction-dense surfaces (tables/cards, charts, maps, dense indexes)
+most likely to overflow. 390px is the broad baseline.
+
+## Assertions (per surface × width)
+
+1. Settled RTL — `documentElement` `dir=rtl`, `lang=ar` (waits for the page's own boot).
+2. Shared shell mounted — `.site-nav` + `<main>` visible.
+3. **No document-level horizontal overflow** — robust detector (below).
+4. RTL-context a11y smoke — exactly one `<main>`, one `<h1>`, zero unnamed `<button>`.
+5. No uncaught page error.
+
+Plus two shared-shell interaction tests in Arabic at 390px:
+
+- **Global search overlay**: trigger opens overlay, focus moves to the input, Arabic query ("ذهب")
+  yields results or a valid empty-state, no overflow while open, `Escape` closes and returns focus
+  to the trigger.
+- **Mobile nav drawer**: hamburger toggles `aria-expanded`/`aria-hidden`, no overflow while open,
+  `Escape` closes and releases the body scroll lock.
+
+## Robust overflow detector
+
+A bare `scrollWidth` check reports _that_ the page overflows; the detector also reports _which_
+element does, while ignoring legitimate horizontal scroll containers (`overflow-x: auto|scroll` —
+responsive tables, carousels, code blocks) and fixed-position chrome. It reports the offending
+tag/id/class/overshoot for fast triage.
+
+## Intentional exclusions
+
+- **`offline.html`** — the service-worker offline fallback. It is a static page with **no ES-module
+  shell boot** (must render with no network/modules), ships bilingual-static content, and hardcodes
+  `<html lang="en" dir="ltr">`. It does not (and should not) respond to the `?lang=ar` runtime boot.
+  This is a deliberate exclusion, not a masked defect.
+- **Country/city pages** — none exist (removed in the 2026-07-04 IA reset), so there is no template
+  family to sample.
+
+## Commands
+
+```bash
+npm run build                                   # produce dist/
+python3 -m http.server 8080 --directory dist &  # serve (CI serves dist on :8080)
+npx playwright test --config=playwright.config.js --project=chromium \
+  tests/e2e/rtl-mobile-public-surface-coverage.spec.js
+```
+
+Runtime: ~8s single-run (18 tests), chromium. Runs automatically in the existing CI
+`Playwright smoke` job; no separate CI matrix added.

--- a/tests/e2e/rtl-mobile-public-surface-coverage.spec.js
+++ b/tests/e2e/rtl-mobile-public-surface-coverage.spec.js
@@ -1,0 +1,211 @@
+const { test, expect } = require('@playwright/test');
+
+// Arabic / RTL mobile regression coverage for the PUBLIC page families NOT covered
+// by tests/e2e/rtl-mobile-overflow.spec.js (which locks the six core surfaces:
+// home, tracker, calculator, shops, methodology, compare).
+//
+// Together the two specs make "RTL layout integrity at mobile width" a durable CI
+// invariant across the whole public product. AGENTS.md: "RTL layouts must work at
+// 360px minimum. Every layout change requires RTL spot-check."
+//
+// Each surface is loaded via its Arabic first-load path (`?lang=ar` — the exact URL
+// shape the language switcher and hreflang alternates link to) and asserted for:
+//   1. settled RTL   (documentElement dir=rtl, lang=ar)
+//   2. shared shell mounted (nav + <main>)
+//   3. NO document-level horizontal overflow (robust detector below)
+//   4. RTL-context a11y smoke (one <main>, one <h1>, no unnamed <button>)
+//   5. no uncaught page error
+//
+// EXCLUDED — offline.html: it is the service-worker offline fallback, a static page
+// with NO ES-module shell boot (it must render with no network / no modules). It ships
+// bilingual-static content and hardcodes `<html lang="en" dir="ltr">`, so it does not
+// (and should not) respond to the `?lang=ar` runtime boot. Excluding it is intentional,
+// not a masked defect. Country/city pages are also absent (removed in the 2026-07-04 IA
+// reset), so there is no template family to sample.
+
+const MOBILE = { width: 390, height: 844 };
+const NARROW = { width: 320, height: 844 };
+
+// Widths: 390 broadly; 320 additionally for the data/interaction-dense surfaces most
+// likely to overflow (tables/cards, charts, maps, filter bars, dense indexes).
+const AR_SURFACES = [
+  { name: 'learn-hub', path: '/learn.html', widths: [MOBILE] },
+  { name: 'glossary', path: '/glossary.html', widths: [MOBILE, NARROW] },
+  { name: 'market', path: '/market.html', widths: [MOBILE, NARROW] },
+  { name: 'heatmap', path: '/heatmap.html', widths: [MOBILE, NARROW] },
+  { name: 'portfolio', path: '/portfolio.html', widths: [MOBILE, NARROW] },
+  { name: 'dubai-landing', path: '/dubai-gold-price.html', widths: [MOBILE, NARROW] },
+  { name: 'privacy', path: '/privacy.html', widths: [MOBILE] },
+  { name: 'terms', path: '/terms.html', widths: [MOBILE] },
+  { name: 'not-found', path: '/404.html', widths: [MOBILE] },
+];
+
+// Robust horizontal-overflow detector. A bare scrollWidth check reports THAT the page
+// overflows; this also reports WHICH element causes it, while deliberately ignoring
+// legitimate horizontal scroll containers (overflow-x: auto/scroll — e.g. responsive
+// tables, carousels, code blocks) and fixed-position chrome. Runs in-page.
+async function detectOverflow(page) {
+  return page.evaluate(() => {
+    const de = document.documentElement;
+    const vw = window.innerWidth;
+    const docOverflow = de.scrollWidth - vw;
+    const offenders = [];
+    if (docOverflow > 1) {
+      for (const el of document.body.querySelectorAll('*')) {
+        const r = el.getBoundingClientRect();
+        if (r.width === 0 || r.height === 0) continue;
+        const s = getComputedStyle(el);
+        if (s.visibility === 'hidden' || s.display === 'none' || s.opacity === '0') continue;
+        if (s.position === 'fixed') continue; // fixed chrome does not scroll the document
+        const over = Math.max(r.right - vw, -r.left); // beyond right edge (LTR) or left edge (RTL)
+        if (over <= 1) continue;
+        let anc = el.parentElement;
+        let inApprovedScroll = false;
+        while (anc && anc !== document.body) {
+          const ox = getComputedStyle(anc).overflowX;
+          if (ox === 'auto' || ox === 'scroll') {
+            inApprovedScroll = true;
+            break;
+          }
+          anc = anc.parentElement;
+        }
+        if (inApprovedScroll) continue;
+        offenders.push({
+          tag: el.tagName.toLowerCase(),
+          id: el.id || '',
+          cls: (el.className && el.className.toString ? el.className.toString() : '').slice(0, 60),
+          over: Math.round(over),
+          text: (el.textContent || '').trim().slice(0, 40),
+        });
+        if (offenders.length >= 5) break;
+      }
+    }
+    return { docOverflow, offenders };
+  });
+}
+
+async function a11ySmoke(page) {
+  return page.evaluate(() => {
+    const accessibleName = (el) =>
+      (el.textContent || '').trim() ||
+      el.getAttribute('aria-label') ||
+      el.getAttribute('aria-labelledby') ||
+      el.getAttribute('title');
+    return {
+      h1Count: document.querySelectorAll('h1').length,
+      mainCount: document.querySelectorAll('main').length,
+      buttonsUnnamed: [...document.querySelectorAll('button')].filter((b) => !accessibleName(b))
+        .length,
+    };
+  });
+}
+
+// Waits for the page's own ?lang=ar boot + shared-shell mount to settle, so assertions
+// run against the final Arabic layout rather than a pre-hydration English flash.
+async function gotoArabic(page, path) {
+  await page.goto(`${path}?lang=ar`);
+  await page.waitForFunction(
+    () =>
+      document.documentElement.getAttribute('dir') === 'rtl' &&
+      document.documentElement.lang === 'ar' &&
+      !!document.querySelector('main') &&
+      !!document.querySelector('.site-nav'),
+    undefined,
+    { timeout: 15000 }
+  );
+}
+
+test.describe('Arabic / RTL mobile public-surface coverage', () => {
+  for (const surface of AR_SURFACES) {
+    for (const vp of surface.widths) {
+      test(`${surface.name} @${vp.width}px: RTL, overflow-free, a11y-clean`, async ({ page }) => {
+        await page.setViewportSize(vp);
+        const pageErrors = [];
+        page.on('pageerror', (e) => pageErrors.push(String(e)));
+
+        await gotoArabic(page, surface.path);
+        await expect(page.locator('main')).toBeVisible();
+
+        const dir = await page.evaluate(() => document.documentElement.getAttribute('dir'));
+        const lang = await page.evaluate(() => document.documentElement.lang);
+        expect(dir, `${surface.name} must be RTL`).toBe('rtl');
+        expect(lang, `${surface.name} must be lang=ar`).toBe('ar');
+
+        const { docOverflow, offenders } = await detectOverflow(page);
+        expect(
+          offenders,
+          `${surface.name} @${vp.width}px has RTL overflow (docOverflow=${docOverflow}px): ` +
+            JSON.stringify(offenders)
+        ).toEqual([]);
+        expect(docOverflow, `${surface.name} @${vp.width}px document overflow`).toBeLessThanOrEqual(
+          1
+        );
+
+        const a = await a11ySmoke(page);
+        expect(a.mainCount, `${surface.name} exactly one <main>`).toBe(1);
+        expect(a.h1Count, `${surface.name} exactly one <h1>`).toBe(1);
+        expect(a.buttonsUnnamed, `${surface.name} unnamed <button> count`).toBe(0);
+
+        expect(pageErrors, `${surface.name} uncaught page errors`).toEqual([]);
+      });
+    }
+  }
+
+  // Global search overlay is part of the shared shell — verify it in Arabic at mobile
+  // width once (representative page). Covers focus management, Arabic input, results,
+  // Escape-to-close, focus return, and no overflow while open.
+  test('global search overlay works in Arabic on mobile', async ({ page }) => {
+    await page.setViewportSize(MOBILE);
+    await gotoArabic(page, '/market.html');
+
+    const trigger = page.locator('#nav-search-btn');
+    const overlay = page.locator('#nav-search-overlay');
+    const input = page.locator('#nav-search-input');
+
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+    await expect(overlay).toBeVisible();
+    await expect(input).toBeFocused();
+
+    await input.fill('ذهب'); // "gold" in Arabic
+    // Either results or a valid empty-state message must render (never a silent blank).
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          () =>
+            document.querySelectorAll('.nav-search-result, [id^="nav-search-result"]').length > 0 ||
+            document.querySelector('#nav-search-message')?.offsetParent != null
+        )
+      )
+      .toBe(true);
+
+    const { docOverflow } = await detectOverflow(page);
+    expect(docOverflow, 'no overflow while search overlay open').toBeLessThanOrEqual(1);
+
+    await page.keyboard.press('Escape');
+    await expect(overlay).toBeHidden();
+    await expect(trigger).toBeFocused();
+  });
+
+  // Mobile navigation drawer must open/close correctly in RTL without stuck scroll lock.
+  test('mobile nav drawer opens and closes in Arabic (RTL)', async ({ page }) => {
+    await page.setViewportSize(MOBILE);
+    await gotoArabic(page, '/glossary.html');
+
+    const burger = page.locator('#nav-hamburger');
+    const drawer = page.locator('#nav-drawer');
+    await expect(burger).toBeVisible();
+    await expect(burger).toHaveAttribute('aria-expanded', 'false');
+
+    await burger.click();
+    await expect(burger).toHaveAttribute('aria-expanded', 'true');
+    await expect(drawer).toHaveAttribute('aria-hidden', 'false');
+    const openOverflow = await detectOverflow(page);
+    expect(openOverflow.docOverflow, 'no overflow with RTL drawer open').toBeLessThanOrEqual(1);
+
+    await page.keyboard.press('Escape');
+    await expect(burger).toHaveAttribute('aria-expanded', 'false');
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true');
+    await expect.poll(async () => page.evaluate(() => document.body.style.overflow)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Extends Arabic/RTL mobile-layout regression protection from the six core surfaces (locked by `rtl-mobile-overflow.spec.js`, PR #662) to the **remaining public page families**, making RTL/mobile integrity a durable CI invariant sitewide. **Test + docs only — no product runtime code changed.**

- `tests/e2e/rtl-mobile-public-surface-coverage.spec.js` — data-driven coverage for: learn hub, glossary, market, heatmap, portfolio, dubai landing, privacy, terms, 404 — each via `?lang=ar`. Plus a global-search-overlay test and an RTL mobile-nav-drawer test.
- `docs/testing/rtl-mobile-coverage.md` — documents the two-spec split, width matrix, assertions, detector, and exclusions.

## Route families covered & sampling strategy

Route inventory came from the actual Vite HTML entries (root `*.html`), not guessed names. Country/city pages **do not exist** (removed in the 2026-07-04 IA reset), so there is no template family to sample; Learn guides render within `learn.html` (no separate routes); shop detail is in-page. So every remaining standalone public page is covered directly.

| Surface | Route | 390px | 320px |
| --- | --- | :-: | :-: |
| Learn hub | `/learn.html` | ✅ | |
| Glossary | `/glossary.html` | ✅ | ✅ |
| Market | `/market.html` | ✅ | ✅ |
| Heatmap | `/heatmap.html` | ✅ | ✅ |
| Portfolio | `/portfolio.html` | ✅ | ✅ |
| Dubai landing | `/dubai-gold-price.html` | ✅ | ✅ |
| Privacy | `/privacy.html` | ✅ | |
| Terms | `/terms.html` | ✅ | |
| 404 | `/404.html` | ✅ | |

**Width matrix:** 390px broadly; 320px added for data/interaction-dense surfaces (tables/cards, charts, maps, dense indexes) most likely to overflow.

## Assertions

Per surface × width: settled RTL (`dir=rtl`, `lang=ar`) · shared shell mounted (`.site-nav` + `<main>`) · **no document-level horizontal overflow** (robust detector) · RTL-context a11y smoke (one `<main>`, one `<h1>`, zero unnamed `<button>`) · no uncaught page error.

Shared-shell interaction (Arabic, 390px): **search overlay** (opens, focus→input, Arabic query "ذهب" → results/valid empty-state, no overflow, `Escape` closes + focus returns) and **mobile nav drawer** (aria state toggles, no overflow open, `Escape` closes + releases scroll lock).

## Robust overflow detector

Beyond `scrollWidth`, it names the offending element (tag/id/class/overshoot) and **ignores legitimate horizontal scroll containers** (`overflow-x: auto|scroll` — responsive tables, carousels, code blocks) and fixed chrome, so intentional scroll areas aren't reported as page-level failures.

## Tables / charts

Market and Dubai use responsive **card** layouts (0 `<table>` elements), so no table-scroll assertion applies; the overflow detector covers them. Chart-bearing pages (learn, portfolio, heatmap map) are asserted overflow-free with charts rendered.

## Accessibility

Folded RTL-context a11y smoke into each page test (complements the English `a11y-baseline.spec.js`). All 9 pages verified `h1=1, main=1, unnamedButtons=0, dupIds=0, imgsNoAlt=0` in Arabic.

## Known exclusions (narrow, justified)

- **`offline.html`** — static service-worker offline fallback; no ES-module shell boot, bilingual-static, hardcodes `lang=en/dir=ltr`; cannot/should not honor `?lang=ar`. Deliberate exclusion, not a masked defect.
- Country/city pages — none exist (IA reset).

## Defects

None found — every covered surface was pre-verified 0px document overflow with correct `dir`/`lang` and clean a11y before assertions were written. No production change was needed or made.

## CI impact

Runs in the existing **"Playwright smoke"** job (matches `**/*.spec.js`, `--project=chromium` vs built `dist/`). No new/duplicated browser matrix. ~8s single-run (18 page tests + 2 interaction tests).

## Verification (worktree from `origin/main`)

- New spec via Playwright runner (chromium vs built `dist/`): **32/32 pass across `--repeat-each=2`** (no flakiness; no arbitrary sleeps — waits on real state).
- `npm run lint` ✅ · `npm run validate` ✅ · `npm test` → **1593/1593, 0 fail** ✅ · `npm run build` ✅. New spec + doc are prettier-clean.
- Fonts are Vite-emitted into `dist/assets` (incl. `cairo-arabic`), so CI renders real fonts — no font-fallback mismatch.

## Risk

- Test + documentation only; no product runtime code changed.
- The "Validate & Build" check will show **pre-existing prettier debt (6 files) red until PR #664 (formatting-only) merges** — not introduced here.
- The campaign state doc / skill-routing matrix live on PR #662's branch (not yet on `main`); their coverage note should be reconciled after both merge.

## Gold provider bakeoff checklist

N/A — no gold provider adapters, bakeoff scripts, X duplicate-post guard, or production gold-price workflows touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation only; no application runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **Playwright regression coverage** so Arabic (`?lang=ar`) mobile RTL layout is enforced on public pages beyond the six core surfaces already covered by `rtl-mobile-overflow.spec.js`.
> 
> **`tests/e2e/rtl-mobile-public-surface-coverage.spec.js`** drives a data-driven `AR_SURFACES` matrix (learn, glossary, market, heatmap, portfolio, Dubai landing, privacy, terms, 404) at 390px and, for dense UIs, 320px. Each case waits for settled RTL boot, then checks shell mount, document-level overflow (with an in-page detector that ignores approved `overflow-x` scroll regions and fixed chrome), light a11y smoke, and no page errors. Two extra tests cover the **global search overlay** (Arabic query, focus, Escape) and the **RTL mobile nav drawer** (ARIA + scroll lock).
> 
> **`docs/testing/rtl-mobile-coverage.md`** documents how the two RTL specs split responsibility, the width matrix, assertions, detector behavior, and intentional exclusions (`offline.html`, absent country/city routes). New tests ride the existing Playwright smoke job; no CI matrix change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b93df79fe0877247a122f3960a4cf21e70cd5775. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->