### PR TITLE
docs(adr): codify foundational design & architecture decisions

### DIFF
--- a/docs/adr/0001-design-token-architecture.md
+++ b/docs/adr/0001-design-token-architecture.md
@@ -1,0 +1,62 @@
+# ADR-0001 — Canonical design-token architecture
+
+**Status:** Accepted (codifies shipped architecture) · **Date:** 2026-07-11
+
+## Context
+
+A premium, cohesive multi-page product needs one source of truth for colour, spacing, type, radius,
+shadow, and motion so surfaces don't drift into per-page styling. GTL is a static multi-page site
+(vanilla ES modules + Vite) with many root HTML pages sharing a design language.
+
+## Decision
+
+Design tokens are CSS custom properties defined in two coordinated `:root` layers, imported once via
+the CSS barrel:
+
+- `styles/partials/tokens.css` — colour system (surfaces, text, brand gold, semantic/status
+  colours), the dark-theme overrides, and movement colours. WCAG contrast pairings are annotated
+  inline.
+- `styles/design-system.css` — the `--gtl-*` primitive scale: fluid type (clamp), 4px-based spacing
+  (`--gtl-1..10`), radii (`--gtl-r-*`), elevation, and motion tokens.
+
+`styles/global.css` is the single barrel that `@import`s the partials in a fixed order (fonts →
+price-display → shell → skeleton → tokens → base → layout → components → utilities). Pages consume
+tokens; they do not hard-code hex/px for themable values. `docs/DESIGN_TOKENS.md` is the
+human-readable reference.
+
+## Alternatives considered
+
+- **Inline `<style>` per page** — rejected: guarantees drift; the big pages are kept free of inline
+  `<style>`.
+- **A CSS framework (Tailwind/Bootstrap)** — rejected: heavier, less control over a restrained
+  financial aesthetic, and a large migration for a working system.
+- **Single mega token file** — rejected in favour of a colour/theme file plus a primitives file for
+  separation of concerns.
+
+## Consequences
+
+- Theming (incl. dark mode, ADR-0003) and RTL adjustments happen centrally.
+- New components must consume tokens; raw hex/px for themable properties is a review smell.
+- Two token files mean contributors must know both layers (mitigated by `docs/DESIGN_TOKENS.md`).
+
+## Invariants
+
+- Themable colour/space/radius/shadow/motion values come from tokens, not inline literals.
+- `styles/global.css` remains the ordered import barrel.
+
+## Relevant files
+
+`styles/partials/tokens.css`, `styles/design-system.css`, `styles/global.css`, `styles/partials/*`,
+`docs/DESIGN_TOKENS.md`.
+
+## Verification mechanism
+
+`npm run validate` includes a basic-a11y gate that checks token contrast pairs (gold/body, dark-mode
+status colours) meet WCAG AA and that `global.css` imports the core partials. Visual review covers
+cohesion.
+
+## Supersession policy
+
+If the token architecture changes (e.g. tokens consolidated, a build step generates
+`DESIGN_TOKENS.md`, or a framework is adopted), supersede this ADR with a new one and link it here.
+Code is the source of truth; correct this ADR if it drifts.

--- a/docs/adr/0002-typography-bilingual-fonts.md
+++ b/docs/adr/0002-typography-bilingual-fonts.md
@@ -1,0 +1,59 @@
+# ADR-0002 — Typography & bilingual (EN/AR) font strategy
+
+**Status:** Accepted (codifies shipped architecture) · **Date:** 2026-07-11
+
+## Context
+
+GTL is bilingual English/Arabic with heavy numeric/tabular content (prices, karat tables). It needs:
+a clean Latin UI face with tabular figures, an editorial display face for headings, and a
+high-quality Arabic face for RTL — without shipping many heavy families or leaking user data to a
+font CDN.
+
+## Decision
+
+Self-host a three-face system (no Google Fonts; a `strip-google-fonts` step enforces this), declared
+in `styles/partials/fonts.css`:
+
+- **Source Sans 3** — Latin UI text and tabular figures (data/tables).
+- **Playfair Display** — Latin editorial display (headings only).
+- **Cairo** — Arabic text, and the display face in RTL (Playfair has no Arabic coverage), so Arabic
+  headings use Cairo rather than a mismatched fallback.
+
+Critical subsets are `<link rel="preload">`ed per page; fonts are subset and emitted by Vite into
+hashed `/assets/*.woff2`. The type scale lives in `design-system.css` (ADR-0001).
+
+## Alternatives considered
+
+- **Google Fonts CDN** — rejected: third-party request, privacy, and a runtime dependency;
+  self-hosting is faster and private.
+- **System font stack only** — rejected: loses the premium editorial identity and consistent Arabic
+  rendering.
+- **One family for both scripts** — rejected: no single high-quality family served EN display +
+  Arabic well; Cairo covers Arabic + display-in-RTL, Playfair covers Latin display.
+
+## Consequences
+
+- RTL swaps the display face to Cairo; headings stay coherent across languages.
+- Font files are versioned assets; adding weights increases payload (kept minimal).
+- Because fonts are Vite-emitted to `/assets`, they render in CI e2e too (no fallback-metric
+  surprises).
+
+## Invariants
+
+- No external font CDN. Latin UI uses tabular figures for prices/tables. Arabic uses Cairo.
+- EN/AR must not diverge in meaning or visual weight (see `AGENTS.md` bilingual policy).
+
+## Relevant files
+
+`styles/partials/fonts.css`, `styles/design-system.css` (type scale), the self-host/strip scripts
+under `scripts/node/`, `assets/*.woff2`.
+
+## Verification mechanism
+
+Build emits hashed woff2 into `dist/assets`; RTL rendering (incl. Arabic display face) is exercised
+by the RTL mobile specs (ADR-0007). `npm run build` + visual review.
+
+## Supersession policy
+
+If a face is added/replaced or the self-host approach changes, supersede this ADR. Code/`fonts.css`
+is authoritative.

--- a/docs/adr/0003-theme-dark-mode-preinit.md
+++ b/docs/adr/0003-theme-dark-mode-preinit.md
@@ -1,0 +1,55 @@
+# ADR-0003 — Theme & dark-mode with FOUC pre-init
+
+**Status:** Accepted (codifies shipped architecture) · **Date:** 2026-07-11
+
+## Context
+
+A premium product needs a cohesive dark mode (designed, not inverted), a user toggle that persists,
+respect for the OS preference, and — critically — **no flash of the wrong theme** (FOUC) on first
+paint. On a static multi-page site every navigation is a fresh document load, which makes FOUC
+especially visible.
+
+## Decision
+
+- Theme is expressed by a `data-theme` attribute on `<html>` (with a `data-theme-mode` for
+  auto/light/dark intent). Dark values are a dedicated block in `styles/partials/tokens.css` plus a
+  `@media (prefers-color-scheme: dark)` mirror, and `color-scheme` is set so native UA controls
+  match.
+- The user preference persists in `localStorage` (`user_prefs.theme` = auto | light | dark). The
+  toggle lives in the shared nav (`src/components/nav.js`).
+- A **render-blocking inline pre-init script** is injected into every page `<head>` at build time by
+  `scripts/node/inject-theme-preinit.js` (marker `gtl-theme-preinit`). It sets `data-theme` before
+  first paint, mirroring the nav's resolution logic, eliminating FOUC. Its presence is CI-checked.
+
+## Alternatives considered
+
+- **CSS `prefers-color-scheme` only** — rejected: no user override/persistence.
+- **JS theme applied by the module bundle** — rejected: modules load after first paint → FOUC.
+- **Invert light colours for dark** — rejected: muddy, poor chart/table contrast; dark is authored.
+
+## Consequences
+
+- The pre-init script is duplicated into each page at build; it must stay in sync with the nav's
+  resolution logic (both are simple and centrally maintained; CI enforces presence).
+- Dark-mode colours are maintained alongside light in the token file (ADR-0001).
+
+## Invariants
+
+- No flash of incorrect theme. `data-theme` is set before first paint.
+- Dark mode meets WCAG AA for text/status/chart contrast (checked in the a11y gate).
+- Preference persists and honours system preference in `auto`.
+
+## Relevant files
+
+`scripts/node/inject-theme-preinit.js` (+ `--check`), `styles/partials/tokens.css` (dark block +
+media mirror), `src/components/nav.js` (toggle + resolution), `localStorage` key `user_prefs.theme`.
+
+## Verification mechanism
+
+`npm run validate` runs `inject-theme-preinit --check` (fails if a page lacks the pre-init) and the
+a11y gate (dark-mode contrast). Theme toggle is covered by `tests/e2e/theme-toggle.spec.js`.
+
+## Supersession policy
+
+If theme resolution moves (e.g. to a service worker or a framework), or the pre-init mechanism
+changes, supersede this ADR. The scripts + nav are authoritative.

--- a/docs/adr/0004-shared-shell-injection.md
+++ b/docs/adr/0004-shared-shell-injection.md
@@ -1,0 +1,60 @@
+# ADR-0004 — Shared shell (nav/footer) injection
+
+**Status:** Accepted (codifies shipped architecture) · **Date:** 2026-07-11
+
+## Context
+
+Sixteen+ root HTML pages must share one header/nav, mobile drawer, global search, language + theme
+toggles, ticker, and footer. Duplicating that markup into every `.html` file guarantees drift and
+makes shell changes a multi-file chore.
+
+## Decision
+
+The shell is **JS-injected at runtime**, not hard-coded per page. Root HTML pages contain **no**
+`<nav>`/`<header>`/`<footer>` markup; each page's module entry calls `mountSharedShell()` in
+`src/components/site-shell.js`, which assembles:
+
+- `src/components/nav.js` — desktop nav + mobile drawer + global search + language/theme toggles
+- `src/components/footer.js`, `ticker.js`, `spotBar.js`, with data from `nav-data.js`
+- `src/search/searchEngine.js` + `searchIndex.js` behind the search UI
+
+A guard, `scripts/node/check-shell-guard.js`, fails CI if a canonical page hard-codes shell markup
+(e.g. a literal `site-nav`), keeping the single-source contract enforced.
+
+## Alternatives considered
+
+- **Duplicated static shell markup per page** — rejected: drift, N-file edits, and the reason this
+  decision exists.
+- **Server-side includes / templating build step that bakes shell into HTML** — viable but the
+  project is a client-hydrated MPA; runtime injection keeps one code path and enables the
+  theme/lang/search behaviour that is JS-driven anyway.
+- **SPA/framework** — rejected: `AGENTS.md` forbids SPA migration without explicit owner request.
+
+## Consequences
+
+- The shell is a shared, high-collision surface; changes to `nav.js`/`site-shell.js` affect every
+  page and must stay single-owner (see `AGENTS.md` / revamp execution rules).
+- Shell content appears after hydration; tests wait for `.site-nav` + `<main>` before asserting (see
+  ADR-0007). Static HTML has no nav for no-JS crawlers — SEO relies on the content + injected
+  metadata/schema, not shell links.
+
+## Invariants
+
+- Root pages do not hard-code shell markup; `check-shell-guard` stays green.
+- Nav/search/drawer keep keyboard access, focus handling, and RTL behaviour.
+
+## Relevant files
+
+`src/components/site-shell.js`, `nav.js`, `footer.js`, `ticker.js`, `spotBar.js`, `nav-data.js`,
+`src/search/*`, `scripts/node/check-shell-guard.js`.
+
+## Verification mechanism
+
+`npm run validate` runs `check-shell-guard.js`. Shell behaviour is covered by
+`tests/e2e/nav-smoke.spec.js`, `mobile-smoke.spec.js`, and the RTL specs (ADR-0007), including the
+search overlay and mobile drawer in Arabic.
+
+## Supersession policy
+
+If the shell moves to a build-time include or a framework, supersede this ADR. `site-shell.js` + the
+guard are authoritative.

--- a/docs/adr/0005-spot-resolver-tracker-engine.md
+++ b/docs/adr/0005-spot-resolver-tracker-engine.md
@@ -1,0 +1,68 @@
+# ADR-0005 — Canonical spot resolver ⟂ tracker live engine
+
+**Status:** Accepted (codifies shipped architecture) · **Date:** 2026-07-11
+
+## Context
+
+Every visible price must be traceable to one calculation path and honest freshness (see `AGENTS.md`
+non-negotiables). Most surfaces need a simple, consistent read of the current spot-derived reference
+price. The flagship Tracker additionally needs a stronger, multi-tier live-polling engine. These are
+different needs and must not be conflated into duplicate pricing paths.
+
+## Decision
+
+Two clearly separated layers, sharing pure math but not merged:
+
+- **Canonical spot resolver** — `src/lib/spot-resolver.js` (`getCanonicalSpot`, `deriveFromSpot`,
+  `karatPerGram`) reads `/data/gold_price.json` via `src/lib/api.js` (cache-bust, retry,
+  localStorage fallback, throw-on-empty). It is the single read point for non-Tracker surfaces
+  (home, calculator, compare, portfolio, market, dubai, shops, …). Pure conversions live in
+  `src/lib/price-calculator.js`; the metals layer in `src/lib/metal-pricing.js`.
+- **Tracker live engine** — `src/lib/realtime-pricing-engine.js` (`createRealtimePricingEngine`)
+  with `realtime-config.js`, `realtime-poll-interval.js`, and `provider-health.js`
+  (live/static/fallback poll tiers, backoff), wired in `src/pages/tracker-pro.js`. It is
+  intentionally stronger and is **not** weakened, duplicated, or replaced to make other surfaces
+  look consistent.
+
+Shared invariants come from `src/config/constants.js` (**AED peg 3.6725**, troy **31.1034768 g**)
+and karat factors from `src/config/karats.js` — never inlined elsewhere.
+
+## Alternatives considered
+
+- **One engine for everything** — rejected: either over-serves simple pages (cost/complexity) or
+  weakens the Tracker.
+- **Per-page ad-hoc pricing** — rejected: creates untraceable numbers and freshness drift; forbidden
+  by the charter.
+- **Move the peg/karat constants inline** — rejected: they are single-source, owner-gated
+  invariants.
+
+## Consequences
+
+- Non-Tracker surfaces converge on `getCanonicalSpot`; a second independent pricing path is a review
+  block.
+- The Tracker keeps its own engine; changes there are isolated from the canonical resolver.
+- Constants are owner-gated (`AGENTS.md`): the peg/troy/karat/FX formulas need owner approval.
+
+## Invariants
+
+- AED peg **3.6725**; troy **31.1034768 g**; karat factors from `karats.js`. Reference price ≠
+  retail quote. Local currency = USD/gram × current FX (not USD→AED→local). Every number is
+  traceable to source + timestamp + freshness state.
+
+## Relevant files
+
+`src/lib/spot-resolver.js`, `price-calculator.js`, `metal-pricing.js`, `api.js`,
+`src/lib/realtime-pricing-engine.js` (+ `realtime-config.js`, `realtime-poll-interval.js`,
+`provider-health.js`), `src/pages/tracker-pro.js`, `src/config/constants.js`,
+`src/config/karats.js`, `data/gold_price.json`.
+
+## Verification mechanism
+
+Unit tests under `tests/` (pricing/karat/FX; a LOCKED assertion pins a known 24K value), plus
+`tests/e2e/calculator-accuracy.spec.js` and `freshness-labels.spec.js`. `docs/price-flow-map.md`
+documents the full flow.
+
+## Supersession policy
+
+Provider strategy, caching, or a resolver/engine change must be an owner-approved decision and a new
+ADR — not an inline edit. Constants and the two modules are authoritative.

--- a/docs/adr/0006-freshness-status-vocabulary.md
+++ b/docs/adr/0006-freshness-status-vocabulary.md
@@ -1,0 +1,62 @@
+# ADR-0006 — Data freshness & status vocabulary
+
+**Status:** Accepted (codifies shipped architecture) · **Date:** 2026-07-11
+
+## Context
+
+Trust is the product. Users must always know whether a number is live, recently updated, cached,
+delayed, stale, or from a failed provider — never be shown cached data labelled "live". The charter
+(`AGENTS.md`) makes freshness labels non-negotiable and defines exact terms. This needs one shared
+vocabulary and one set of components, not per-page ad-hoc wording.
+
+## Decision
+
+A single freshness system evaluates state and renders it consistently:
+
+- **Policy/evaluation** — `src/lib/freshness-policy.js` (`evaluateFreshnessState`, budgets) and
+  `src/lib/live-status.js` (age thresholds, market open/closed).
+- **Shared UI** — `src/lib/data-status-banner.js` (offline/error banner),
+  `src/components/FreshnessBadge.js`, `MarketStatusPanel.js`, `QuoteMetaPanel.js`.
+- **Contract** — `docs/freshness-contract.md` plus the terminology in `AGENTS.md`: `live`,
+  `updated`, `cached`, `delayed`, and also `estimated`, `fallback`, `stale`, `unavailable`,
+  `closed`.
+
+Every price surface shows source, timestamp, and state. Status is never communicated by colour alone
+(icon + text + timestamp + accessible label). Degraded states render honestly (e.g. "Live feed
+unavailable — showing last cached price" when the provider is unreachable).
+
+## Alternatives considered
+
+- **Per-page freshness copy** — rejected: drift and the risk of mislabelling cached as live.
+- **Colour-only status** — rejected: fails accessibility and the charter's non-colour requirement.
+- **Hiding staleness for a "cleaner" look** — explicitly forbidden by the charter.
+
+## Consequences
+
+- New price surfaces reuse the shared freshness components + vocabulary; new wording is a review
+  smell.
+- Freshness labels/methodology links/reference-vs-retail disclaimers must remain visible; removing
+  them "to look cleaner" is a block-level violation.
+
+## Invariants
+
+- If data is not truly live, it is not labelled live. Cached/fallback/estimated/delayed values show
+  source + timestamp + state. Non-colour status indicators. EN/AR parity of freshness meaning.
+
+## Relevant files
+
+`src/lib/freshness-policy.js`, `src/lib/live-status.js`, `src/lib/data-status-banner.js`,
+`src/components/FreshnessBadge.js`, `MarketStatusPanel.js`, `QuoteMetaPanel.js`,
+`docs/freshness-contract.md`, terminology in `AGENTS.md`.
+
+## Verification mechanism
+
+`npm run validate` includes freshness-metadata / reference-language sweeps; `tests/` cover freshness
+policy; `tests/e2e/freshness-labels.spec.js` asserts labels in the live DOM. Offline/degraded state
+observed in browser renders.
+
+## Supersession policy
+
+If the vocabulary or components change (e.g. new state, a provider with documented lag), update
+`docs/freshness-contract.md` + `AGENTS.md` and supersede this ADR. The policy modules are
+authoritative.

--- a/docs/adr/0007-rtl-mobile-regression-strategy.md
+++ b/docs/adr/0007-rtl-mobile-regression-strategy.md
@@ -1,0 +1,66 @@
+# ADR-0007 — RTL & mobile regression strategy
+
+**Status:** Accepted (codifies shipped architecture) · **Date:** 2026-07-11
+
+## Context
+
+GTL is bilingual with a first-class Arabic/RTL experience. `AGENTS.md` requires RTL to work at
+≥360px and every layout change to get an RTL spot-check. Historically the mobile no-overflow guard
+(`tests/e2e/mobile-smoke.spec.js`) ran mostly in English/LTR, so an RTL-only bidi overflow could
+regress silently on the highest-traffic Arabic pages.
+
+## Decision
+
+RTL/mobile layout integrity is a **CI invariant**, enforced by two complementary Playwright specs
+run in the existing `Playwright smoke` job (`--project=chromium` vs the built `dist/`):
+
+- `tests/e2e/rtl-mobile-overflow.spec.js` — the six core surfaces (home, tracker, calculator, shops,
+  methodology, compare).
+- `tests/e2e/rtl-mobile-public-surface-coverage.spec.js` — the remaining public families (learn,
+  glossary, market, heatmap, portfolio, dubai landing, privacy, terms, 404) plus the global search
+  overlay and the mobile nav drawer, in Arabic.
+
+Each surface loads via its Arabic first-load path (`?lang=ar`) and asserts: settled RTL
+(`dir=rtl`/`lang=ar`), shell mounted, **no document-level horizontal overflow** (a robust detector
+that names the offending element and ignores approved `overflow-x` scroll containers + fixed
+chrome), RTL-context a11y smoke (one `<main>`, one `<h1>`, no unnamed `<button>`), and no uncaught
+page error. Widths: 390px broadly, 320px for data/interaction-dense surfaces.
+`docs/testing/rtl-mobile-coverage.md` documents the matrix and exclusions.
+
+## Alternatives considered
+
+- **Full pixel visual-regression (screenshots)** — rejected for now: high maintenance/flakiness
+  without dedicated infra; targeted structural assertions catch layout breakage reliably.
+- **One giant spec** — rejected: split by scope (core vs remaining) keeps each reviewable and
+  non-overlapping.
+- **Naive `scrollWidth` only** — insufficient: it can't distinguish an intentional table/carousel
+  scroll container from a real page overflow, hence the robust detector.
+
+## Consequences
+
+- Adding a public page family means adding a row to the `AR_SURFACES` matrix.
+- `offline.html` is intentionally excluded (static SW fallback, no shell boot, bilingual-static,
+  hardcoded `lang=en/dir=ltr`); country/city pages don't exist (2026-07-04 IA reset).
+- Fonts are Vite-emitted to `dist/assets`, so CI renders real fonts (no fallback-metric drift).
+
+## Invariants
+
+- Every standard public surface stays overflow-free with correct `dir=rtl`/`lang=ar` at mobile width
+  in Arabic. Exclusions are narrow and documented.
+
+## Relevant files
+
+`tests/e2e/rtl-mobile-overflow.spec.js`, `tests/e2e/rtl-mobile-public-surface-coverage.spec.js`,
+`tests/e2e/mobile-smoke.spec.js`, `docs/testing/rtl-mobile-coverage.md`, `playwright.config.js`,
+`.github/workflows/ci.yml` (Playwright smoke job).
+
+## Verification mechanism
+
+The specs run in CI on every PR/main push; locally via `npx playwright test --project=chromium`
+against served `dist/`. Verified 6/6 (core) and 18/18 (+2 interaction) green, non-flaky under
+`--repeat-each=2`.
+
+## Supersession policy
+
+If a visual-regression system is adopted, or the coverage/matrix strategy changes materially,
+supersede this ADR. The specs + `rtl-mobile-coverage.md` are authoritative.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,37 @@
+# Architecture Decision Records (ADR)
+
+This directory records the **foundational, already-implemented** architecture decisions of Gold
+Ticker Live so future contributors and agents do not re-litigate settled choices. Each ADR describes
+the system **as it exists today** (verified against the code), not aspirational design.
+
+> These ADRs are descriptive/codifying, not proposals. They were written after the fact to capture
+> decisions that are already shipped and gated by CI. Do not change production code to "match" an
+> ADR — if code and ADR disagree, the code is the source of truth and the ADR must be corrected (see
+> each ADR's supersession policy).
+
+Related, non-duplicating docs:
+
+- Verified current state:
+  [`../agent/GOLDTICKERLIVE_REVAMP_STATE.md`](../agent/GOLDTICKERLIVE_REVAMP_STATE.md)
+- Canonical charter: [`../../AGENTS.md`](../../AGENTS.md)
+- Design tokens reference: [`../DESIGN_TOKENS.md`](../DESIGN_TOKENS.md)
+- Freshness contract: [`../freshness-contract.md`](../freshness-contract.md)
+- Ad-hoc decision briefs: [`../decisions/`](../decisions/) (phase-specific notes; this ADR series is
+  the durable, numbered record of the foundational architecture)
+
+## Index
+
+| ADR                                                  | Title                                        | Status   |
+| ---------------------------------------------------- | -------------------------------------------- | -------- |
+| [ADR-0001](./0001-design-token-architecture.md)      | Canonical design-token architecture          | Accepted |
+| [ADR-0002](./0002-typography-bilingual-fonts.md)     | Typography & bilingual (EN/AR) font strategy | Accepted |
+| [ADR-0003](./0003-theme-dark-mode-preinit.md)        | Theme & dark-mode with FOUC pre-init         | Accepted |
+| [ADR-0004](./0004-shared-shell-injection.md)         | Shared shell (nav/footer) injection          | Accepted |
+| [ADR-0005](./0005-spot-resolver-tracker-engine.md)   | Canonical spot resolver ⟂ tracker engine     | Accepted |
+| [ADR-0006](./0006-freshness-status-vocabulary.md)    | Data freshness & status vocabulary           | Accepted |
+| [ADR-0007](./0007-rtl-mobile-regression-strategy.md) | RTL & mobile regression strategy             | Accepted |
+
+## Format
+
+Each ADR uses: Status · Context · Decision · Alternatives considered · Consequences · Invariants ·
+Relevant files · Verification mechanism · Date · Supersession policy.


### PR DESCRIPTION
## Summary

Adds `docs/adr/` — a numbered **Architecture Decision Record** series that codifies the
**already-shipped** foundational architecture, so future contributors and agents stop re-litigating
settled choices. **Documentation only** — no production code changed, no decision reopened, no
architecture invented.

## ADRs added

| ADR | Title | Codifies |
| --- | --- | --- |
| 0001 | Canonical design-token architecture | `styles/partials/tokens.css` + `styles/design-system.css`, the `global.css` import barrel |
| 0002 | Typography & bilingual EN/AR fonts | self-hosted Source Sans 3 / Playfair Display / Cairo (`fonts.css`) |
| 0003 | Theme & dark-mode with FOUC pre-init | `data-theme` + `inject-theme-preinit.js` (CI-checked) |
| 0004 | Shared shell injection | JS-mounted nav/footer/search (`site-shell.js`) + `check-shell-guard.js` |
| 0005 | Canonical spot resolver ⟂ tracker engine | `spot-resolver.js` vs `realtime-pricing-engine.js`; peg 3.6725; spot≠retail |
| 0006 | Data freshness & status vocabulary | `freshness-policy.js`/`live-status.js` + shared badges + contract |
| 0007 | RTL & mobile regression strategy | the two Playwright specs (PRs #662 / #666) |

Each ADR uses the required structure: **Status · Context · Decision · Alternatives considered ·
Consequences · Invariants · Relevant files · Verification mechanism · Date · Supersession policy.**

## Existing architecture codified (not changed)

Every ADR describes the system **as it exists**, verified against the code and against
`docs/agent/GOLDTICKERLIVE_REVAMP_STATE.md`. The index states explicitly that **code is the source
of truth** — if code and an ADR ever disagree, the ADR is corrected, not the code. This complements
the ad-hoc `docs/decisions/` briefs with a durable, numbered record; no existing ADR convention
existed to extend.

## Documentation checks

- `npm run lint` → ✅ (markdown isn't linted; confirms no stray JS)
- All ADRs + index → ✅ prettier-clean (`prettier --check docs/adr/`)
- Docs-only: no source, tests, or build affected (sibling branch from the same base verified
  `npm test` 1593/1593, `npm run build` clean).

## Risk

- None to runtime — pure documentation.
- The "Validate & Build" check will show the same **pre-existing prettier debt (6 files) red until
  PR #664 merges** — not introduced here.

## Gold provider bakeoff checklist

N/A — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no application, test, or build logic changes.
> 
> **Overview**
> Introduces **`docs/adr/`** with a numbered ADR series and **`README.md`** index so already-shipped architecture is written down instead of re-debated in reviews.
> 
> **Seven accepted ADRs** (descriptive, not proposals) each follow the same template—context, decision, alternatives, invariants, verification, supersession—and point at real code and CI gates: **0001** design tokens (`tokens.css`, `design-system.css`, `global.css` barrel); **0002** self-hosted EN/AR fonts; **0003** `data-theme` + build-time FOUC pre-init; **0004** runtime shell via `mountSharedShell()` + shell guard; **0005** `spot-resolver.js` vs tracker `realtime-pricing-engine.js`; **0006** shared freshness policy/UI + contract vocabulary; **0007** dual Playwright RTL/mobile specs and coverage doc.
> 
> The index states **code remains source of truth**—if an ADR drifts, fix the ADR—and links `AGENTS.md`, `DESIGN_TOKENS.md`, `freshness-contract.md`, and `docs/decisions/` without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be99d1c654da37e253b8fe50657ef298fac86676. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->