### PR TITLE
feat(trust): unified "About this price" provenance control (Stage-2C pilot)

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -82,6 +82,7 @@
          design-system.css = tokens + opt-in .gtl-* only; compare-redesign.css
          loads last to win by source order. -->
     <link rel="stylesheet" href="./styles/design-system.css" />
+    <link rel="stylesheet" href="./styles/components/price-provenance.css" />
     <link rel="stylesheet" href="./styles/pages/compare-redesign.css" />
     <link rel="apple-touch-icon" href="assets/apple-touch-icon.png" />
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
@@ -168,6 +169,8 @@
             >
             <a id="compare-methodology" href="methodology.html">How prices work →</a>
           </p>
+          <!-- Unified "About this price" provenance control (Stage-2C, JS-mounted). -->
+          <div id="compare-provenance"></div>
         </div>
       </section>
 

--- a/docs/price-flow-map.md
+++ b/docs/price-flow-map.md
@@ -115,12 +115,31 @@ to the same gold-api.com / committed snapshot. The Tracker uses the realtime eng
 `setVisibility()` for background throttling and its own inline freshness overlay
 (`src/tracker/freshness.js`). Leave it untouched.
 
-## 5. Known follow-ups
+## 5. Trust/provenance layer ("About this price")
 
-- Trust/provenance ("about this price") progressive-disclosure layer is not yet a shared
-  component — freshness dots + source attribution exist per-surface (footer via
-  `data-attribution.js`); a unified compact badge + expandable basis (USD/AED, karat/weight,
-  spot-vs-retail, Methodology link) is Stage-2C.
+`src/components/priceProvenance.js` → `renderPriceProvenance({ lang, depth, updatedAt,
+hasLiveFailure, isFallback, isFresh, open })` is the shared Stage-2C control: a compact
+`<details>` whose summary is a freshness chip + "About this price", expanding to disclose
+**source** (Gold-API.com + cadence), **updated** (UTC timestamp + relative age), **basis**
+(troy-oz 31.1035, USD→AED peg 3.6725, karat purity = code/24), **spot ≠ retail**, and a
+**methodology** link. It resolves state through `getLiveFreshness` + `applyMarketClosedOverlay`
+(honest, never "Live" while closed) and is built entirely from `data-attribution.js` +
+constitutional constants — no new data path. Bilingual EN/AR (RTL), theme-aware, mobile,
+keyboard-accessible (native `<details>`, not hover-only); `gtl-`-namespaced CSS in
+`styles/components/price-provenance.css`. Styles/tests: `tests/price-provenance.test.js`.
+
+**Rollout pattern** (piloted on `compare.html`): link the component CSS after `design-system.css`;
+add an empty mount container in the page HTML; in the page controller, on each price render call
+`slot.replaceChildren(renderPriceProvenance({ lang, depth, updatedAt, hasLiveFailure }))`,
+preserving the user's open/closed state across refreshes (`open: slot.querySelector('.gtl-provenance')?.hasAttribute('open')`).
+Pilot surface = compare (lean hero, no verbose existing trust block). Next candidates: portfolio,
+heatmap, then consolidate the scattered inline trust copy on home/calculator/dubai/market into
+this one control rather than adding a second disclosure beside them.
+
+## 6. Known follow-ups
+
+- Roll `priceProvenance` out to the remaining tool surfaces (see pattern above); on
+  home/calculator/dubai it should **consolidate** existing scattered trust copy, not duplicate it.
 - `classifyFreshness` never emits `estimated`; only `evaluateFreshnessState` does. If a surface
   needs to distinguish "provider unavailable, value estimated" from "cached", it must go through
   the policy evaluator, not the snapshot's `freshness.state`.

--- a/src/components/priceProvenance.js
+++ b/src/components/priceProvenance.js
@@ -1,0 +1,194 @@
+/**
+ * components/priceProvenance.js — the shared "About this price" trust control.
+ *
+ * A COMPACT, progressive-disclosure provenance badge (Stage-2C): a small
+ * summary line (a freshness chip + "About this price") that expands to disclose,
+ * in one place, everything a user needs to judge the number:
+ *   - Source      — where the spot price comes from (Gold-API.com) + cadence
+ *   - Updated     — the data-source UTC timestamp + relative age (honest state)
+ *   - Basis       — the fixed conversions every surface derives from
+ *                   (troy-oz 31.1035 g, USD→AED peg 3.6725, karat purity = code/24)
+ *   - Spot ≠ retail — the number is a spot-linked reference, not a shop quote
+ *   - Methodology — link to the full write-up
+ *
+ * Design contract (per the trust-layer mission):
+ *   - Progressive disclosure via native <details>/<summary> — keyboard
+ *     accessible, NOT hover-only; the core price stays visually dominant.
+ *   - No critical info is hover-only; the summary always shows the honest state.
+ *   - Bilingual EN/AR (natural Arabic), RTL-aware, theme-aware (design-system
+ *     tokens), mobile-friendly. `gtl-` namespaced, no `.ds-*` collisions.
+ *   - Reusable: every price surface can mount the same control. This is the
+ *     consolidation point for freshness+source+basis disclosure so surfaces stop
+ *     each rolling their own scattered trust copy.
+ *
+ * Built entirely with safe-dom `el()` (no innerHTML sink).
+ */
+
+import { el, safeHref } from '../lib/safe-dom.js';
+import { DATA_ATTRIBUTION, getRefreshStatement } from '../config/data-attribution.js';
+import { getLiveFreshness, applyMarketClosedOverlay, formatRelativeAge } from '../lib/live-status.js';
+import { formatTimestampShort } from '../lib/formatter.js';
+
+// The immutable invariants (troy-oz 31.1035, peg 3.6725, karat÷24) are stated as
+// prose in COPY below — they are constitutional constants, not runtime values.
+
+const FRESHNESS_LABEL = {
+  live: { en: 'Live', ar: 'مباشر' },
+  delayed: { en: 'Delayed', ar: 'متأخر قليلاً' },
+  cached: { en: 'Cached', ar: 'مخزن مؤقتاً' },
+  stale: { en: 'Stale', ar: 'قديم' },
+  fallback: { en: 'Fallback', ar: 'بديل احتياطي' },
+  closed: { en: 'Closed', ar: 'مغلق' },
+  unavailable: { en: 'Unavailable', ar: 'غير متاح' },
+};
+
+const COPY = {
+  en: {
+    summary: 'About this price',
+    sourceLabel: 'Source',
+    sourceRole: 'Gold spot price (XAU/USD)',
+    updatedLabel: 'Updated',
+    basisLabel: 'How it is derived',
+    basisTroy: '1 troy ounce = 31.1035 g',
+    basisPeg: 'USD → AED at the fixed peg 1 USD = 3.6725 AED',
+    basisKarat: 'Karat purity = karat ÷ 24 (24K = pure)',
+    spotVsRetail:
+      'This is a spot-linked reference for the metal itself — not a shop retail quote. A jeweller adds making charges, dealer margin, and any VAT.',
+    methodology: 'Full methodology',
+  },
+  ar: {
+    summary: 'عن هذا السعر',
+    sourceLabel: 'المصدر',
+    sourceRole: 'سعر الذهب الفوري (XAU/USD)',
+    updatedLabel: 'آخر تحديث',
+    basisLabel: 'كيف يُحتسب',
+    basisTroy: 'الأونصة التروية = 31.1035 غرام',
+    basisPeg: 'تحويل الدولار إلى الدرهم بالربط الثابت: 1 دولار = 3.6725 درهم',
+    basisKarat: 'نقاء العيار = العيار ÷ 24 (عيار 24 = خالص)',
+    spotVsRetail:
+      'هذا سعر مرجعي مرتبط بالسعر الفوري للمعدن نفسه — وليس سعر تجزئة من متجر. يضيف الصائغ أجور الصياغة وهامش التاجر وأي ضريبة قيمة مضافة.',
+    methodology: 'المنهجية الكاملة',
+  },
+};
+
+function freshnessLabel(key, lang) {
+  return (FRESHNESS_LABEL[key] || FRESHNESS_LABEL.unavailable)[lang === 'ar' ? 'ar' : 'en'];
+}
+
+function row(dict, labelText, valueNode) {
+  return el('div', { class: 'gtl-provenance__row' }, [
+    el('dt', { class: 'gtl-provenance__key' }, labelText),
+    el('dd', { class: 'gtl-provenance__val' }, valueNode),
+  ]);
+}
+
+/**
+ * Build the "About this price" control.
+ *
+ * @param {{
+ *   lang?: 'en'|'ar',
+ *   depth?: number,
+ *   updatedAt?: string|null,
+ *   hasLiveFailure?: boolean,
+ *   isFallback?: boolean|null,
+ *   isFresh?: boolean|null,
+ *   open?: boolean,
+ * }} opts
+ * @returns {HTMLElement} a <details class="gtl-provenance"> element
+ */
+export function renderPriceProvenance(opts = {}) {
+  const lang = opts.lang === 'ar' ? 'ar' : 'en';
+  const depth = Number.isInteger(opts.depth) ? opts.depth : 0;
+  const c = COPY[lang];
+  // safeHref only accepts explicitly-relative (`./`, `../`) or absolute URLs, so
+  // depth 0 must be `./methodology.html`, not a bare `methodology.html`.
+  const prefix = depth > 0 ? '../'.repeat(depth) : './';
+
+  // Resolve freshness through the shared label layer + market-closed overlay so
+  // the summary chip is honest and never claims "Live" while the market is shut.
+  const fresh = getLiveFreshness({
+    updatedAt: opts.updatedAt ?? null,
+    lang,
+    hasLiveFailure: Boolean(opts.hasLiveFailure),
+    isFallback: opts.isFallback ?? null,
+    isFresh: opts.isFresh ?? null,
+  });
+  const stateKey = applyMarketClosedOverlay(fresh.key);
+  const stateLabel = freshnessLabel(stateKey, lang);
+
+  const details = el('details', {
+    class: 'gtl-provenance',
+    'data-freshness': stateKey,
+  });
+  if (opts.open) details.setAttribute('open', '');
+
+  // Summary: freshness chip + affordance. The chip carries the honest state so
+  // the key info is visible without expanding.
+  const summary = el('summary', { class: 'gtl-provenance__summary' }, [
+    el('span', { class: 'gtl-provenance__chip' }, [
+      el('span', { class: 'gtl-provenance__dot', 'aria-hidden': 'true' }),
+      el('span', { class: 'gtl-provenance__state' }, stateLabel),
+    ]),
+    el('span', { class: 'gtl-provenance__cta' }, c.summary),
+    el('span', { class: 'gtl-provenance__chevron', 'aria-hidden': 'true' }),
+  ]);
+  details.appendChild(summary);
+
+  const body = el('div', { class: 'gtl-provenance__body' });
+
+  // Source
+  const sourceLink = el(
+    'a',
+    {
+      class: 'gtl-provenance__link',
+      href: safeHref(DATA_ATTRIBUTION.gold.url),
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    },
+    DATA_ATTRIBUTION.gold.label
+  );
+  const dl = el('dl', { class: 'gtl-provenance__list' }, [
+    row(c, c.sourceLabel, el('span', null, [sourceLink, el('span', { class: 'gtl-provenance__muted' }, ` · ${c.sourceRole}`)])),
+  ]);
+
+  // Updated — timestamp + relative age
+  if (opts.updatedAt) {
+    const timeText = formatTimestampShort(opts.updatedAt, lang);
+    const ageText = formatRelativeAge(fresh.ageMs, lang);
+    dl.appendChild(
+      row(c, c.updatedLabel, el('span', null, `${timeText} · ${ageText}`))
+    );
+  }
+
+  // Basis — the fixed conversions
+  dl.appendChild(
+    row(
+      c,
+      c.basisLabel,
+      el('ul', { class: 'gtl-provenance__basis' }, [
+        el('li', null, c.basisTroy),
+        el('li', null, c.basisPeg),
+        el('li', null, c.basisKarat),
+      ])
+    )
+  );
+  body.appendChild(dl);
+
+  // Refresh cadence (from the single attribution source of truth)
+  body.appendChild(el('p', { class: 'gtl-provenance__note' }, getRefreshStatement(lang)));
+
+  // Spot vs retail — the honest non-negotiable
+  body.appendChild(el('p', { class: 'gtl-provenance__retail' }, c.spotVsRetail));
+
+  // Methodology link
+  body.appendChild(
+    el(
+      'a',
+      { class: 'gtl-provenance__method', href: safeHref(`${prefix}methodology.html`) },
+      `${c.methodology} →`
+    )
+  );
+
+  details.appendChild(body);
+  return details;
+}

--- a/src/pages/compare.js
+++ b/src/pages/compare.js
@@ -25,6 +25,7 @@ import { mountSharedShell } from '../components/site-shell.js';
 import { injectBreadcrumbs } from '../components/breadcrumbs.js';
 import { updateTicker } from '../components/ticker.js';
 import { updateSpotBar } from '../components/spotBar.js';
+import { renderPriceProvenance } from '../components/priceProvenance.js';
 import { el, clear } from '../lib/safe-dom.js';
 import { flagSymbolForCountry, iconUseElement } from '../components/icon-sprite.js';
 import { track, EVENTS } from '../lib/analytics.js';
@@ -309,6 +310,23 @@ function renderSpotBadge() {
     freshEl.append(
       el('span', { class: 'compare-fresh-dot', 'aria-hidden': 'true' }),
       el('span', null, `${label} · ${f.ageText}`)
+    );
+  }
+
+  // Unified "About this price" provenance control (Stage-2C pilot). Preserve the
+  // user's open/closed state across the 90s refresh so a re-render never snaps it
+  // shut mid-read.
+  const provSlot = document.getElementById('compare-provenance');
+  if (provSlot) {
+    const wasOpen = provSlot.querySelector('.gtl-provenance')?.hasAttribute('open');
+    provSlot.replaceChildren(
+      renderPriceProvenance({
+        lang: STATE.lang,
+        depth: 0,
+        updatedAt: STATE.freshness.goldUpdatedAt,
+        hasLiveFailure: STATE.spotSource !== 'live',
+        open: wasOpen,
+      })
     );
   }
 }

--- a/styles/components/price-provenance.css
+++ b/styles/components/price-provenance.css
@@ -1,0 +1,166 @@
+/* ==========================================================================
+   price-provenance.css — the shared "About this price" trust control.
+   Namespaced `gtl-`; built on design-system tokens (light + dark aware);
+   RTL-safe via logical properties. Compact by default — the core price stays
+   visually dominant; details are one click away (native <details>).
+   ========================================================================== */
+
+.gtl-provenance {
+  --gtl-prov-accent: var(--color-gold-dark, #9a7b3f);
+
+  display: block;
+  max-width: 34rem;
+  margin-block-start: 0.5rem;
+  border: 1px solid var(--color-border-subtle, rgb(0 0 0 / 10%));
+  border-radius: var(--radius-md, 10px);
+  background: var(--color-surface, #fff);
+  font-family: var(--gtl-sans, system-ui, sans-serif);
+}
+
+/* ── Summary (always visible) ─────────────────────────────────────────────── */
+.gtl-provenance__summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  list-style: none;
+  font-size: 0.8125rem;
+  color: var(--color-text, #1a1a1a);
+}
+.gtl-provenance__summary::-webkit-details-marker {
+  display: none;
+}
+.gtl-provenance__summary:focus-visible {
+  outline: 2px solid var(--gtl-prov-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-xs, 6px);
+}
+
+.gtl-provenance__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+.gtl-provenance__dot {
+  inline-size: 0.5rem;
+  block-size: 0.5rem;
+  border-radius: 50%;
+  background: var(--color-stale, #b06a1f);
+  flex: none;
+}
+
+/* Only a genuinely live state gets the live colour; every other state
+   (including closed/cached/fallback) reads neutral — never a live green. */
+.gtl-provenance[data-freshness='live'] .gtl-provenance__dot {
+  background: var(--color-live, #2e9e5b);
+}
+.gtl-provenance__state {
+  color: var(--color-text-muted, #555);
+}
+.gtl-provenance__cta {
+  color: var(--gtl-prov-accent);
+  font-weight: 600;
+}
+.gtl-provenance__chevron {
+  margin-inline-start: auto;
+  inline-size: 0.6rem;
+  block-size: 0.6rem;
+  border-inline-end: 2px solid var(--color-text-muted, #777);
+  border-block-end: 2px solid var(--color-text-muted, #777);
+  transform: rotate(45deg);
+  transition: transform 0.18s ease;
+}
+.gtl-provenance[open] .gtl-provenance__chevron {
+  transform: rotate(-135deg);
+}
+
+/* ── Body (expanded) ──────────────────────────────────────────────────────── */
+.gtl-provenance__body {
+  padding: 0.25rem 0.75rem 0.75rem;
+  border-block-start: 1px solid var(--color-border-subtle, rgb(0 0 0 / 8%));
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--color-text, #1a1a1a);
+}
+.gtl-provenance__list {
+  margin: 0.5rem 0 0;
+}
+.gtl-provenance__row {
+  display: grid;
+  grid-template-columns: minmax(5.5rem, auto) 1fr;
+  gap: 0.25rem 0.75rem;
+  padding-block: 0.3rem;
+  border-block-start: 1px dotted var(--color-border-subtle, rgb(0 0 0 / 8%));
+}
+.gtl-provenance__row:first-child {
+  border-block-start: 0;
+}
+.gtl-provenance__key {
+  margin: 0;
+  color: var(--color-text-muted, #555);
+  font-weight: 600;
+}
+.gtl-provenance__val {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+.gtl-provenance__muted {
+  color: var(--color-text-muted, #666);
+}
+.gtl-provenance__basis {
+  margin: 0;
+  padding-inline-start: 1.1rem;
+}
+.gtl-provenance__basis li {
+  margin-block: 0.1rem;
+}
+.gtl-provenance__note,
+.gtl-provenance__retail {
+  margin: 0.6rem 0 0;
+  color: var(--color-text-muted, #555);
+}
+.gtl-provenance__retail {
+  color: var(--color-text, #1a1a1a);
+}
+.gtl-provenance__link {
+  color: var(--gtl-prov-accent);
+  font-weight: 600;
+}
+.gtl-provenance__method {
+  display: inline-block;
+  margin-block-start: 0.6rem;
+  color: var(--gtl-prov-accent);
+  font-weight: 700;
+  text-decoration: none;
+}
+.gtl-provenance__method:hover,
+.gtl-provenance__method:focus-visible {
+  text-decoration: underline;
+}
+
+/* ── Dark theme: tokens already flip; nudge the panel surface for depth. ───── */
+:root[data-theme='dark'] .gtl-provenance,
+[data-theme='dark'] .gtl-provenance {
+  background: var(--color-surface-2, #17171b);
+  border-color: var(--color-border, rgb(255 255 255 / 12%));
+}
+
+/* ── Mobile ───────────────────────────────────────────────────────────────── */
+@media (max-width: 480px) {
+  .gtl-provenance {
+    max-width: 100%;
+  }
+  .gtl-provenance__row {
+    grid-template-columns: 1fr;
+    gap: 0.1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gtl-provenance__chevron {
+    transition: none;
+  }
+}

--- a/tests/price-provenance.test.js
+++ b/tests/price-provenance.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+/**
+ * Unit tests for the shared "About this price" provenance control.
+ * Uses the same lightweight DOM stub pattern as safe-dom.test.js so el() runs
+ * under node:test without jsdom.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+function importModule(relPath) {
+  const url = new URL('file://' + path.resolve(__dirname, '..', relPath));
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+function installMockDocument() {
+  const originalDocument = global.document;
+  const originalNode = global.Node;
+  const doc = {
+    createElement(tag) {
+      return {
+        tagName: String(tag).toUpperCase(),
+        nodeType: 1,
+        ownerDocument: doc,
+        attrs: {},
+        dataset: {},
+        style: { setProperty() {} },
+        children: [],
+        appendChild(child) {
+          this.children.push(child);
+          return child;
+        },
+        append(...vals) {
+          for (const value of vals) {
+            if (value && typeof value === 'object' && typeof value.nodeType === 'number') {
+              this.children.push(value);
+            } else {
+              this.children.push(doc.createTextNode(value));
+            }
+          }
+        },
+        setAttribute(name, value) {
+          this.attrs[name] = String(value);
+        },
+        addEventListener() {},
+      };
+    },
+    createTextNode(value) {
+      return { nodeType: 3, ownerDocument: doc, textContent: String(value) };
+    },
+  };
+  global.Node = class Node {};
+  global.document = doc;
+  return {
+    restore() {
+      global.document = originalDocument;
+      global.Node = originalNode;
+    },
+  };
+}
+
+// Recursively collect all text in a rendered node tree.
+function allText(node) {
+  if (!node) return '';
+  if (node.nodeType === 3) return node.textContent || '';
+  let s = typeof node.textContent === 'string' && !node.children?.length ? node.textContent : '';
+  for (const c of node.children || []) s += ' ' + allText(c);
+  return s;
+}
+// Collect all values of an attribute across the tree.
+function collectAttr(node, attr, out = []) {
+  if (!node || node.nodeType !== 1) return out;
+  if (node.attrs && node.attrs[attr] != null) out.push(node.attrs[attr]);
+  for (const c of node.children || []) collectAttr(c, attr, out);
+  return out;
+}
+
+const UPDATED = '2026-07-11T08:00:00Z';
+
+test('provenance: EN render exposes summary, source, basis, spot-vs-retail, methodology', async () => {
+  const dom = installMockDocument();
+  try {
+    const { renderPriceProvenance } = await importModule('src/components/priceProvenance.js');
+    const node = renderPriceProvenance({ lang: 'en', depth: 0, updatedAt: UPDATED, hasLiveFailure: false });
+    assert.equal(node.tagName, 'DETAILS');
+    const text = allText(node);
+    assert.match(text, /About this price/);
+    assert.match(text, /Gold-API\.com/);
+    assert.match(text, /3\.6725/, 'AED peg basis stated');
+    assert.match(text, /31\.1035/, 'troy-oz basis stated');
+    assert.match(text, /not a shop retail quote/i, 'spot-vs-retail disclosed');
+    assert.match(text, /Full methodology/);
+    // methodology link is depth-0 relative
+    const hrefs = collectAttr(node, 'href');
+    assert.ok(hrefs.some((h) => h === './methodology.html'), `expected ./methodology.html in ${hrefs}`);
+  } finally {
+    dom.restore();
+  }
+});
+
+test('provenance: AR render uses natural Arabic copy', async () => {
+  const dom = installMockDocument();
+  try {
+    const { renderPriceProvenance } = await importModule('src/components/priceProvenance.js');
+    const node = renderPriceProvenance({ lang: 'ar', depth: 0, updatedAt: UPDATED });
+    const text = allText(node);
+    assert.match(text, /عن هذا السعر/, 'AR summary');
+    assert.match(text, /المنهجية الكاملة/, 'AR methodology label');
+    assert.match(text, /3\.6725/, 'peg still stated in AR');
+  } finally {
+    dom.restore();
+  }
+});
+
+test('provenance: depth adjusts the methodology href', async () => {
+  const dom = installMockDocument();
+  try {
+    const { renderPriceProvenance } = await importModule('src/components/priceProvenance.js');
+    const node = renderPriceProvenance({ lang: 'en', depth: 2, updatedAt: UPDATED });
+    const hrefs = collectAttr(node, 'href');
+    assert.ok(hrefs.some((h) => h === '../../methodology.html'), `expected ../../methodology.html in ${hrefs}`);
+  } finally {
+    dom.restore();
+  }
+});
+
+test('provenance: a fallback snapshot never renders a live state', async () => {
+  const dom = installMockDocument();
+  try {
+    const { renderPriceProvenance } = await importModule('src/components/priceProvenance.js');
+    const node = renderPriceProvenance({ lang: 'en', updatedAt: UPDATED, isFallback: true });
+    assert.notEqual(node.attrs['data-freshness'], 'live', 'fallback input must not read live');
+  } finally {
+    dom.restore();
+  }
+});
+
+test('provenance: missing timestamp still renders (no Updated row, no crash)', async () => {
+  const dom = installMockDocument();
+  try {
+    const { renderPriceProvenance } = await importModule('src/components/priceProvenance.js');
+    const node = renderPriceProvenance({ lang: 'en' });
+    assert.equal(node.tagName, 'DETAILS');
+    assert.match(allText(node), /About this price/);
+  } finally {
+    dom.restore();
+  }
+});


### PR DESCRIPTION
## Mission 4 — trust/provenance layer (scoped, quality-first pilot)

One reusable, progressive-disclosure control that consolidates everything a user needs to judge a price into a **compact badge that expands on click** — the core price stays visually dominant.

**`renderPriceProvenance(...)`** discloses, in one place:
- **Source** — Gold-API.com (XAU/USD) + refresh cadence
- **Updated** — data-source UTC timestamp + relative age (honest state chip in the summary)
- **How it is derived** — troy-oz 31.1035 g · USD→AED peg 3.6725 · karat purity = karat ÷ 24
- **Spot ≠ retail** — "a spot-linked reference, not a shop quote…"
- **Full methodology** link

### Why this is verify-don't-rebuild
Built **entirely on the existing `data-attribution.js` + constitutional constants** — no new fetch/state path. State resolves through `getLiveFreshness` + `applyMarketClosedOverlay`, so the summary chip is honest and **never reads "Live" while the market is closed** (consistent with #665). `safe-dom` only (no innerHTML).

### Design contract met
- Progressive disclosure via native `<details>` — keyboard-accessible, **not hover-only**; no critical info hidden behind hover.
- Bilingual EN/AR (natural Arabic, RTL via logical properties), theme-aware (design-system tokens, light+dark), mobile. `gtl-`-namespaced, no `.ds-*` collisions.

### Pilot = compare.html
Lean hero with no verbose existing trust block → clean additive pilot. Mounts under the spot badge; **preserves the user's open/closed state across the 90s refresh**. `docs/price-flow-map.md` documents the component + a rollout pattern (next: portfolio/heatmap; then consolidate the scattered inline trust copy on home/calculator/dubai into this one control).

Fixed en route: `safeHref` rejects bare-relative URLs, so the methodology link needs `./methodology.html` at depth 0 (caught by the component test).

## Verification
- `npm test` → **1618 pass** (5 new, DOM-stubbed) · `eslint`/`stylelint`/`build`/`validate` → exit 0 · no unexpected HTML mutations
- **Local Playwright + axe** (served repo root, per QA gotcha — not vite preview), EN/AR × light/dark × mobile 390px: control renders, expands, **axe 0 wcag2a/aa violations**, honest `state=closed`, 0 console errors.

Screenshots (light / dark / AR-RTL) captured; core price remains dominant. Will re-verify on the live deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI on compare only, reusing existing attribution and freshness helpers; no auth, payments, or new data pipelines.
> 
> **Overview**
> Adds a shared **`renderPriceProvenance`** control: a compact `<details>` with a freshness chip and **About this price**, expanding to source, update time, derivation basis (troy oz, AED peg, karat), spot-vs-retail copy, and a methodology link. State comes from existing **`getLiveFreshness`** + **`applyMarketClosedOverlay`** and **`data-attribution.js`**—no new price fetch path; DOM is built with **`safe-dom`** only.
> 
> **Compare** is the pilot: **`compare.html`** loads **`price-provenance.css`**, adds **`#compare-provenance`**, and **`compare.js`** mounts the control on each spot refresh while **preserving open/closed** across the 90s update. **`docs/price-flow-map.md`** documents the component and rollout pattern for other surfaces.
> 
> Includes **`gtl-`** namespaced styles (EN/AR, RTL, theme tokens) and **`tests/price-provenance.test.js`** (DOM stub).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dc3b783d2ed27303080faab77bc5acbb85b2c4c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->