### PR TITLE
feat(market): honest reference-movement panel in the worked example (Stage 3.1)

### DIFF
--- a/market.html
+++ b/market.html
@@ -333,6 +333,44 @@
               </span>
             </div>
 
+            <!-- Reference movement — an honest OBSERVATION of how the reference
+                 figure has changed since the last one we recorded. market.js
+                 fills it from /data/last_gold_price.json (the last reference we
+                 published) vs the canonical spot, always showing the REAL window
+                 from that record's timestamp — never a fabricated "24h", never a
+                 forecast, never a stated cause. Hidden until data is present. -->
+            <div class="mkt-worked-move" id="mkt-worked-move" hidden aria-hidden="true">
+              <p class="mkt-worked-move-label">
+                <span data-lang-block="en">Movement since the last reference we recorded</span>
+                <span data-lang-block="ar" lang="ar" dir="rtl">التغيّر منذ آخر مرجع سجّلناه</span>
+              </p>
+              <p class="mkt-worked-move-figure">
+                <span class="mkt-worked-move-pct" id="mkt-move-pct"></span>
+                <span class="mkt-worked-move-window" id="mkt-move-window"></span>
+              </p>
+              <p class="mkt-worked-move-compare">
+                <span class="mkt-worked-move-pair">
+                  <span class="mkt-worked-move-k" data-lang-block="en">Now</span>
+                  <span class="mkt-worked-move-k" data-lang-block="ar" lang="ar" dir="rtl">الآن</span>
+                  <span class="mkt-worked-move-v" id="mkt-move-now"></span>
+                </span>
+                <span class="mkt-worked-move-pair">
+                  <span class="mkt-worked-move-k" data-lang-block="en">Then</span>
+                  <span class="mkt-worked-move-k" data-lang-block="ar" lang="ar" dir="rtl">حينها</span>
+                  <span class="mkt-worked-move-v" id="mkt-move-then"></span>
+                </span>
+              </p>
+              <p class="mkt-worked-move-note">
+                <span data-lang-block="en"
+                  >An observation of the reference figure — not a forecast, and not a stated
+                  cause.</span
+                >
+                <span data-lang-block="ar" lang="ar" dir="rtl"
+                  >ملاحظة لرقم مرجعي — وليست توقّعاً ولا سبباً معلَناً.</span
+                >
+              </p>
+            </div>
+
             <ol class="mkt-worked-flow">
               <li class="mkt-worked-node">
                 <span class="mkt-worked-step">

--- a/src/lib/reference-move.js
+++ b/src/lib/reference-move.js
@@ -1,0 +1,39 @@
+/**
+ * Reference-movement observation — pure, side-effect-free.
+ *
+ * Compares a CURRENT reference figure against a PRIOR recorded reference and
+ * reports direction + magnitude with the prior record's timestamp, so any
+ * surface can honestly say "the reference is X% above/below the value recorded
+ * at <time>". This is deliberately framed as an OBSERVATION of the published
+ * reference figure — it is not a forecast, not intraday OHLC, and never states a
+ * cause. Callers must render the real window (from `ts`), never a fabricated
+ * "24h", and never colour-only direction (see the freshness/honesty contract).
+ *
+ * Shared by market.html's worked example (3.1) and reused by the wider
+ * price-change explainability pass (3.2).
+ */
+
+// Below this absolute percentage the two figures are the same for display
+// purposes — we say "virtually unchanged" (neutral) rather than drawing a
+// misleading ±0.0x% arrow on rounding noise.
+export const MOVE_FLAT_PCT = 0.05;
+
+/**
+ * @param {number} current  current reference value (same unit as `prior`)
+ * @param {number} prior    last recorded reference value
+ * @param {string|null|undefined} ts  ISO timestamp the prior reference was recorded at
+ * @returns {{current:number, prior:number, ts:string, change:number, pct:number,
+ *            direction:'up'|'down'|'neutral'}|null}
+ *   `null` unless BOTH values are finite positives AND a timestamp is present —
+ *   we never show a change without an honest window.
+ */
+export function referenceMove(current, prior, ts) {
+  if (!Number.isFinite(current) || current <= 0) return null;
+  if (!Number.isFinite(prior) || prior <= 0) return null;
+  if (!ts || typeof ts !== 'string') return null;
+
+  const change = current - prior;
+  const pct = (change / prior) * 100;
+  const direction = Math.abs(pct) < MOVE_FLAT_PCT ? 'neutral' : change > 0 ? 'up' : 'down';
+  return { current, prior, ts, change, pct, direction };
+}

--- a/src/pages/market.js
+++ b/src/pages/market.js
@@ -22,10 +22,18 @@ import { initPageEnter } from '../lib/page-enter.js';
 import { getCanonicalSpot } from '../lib/spot-resolver.js';
 import { applyMarketClosedOverlay } from '../lib/live-status.js';
 import { startVisibilityAwareRefresh } from '../lib/visibility-refresh.js';
+import { parseLastGoldPriceSnapshot } from '../lib/quote-providers/last-gold-price-parse.js';
+import { referenceMove } from '../lib/reference-move.js';
 import { CONSTANTS } from '../config/index.js';
-import { formatNumber, formatCurrency, formatTimestampShort } from '../lib/formatter.js';
+import {
+  formatNumber,
+  formatCurrency,
+  formatTimestampShort,
+  formatDate,
+  formatRelativeTime,
+} from '../lib/formatter.js';
 
-const STATE = { lang: 'en', snapshot: null, timer: null };
+const STATE = { lang: 'en', snapshot: null, prior: null, timer: null };
 
 const T = {
   en: {
@@ -106,14 +114,83 @@ function renderWorked() {
     pill.hidden = false;
   }
 
+  renderMove();
   card.removeAttribute('aria-busy');
+}
+
+function computeMove() {
+  const snap = STATE.snapshot;
+  const prior = STATE.prior;
+  const current = snap?.ok ? snap.spotUsdPerOz : null;
+  return referenceMove(current, prior?.price, prior?.ts);
+}
+
+function renderMove() {
+  const panel = document.getElementById('mkt-worked-move');
+  if (!panel) return;
+  const move = computeMove();
+  if (!move) {
+    panel.hidden = true;
+    panel.setAttribute('aria-hidden', 'true');
+    return;
+  }
+
+  const arrow = move.direction === 'up' ? '↑' : move.direction === 'down' ? '↓' : '±';
+  const pctStr = formatNumber(Math.abs(move.change) / move.prior, STATE.lang, {
+    style: 'percent',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const pctNode = document.getElementById('mkt-move-pct');
+  if (pctNode) {
+    pctNode.textContent = `${arrow} ${pctStr}`;
+    pctNode.className = `mkt-worked-move-pct mkt-worked-move-pct--${move.direction}`;
+  }
+
+  const windowNode = document.getElementById('mkt-move-window');
+  if (windowNode) {
+    const date = formatDate(move.ts, STATE.lang);
+    const rel = formatRelativeTime(move.ts, STATE.lang);
+    windowNode.textContent = `${date} · ${rel}`;
+  }
+
+  const nowNode = document.getElementById('mkt-move-now');
+  if (nowNode) nowNode.textContent = formatCurrency(move.current, 'USD', STATE.lang, 2);
+  const thenNode = document.getElementById('mkt-move-then');
+  if (thenNode) thenNode.textContent = formatCurrency(move.prior, 'USD', STATE.lang, 2);
+
+  panel.hidden = false;
+  panel.removeAttribute('aria-hidden');
+}
+
+/**
+ * Read the last reference we published (`/data/last_gold_price.json`). Reuses the
+ * canonical parser (`parseLastGoldPriceSnapshot`) so the price sanity-check and
+ * timestamp precedence match the Tracker's fallback tier — no duplicate price
+ * logic. Never throws: a missing/old/invalid record just leaves the movement
+ * panel hidden, and the static worked example stands on its own.
+ * @returns {Promise<{price:number, ts:string|null}|null>}
+ */
+async function fetchPrior() {
+  try {
+    const res = await fetch(`/data/last_gold_price.json?t=${Date.now()}`, { cache: 'no-store' });
+    if (!res.ok) return null;
+    const parsed = parseLastGoldPriceSnapshot(await res.json());
+    if (!parsed) return null;
+    return { price: parsed.price, ts: parsed.providerTimestamp };
+  } catch {
+    return null;
+  }
 }
 
 async function fetchWorked() {
   try {
-    const snap = await getCanonicalSpot({ force: true });
+    // Prior reference is fetched alongside but independently — fetchPrior never
+    // throws, so a missing last_gold_price.json can't block the worked example.
+    const [snap, prior] = await Promise.all([getCanonicalSpot({ force: true }), fetchPrior()]);
     if (snap && snap.ok) {
       STATE.snapshot = snap;
+      STATE.prior = prior;
       renderWorked();
     }
   } catch {

--- a/styles/pages/market-redesign.css
+++ b/styles/pages/market-redesign.css
@@ -108,6 +108,84 @@
   box-shadow: 0 0 0 3px rgb(176 106 31 / 16%);
 }
 
+/* Reference movement panel — an honest observation of change since the last
+   reference we recorded. Uses the site's purpose-built movement palette
+   (--color-move-up/down), which is theme-flipped and WCAG-AA in both light and
+   dark; direction is never colour-only (arrow glyph + "Now/Then" figures +
+   label carry it too). Logical properties keep it correct in RTL. */
+.mkt-worked-move {
+  margin-bottom: var(--gtl-5);
+  padding: var(--gtl-3) var(--gtl-4);
+  border: 1px solid var(--color-border-subtle);
+  border-inline-start: 3px solid var(--color-gold);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-2);
+}
+.mkt-worked-move-label {
+  margin: 0;
+  font-size: var(--gtl-meta);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+.mkt-worked-move-figure {
+  margin: 0.35em 0 0;
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.3em 0.7em;
+}
+.mkt-worked-move-pct {
+  font-size: clamp(1.35rem, 3.4vw, 1.7rem);
+  font-weight: 700;
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
+}
+.mkt-worked-move-pct--up {
+  color: var(--color-move-up);
+}
+.mkt-worked-move-pct--down {
+  color: var(--color-move-down);
+}
+.mkt-worked-move-pct--neutral {
+  color: var(--color-text-muted);
+}
+.mkt-worked-move-window {
+  font-size: var(--gtl-meta);
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.mkt-worked-move-compare {
+  margin: 0.5em 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35em 1.25em;
+  font-size: var(--gtl-meta);
+  font-variant-numeric: tabular-nums;
+}
+.mkt-worked-move-pair {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45em;
+}
+.mkt-worked-move-k {
+  color: var(--color-text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.82em;
+}
+.mkt-worked-move-v {
+  color: var(--color-text);
+  font-weight: 600;
+}
+.mkt-worked-move-note {
+  margin: 0.55em 0 0;
+  font-size: var(--gtl-meta);
+  color: var(--color-text-faint);
+  font-style: italic;
+}
+
 /* Flow of nodes + operators. */
 .mkt-worked-flow {
   list-style: none;

--- a/tests/reference-move.test.js
+++ b/tests/reference-move.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * Unit tests for the shared reference-movement observation helper
+ * (src/lib/reference-move.js), used by market.html's worked example (3.1) and
+ * reused by the wider price-change explainability pass (3.2).
+ *
+ * The helper must NEVER report a change without an honest window (a timestamp),
+ * must treat rounding-noise deltas as neutral rather than drawing a misleading
+ * arrow, and must reject non-finite / non-positive inputs.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+function importModule(relPath) {
+  const url = new URL('file://' + path.resolve(__dirname, '..', relPath));
+  return import(url.href + `?v=${Date.now()}`);
+}
+
+const TS = '2026-07-06T12:06:20Z';
+
+test('reports a downward move with signed change, pct and window', async () => {
+  const { referenceMove } = await importModule('src/lib/reference-move.js');
+  const m = referenceMove(4121.4, 4157.7, TS);
+  assert.ok(m, 'expected a move object');
+  assert.equal(m.direction, 'down');
+  assert.equal(m.ts, TS);
+  assert.ok(m.change < 0);
+  // (4121.4 - 4157.7) / 4157.7 * 100 ≈ -0.873%
+  assert.ok(Math.abs(m.pct - -0.8730) < 0.01, `pct was ${m.pct}`);
+  assert.equal(m.current, 4121.4);
+  assert.equal(m.prior, 4157.7);
+});
+
+test('reports an upward move', async () => {
+  const { referenceMove } = await importModule('src/lib/reference-move.js');
+  const m = referenceMove(4200, 4100, TS);
+  assert.equal(m.direction, 'up');
+  assert.ok(m.change > 0 && m.pct > 0);
+});
+
+test('treats sub-threshold deltas as neutral (no misleading arrow)', async () => {
+  const { referenceMove, MOVE_FLAT_PCT } = await importModule('src/lib/reference-move.js');
+  assert.equal(MOVE_FLAT_PCT, 0.05);
+  // 0.02% move — below the flat band.
+  const m = referenceMove(4000.8, 4000, TS);
+  assert.ok(m);
+  assert.equal(m.direction, 'neutral');
+});
+
+test('returns null without a timestamp — never a change without an honest window', async () => {
+  const { referenceMove } = await importModule('src/lib/reference-move.js');
+  assert.equal(referenceMove(4121.4, 4157.7, null), null);
+  assert.equal(referenceMove(4121.4, 4157.7, ''), null);
+  assert.equal(referenceMove(4121.4, 4157.7, undefined), null);
+  assert.equal(referenceMove(4121.4, 4157.7, 1720000000000), null, 'non-string ts rejected');
+});
+
+test('returns null for non-finite / non-positive inputs', async () => {
+  const { referenceMove } = await importModule('src/lib/reference-move.js');
+  assert.equal(referenceMove(null, 4157.7, TS), null);
+  assert.equal(referenceMove(4121.4, null, TS), null);
+  assert.equal(referenceMove(NaN, 4157.7, TS), null);
+  assert.equal(referenceMove(4121.4, 0, TS), null);
+  assert.equal(referenceMove(-1, 4157.7, TS), null);
+  assert.equal(referenceMove(4121.4, -5, TS), null);
+});


### PR DESCRIPTION
## Summary
Stage 3.1 — adds a **"Movement since the last reference we recorded"** panel to `market.html`'s live worked example. market.html is an educational explainer (not a live dashboard), so this is framed strictly as an **observation**, not a forecast/driver.

It compares the current canonical spot (`getCanonicalSpot()`) against the last reference we published (`/data/last_gold_price.json`) and shows **direction + %** with the **real window** from that record's `posted_at_utc`.

## Semantics — verified first (per the task's explicit ask)
`last_gold_price.json` is **not** a 24h-ago price. It's the last *published/recorded* reference — the tweet-guard baseline, deduped by `content_hash`, and also the Tracker's final fallback tier. Right now `posted_at_utc` is ~5 days old (weekend, market closed). So the panel:
- renders the **actual elapsed window** (`6 Jul · 5 days ago`) — never a fabricated "24h";
- shows current-vs-prior figures (**Now** `$4,121.40` / **Then** `$4,157.70`);
- carries an explicit *"observation of the reference figure — not a forecast, and not a stated cause"* note;
- conveys direction with an **arrow glyph + Now/Then figures + label** (never colour-only).

## Changes
- **New** `src/lib/reference-move.js` — pure, side-effect-free `referenceMove()` (+ `MOVE_FLAT_PCT`). Returns `null` unless both figures are finite positives **and** a timestamp is present (no change without an honest window); sub-0.05% deltas are neutral, not a misleading ±0.0x% arrow. Reusable by the 3.2 explainability pass.
- Prior reference parsed via the canonical `parseLastGoldPriceSnapshot` (**no duplicate price logic**); fetched independently so a missing/old/invalid record just hides the panel and the static worked example stands on its own.
- Styling reuses the site's purpose-built `--color-move-up/down` palette (theme-flipped, WCAG-AA light **and** dark); logical properties keep it RTL-safe.
- 5 unit tests.

## Verification
- `npm test` **1623/0**, `eslint` / `stylelint` / `npm run build` / `npm run validate` **exit 0**.
- Playwright EN/AR × light/dark × mobile(390): panel visible & correct, **axe color-contrast 0 violations**, no console errors from the panel.
- Graceful degradation: prior record absent → panel hidden, worked example intact (spot + AED still render, `aria-busy` cleared).

## Invariants
Canonical resolver only; no duplicate price logic; Tracker engine untouched; honest freshness/window; no fabricated data/trend/causation. `spot ≠ retail` step preserved (the retail node stays "shop-set", never fabricated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Educational UI on the market page with graceful degradation; no auth, pricing engine, or tracker changes—only display logic and a small pure library.
> 
> **Overview**
> Adds a **“Movement since the last reference we recorded”** block to the market page live worked example, comparing **canonical spot** (`getCanonicalSpot`) to the last published record in `/data/last_gold_price.json`, with bilingual copy that frames the change as an **observation** (not a forecast or cause).
> 
> Introduces shared **`referenceMove()`** in `src/lib/reference-move.js` (direction, % change, neutral band below 0.05%, `null` without a valid prior timestamp). `market.js` loads the prior via **`parseLastGoldPriceSnapshot`**, renders arrow + % + real date/relative window + Now/Then USD figures, and **hides the panel** if prior data is missing—without blocking the rest of the worked example. Styling uses `--color-move-up/down` with non–color-only direction cues; **5 unit tests** cover the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 438fbe56467cc6d1a80c2f98c958684223a15133. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->