### PR TITLE
feat(charts): accessible series summary + localized time axis (shared chart system, slice 1)

### DIFF
--- a/src/components/chart-summary.js
+++ b/src/components/chart-summary.js
@@ -1,0 +1,179 @@
+/**
+ * components/chart-summary.js — accessible series summary for canvas charts.
+ *
+ * A Lightweight Charts canvas is invisible to assistive technology: the page
+ * wrapper may carry an aria-label (tracker's `.tracker-chart-wrap` does), but
+ * the DATA the chart shows has no text equivalent. This module derives a
+ * deterministic summary from the EXACT series array the chart renders (same
+ * points, same values — no separate calculation path) and maintains it as a
+ * visually-hidden `.sr-only` paragraph inside the chart container, so screen
+ * readers can browse what the chart shows: period, points, direction, change,
+ * high, low.
+ *
+ * Deliberately NOT a live region — chart data refreshes on a timer and a
+ * `role="status"` here would spam announcements. It also does not add
+ * `role="img"`/`aria-label` to the container: the chart area contains
+ * interactive content (scroll/scale surface, attribution link) that an image
+ * role would hide, and the tracker already labels its wrapper.
+ *
+ * Numbers/dates go through the shared formatter conventions (`formatNumber`,
+ * ar-AE/en-AE dates) and all strings live in `translations.js`. Nothing is
+ * invented: an empty/short series produces the explicit "no data" sentence,
+ * never placeholder values. `computeSeriesSummary` is pure and unit-testable
+ * without a DOM.
+ */
+
+import { TRANSLATIONS } from '../config/translations.js';
+import { translate } from '../lib/i18n.js';
+import { formatNumber } from '../lib/formatter.js';
+
+/**
+ * Convert a Lightweight-Charts time value ('YYYY-MM-DD' string or unix
+ * seconds) to a Date, or null when unparseable.
+ * @param {string|number} time
+ * @returns {Date|null}
+ */
+function timeToDate(time) {
+  const date =
+    typeof time === 'string' ? new Date(`${time}T00:00:00Z`) : new Date(Number(time) * 1000);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
+/**
+ * Derive summary statistics from a rendered chart series.
+ * Pure: no DOM, no locale — formatting happens separately.
+ *
+ * @param {Array<{ time: string|number, value: number }>} points
+ *   The series in Lightweight Charts format, ascending by time (the same
+ *   array handed to `series.setData()`).
+ * @returns {{
+ *   points: number,
+ *   firstValue: number, lastValue: number,
+ *   change: number, pctChange: number,
+ *   high: number, low: number,
+ *   firstDate: Date, lastDate: Date,
+ * } | null}  null when fewer than 2 valid points exist.
+ */
+export function computeSeriesSummary(points) {
+  if (!Array.isArray(points)) return null;
+  const valid = points.filter(
+    (p) => p && Number.isFinite(Number(p.value)) && Number(p.value) > 0 && timeToDate(p.time)
+  );
+  if (valid.length < 2) return null;
+
+  const first = valid[0];
+  const last = valid[valid.length - 1];
+  let high = -Infinity;
+  let low = Infinity;
+  for (const p of valid) {
+    const v = Number(p.value);
+    if (v > high) high = v;
+    if (v < low) low = v;
+  }
+  const firstValue = Number(first.value);
+  const lastValue = Number(last.value);
+  const change = lastValue - firstValue;
+  const pctChange = firstValue !== 0 ? (change / firstValue) * 100 : 0;
+
+  return {
+    points: valid.length,
+    firstValue,
+    lastValue,
+    change,
+    pctChange,
+    high,
+    low,
+    firstDate: timeToDate(first.time),
+    lastDate: timeToDate(last.time),
+    // Numeric (unix-second) endpoints mean an intraday series: its dates must
+    // be formatted in local time to match what the chart axis displays.
+    // 'YYYY-MM-DD' business-day strings stay UTC-pinned.
+    intraday: typeof first.time === 'number' || typeof last.time === 'number',
+  };
+}
+
+/** Mirrors the formatter.js timestamp convention (ar-AE / en-AE). */
+function localeFor(lang) {
+  return lang === 'ar' ? 'ar-AE' : 'en-AE';
+}
+
+function formatSummaryDate(date, lang, intraday = false) {
+  try {
+    return date.toLocaleDateString(localeFor(lang), {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      // Business-day ('YYYY-MM-DD') points are calendar dates — pin to UTC so
+      // the label can't shift a day in western timezones. Intraday points are
+      // real instants — format in local time so the summary matches the dates
+      // the chart's time axis shows the user.
+      ...(intraday ? {} : { timeZone: 'UTC' }),
+    });
+  } catch {
+    return date.toISOString().slice(0, 10);
+  }
+}
+
+const NUM_2DP = { minimumFractionDigits: 2, maximumFractionDigits: 2 };
+
+/**
+ * Build the full localized summary sentence for a computed series summary.
+ *
+ * @param {ReturnType<typeof computeSeriesSummary>} summary
+ * @param {'en'|'ar'} lang
+ * @param {{ unitKey?: string|null }} [opts]
+ *   `unitKey` — translation key of a trailing unit-disclosure sentence (e.g.
+ *   'chart.summary.unitUsdOz'). Pass null/omit for series whose unit is not
+ *   known to this module (custom-injected data) so the summary never claims a
+ *   unit it cannot verify.
+ * @returns {string}
+ */
+export function formatChartSummaryText(summary, lang = 'en', opts = {}) {
+  if (!summary) return translate(TRANSLATIONS, lang, 'chart.summary.noData');
+  const vars = {
+    from: formatSummaryDate(summary.firstDate, lang, summary.intraday),
+    to: formatSummaryDate(summary.lastDate, lang, summary.intraday),
+    points: formatNumber(summary.points, lang),
+    change: formatNumber(Math.abs(summary.change), lang, NUM_2DP),
+    pct: formatNumber(Math.abs(summary.pctChange), lang, NUM_2DP),
+    latest: formatNumber(summary.lastValue, lang, NUM_2DP),
+    high: formatNumber(summary.high, lang, NUM_2DP),
+    low: formatNumber(summary.low, lang, NUM_2DP),
+  };
+  // A change that displays as 0.00 must not be announced as movement.
+  const isFlat = Math.abs(summary.change) < 0.005;
+  let body;
+  if (isFlat) {
+    body = translate(TRANSLATIONS, lang, 'chart.summary.textFlat', { vars });
+  } else {
+    vars.direction =
+      summary.change > 0
+        ? translate(TRANSLATIONS, lang, 'chart.summary.up')
+        : translate(TRANSLATIONS, lang, 'chart.summary.down');
+    body = translate(TRANSLATIONS, lang, 'chart.summary.text', { vars });
+  }
+  return opts.unitKey ? `${body} ${translate(TRANSLATIONS, lang, opts.unitKey)}` : body;
+}
+
+/**
+ * Create/refresh the visually-hidden summary paragraph inside a chart
+ * container. Idempotent — safe to call on every render. Text-only DOM writes.
+ *
+ * @param {HTMLElement|null} container  The chart mount node.
+ * @param {Array<{ time: string|number, value: number }>|null} points
+ *   The exact series rendered, or null/empty when the chart has no data.
+ * @param {'en'|'ar'} lang
+ * @param {{ unitKey?: string|null }} [opts]  See formatChartSummaryText().
+ */
+export function updateChartSummary(container, points, lang = 'en', opts = {}) {
+  if (!container) return;
+  let srNode = container.querySelector(':scope > .chart-sr-summary');
+  if (!srNode) {
+    srNode = (container.ownerDocument || document).createElement('p');
+    srNode.className = 'sr-only chart-sr-summary';
+    container.appendChild(srNode);
+  }
+  srNode.textContent = formatChartSummaryText(computeSeriesSummary(points), lang, opts);
+  srNode.setAttribute('lang', lang);
+  srNode.setAttribute('dir', lang === 'ar' ? 'rtl' : 'ltr');
+}

--- a/src/components/chart.js
+++ b/src/components/chart.js
@@ -14,6 +14,7 @@
  */
 
 import { getUnifiedHistory, toChartData, filterByRange } from '../lib/historical-data.js';
+import { updateChartSummary } from './chart-summary.js';
 
 const CHART_CACHE_KEY = 'gold_chart_snapshots';
 const MAX_SNAPSHOTS = 5000; // ~5 days at 90s intervals
@@ -161,6 +162,10 @@ export class GoldChart {
     this._chart = this._LW.createChart(container, {
       width: container.clientWidth,
       height: chartHeight,
+      // Localize time-axis / crosshair dates to the page language, mirroring
+      // the formatter.js ar-AE / en-AE date convention. Price digits keep the
+      // library default (Latin), matching formatPrice() sitewide.
+      localization: { locale: this.lang === 'ar' ? 'ar-AE' : 'en-AE' },
       layout: {
         background: { color: 'transparent' },
         textColor: theme.text,
@@ -202,14 +207,14 @@ export class GoldChart {
       attributeFilter: ['data-theme'],
     });
 
-    const ro = new ResizeObserver(() => {
+    this._resizeObserver = new ResizeObserver(() => {
       if (this._chart) {
         const w = container.clientWidth;
         const h = wrap ? Math.max(240, wrap.clientHeight - 4) : chartHeight;
         if (w > 0) this._chart.resize(w, h);
       }
     });
-    ro.observe(container);
+    this._resizeObserver.observe(container);
 
     this._injectTradingViewAttribution(container);
 
@@ -328,6 +333,8 @@ export class GoldChart {
     const data = this._getChartData();
     if (!data || data.length < 2) {
       this._showFallback('no-data');
+      // Keep the SR summary truthful when a range switch empties the series.
+      updateChartSummary(document.getElementById(this.containerId), null, this.lang);
       return;
     }
     this._clearFallback();
@@ -350,6 +357,13 @@ export class GoldChart {
 
     this._series.setData(deduped);
     this._chart.timeScale().fitContent();
+    // Accessible text equivalent of the exact series just rendered. The
+    // USD/troy-oz unit sentence applies only to this component's own data
+    // paths (spot snapshots + unified history); custom-injected series may
+    // use other units/currencies, so their summary makes no unit claim.
+    updateChartSummary(document.getElementById(this.containerId), deduped, this.lang, {
+      unitKey: this._customData === null ? 'chart.summary.unitUsdOz' : null,
+    });
   }
 
   addPoint(price, timestamp) {
@@ -366,6 +380,11 @@ export class GoldChart {
       if (data && data.length >= 2) {
         this._clearFallback();
         this._series.update({ time, value: price });
+        // Keep the SR summary in step with the incrementally-updated canvas
+        // (data from _getChartData already includes the point just pushed).
+        updateChartSummary(document.getElementById(this.containerId), data, this.lang, {
+          unitKey: this._customData === null ? 'chart.summary.unitUsdOz' : null,
+        });
       }
     }
   }
@@ -376,6 +395,34 @@ export class GoldChart {
   }
 
   setLang(lang) {
+    if (this.lang === lang) return;
     this.lang = lang;
+    // Re-localize the time axis and refresh the SR summary in the new language.
+    if (this._chart) {
+      this._chart.applyOptions({
+        localization: { locale: lang === 'ar' ? 'ar-AE' : 'en-AE' },
+      });
+    }
+    if (this._ready) this._render();
+  }
+
+  /**
+   * Tear down the chart and its observers. Safe to call twice. Pages that
+   * re-mount charts (language/theme rebuilds) should call this to avoid
+   * leaking MutationObserver/ResizeObserver instances.
+   */
+  destroy() {
+    this._themeObserver?.disconnect();
+    this._themeObserver = null;
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = null;
+    if (this._chart) {
+      try {
+        this._chart.remove();
+      } catch {}
+      this._chart = null;
+    }
+    this._series = null;
+    this._ready = false;
   }
 }

--- a/src/config/translations.js
+++ b/src/config/translations.js
@@ -176,6 +176,14 @@ export const TRANSLATIONS = {
     'tracker.chart.downloadJson': 'Download snapshot JSON',
     'tracker.chart.legendMain': 'Selected series',
     'tracker.chart.chartAriaLabel': 'Gold price chart',
+    'chart.summary.text':
+      'Chart data summary: from {from} to {to}, {points} data points. The reference price moved {direction} by {change} ({pct}%). Latest {latest}, period high {high}, period low {low}.',
+    'chart.summary.textFlat':
+      'Chart data summary: from {from} to {to}, {points} data points. The reference price was effectively unchanged over this period. Latest {latest}, period high {high}, period low {low}.',
+    'chart.summary.unitUsdOz': 'Values in USD per troy ounce.',
+    'chart.summary.noData': 'No chart data is available for this range yet.',
+    'chart.summary.up': 'up',
+    'chart.summary.down': 'down',
     'tracker.chart.emptyTitle':
       'Waiting for price data — select a time range above or refresh to load history.',
     'tracker.chart.emptyNote':
@@ -1638,6 +1646,14 @@ export const TRANSLATIONS = {
     'tracker.chart.downloadJson': 'تنزيل اللقطة بصيغة JSON',
     'tracker.chart.legendMain': 'السلسلة المختارة',
     'tracker.chart.chartAriaLabel': 'الرسم البياني لسعر الذهب',
+    'chart.summary.text':
+      'ملخص بيانات الرسم البياني: من {from} إلى {to}، وعدد نقاط البيانات {points}. تحرك السعر المرجعي {direction} بمقدار {change} ({pct}٪). الأحدث {latest}، أعلى قيمة خلال الفترة {high}، أدنى قيمة خلال الفترة {low}.',
+    'chart.summary.textFlat':
+      'ملخص بيانات الرسم البياني: من {from} إلى {to}، وعدد نقاط البيانات {points}. ظل السعر المرجعي دون تغيير يُذكر خلال هذه الفترة. الأحدث {latest}، أعلى قيمة خلال الفترة {high}، أدنى قيمة خلال الفترة {low}.',
+    'chart.summary.unitUsdOz': 'القيم بالدولار الأمريكي لكل أوقية تروي.',
+    'chart.summary.noData': 'لا تتوفر بيانات للرسم البياني في هذا النطاق بعد.',
+    'chart.summary.up': 'صعوداً',
+    'chart.summary.down': 'هبوطاً',
     'tracker.chart.emptyTitle':
       'في انتظار بيانات السعر — اختر نطاقاً زمنياً أعلاه أو حدّث الصفحة لتحميل السجل.',
     'tracker.chart.emptyNote':

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -1881,6 +1881,9 @@ async function init() {
       shell.updateLang(lang);
       applyLangToPage();
       mountHomeQuickConvert();
+      // Re-localize the interactive chart (time axis + SR summary); safe
+      // no-op before the lazy chart has mounted.
+      _homeChart?.setLang(lang);
       injectFaqSchema(document, buildMethodologyFaqSchema(lang));
     });
   });

--- a/tests/chart-summary.test.js
+++ b/tests/chart-summary.test.js
@@ -1,0 +1,193 @@
+/**
+ * Tests for src/components/chart-summary.js — the accessible series summary
+ * derived from the exact points a Lightweight Charts canvas renders.
+ *
+ * Follows the tests/formatter-locale.test.js pattern: CJS test file loading
+ * the real ESM module via dynamic import, and assertions that check structure
+ * and digits rather than pinning volatile ICU output.
+ */
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadChartSummary() {
+  const url = new URL(
+    'file://' + path.resolve(__dirname, '..', 'src', 'components', 'chart-summary.js')
+  );
+  return import(url.href);
+}
+
+const SERIES = [
+  { time: '2026-01-01', value: 2000 },
+  { time: '2026-02-01', value: 2100 },
+  { time: '2026-03-01', value: 1950 },
+  { time: '2026-04-01', value: 2050 },
+];
+
+describe('computeSeriesSummary()', () => {
+  test('returns null for non-arrays and series shorter than 2 valid points', async () => {
+    const { computeSeriesSummary } = await loadChartSummary();
+    assert.equal(computeSeriesSummary(null), null);
+    assert.equal(computeSeriesSummary(undefined), null);
+    assert.equal(computeSeriesSummary([]), null);
+    assert.equal(computeSeriesSummary([{ time: '2026-01-01', value: 2000 }]), null);
+    // Two points but only one valid → still null
+    assert.equal(
+      computeSeriesSummary([
+        { time: '2026-01-01', value: 2000 },
+        { time: '2026-01-02', value: 0 },
+      ]),
+      null
+    );
+  });
+
+  test('computes change, percentage, high and low from first→last valid points', async () => {
+    const { computeSeriesSummary } = await loadChartSummary();
+    const s = computeSeriesSummary(SERIES);
+    assert.ok(s);
+    assert.equal(s.points, 4);
+    assert.equal(s.firstValue, 2000);
+    assert.equal(s.lastValue, 2050);
+    assert.equal(s.change, 50);
+    assert.ok(Math.abs(s.pctChange - 2.5) < 1e-9);
+    assert.equal(s.high, 2100);
+    assert.equal(s.low, 1950);
+    assert.equal(s.firstDate.toISOString().slice(0, 10), '2026-01-01');
+    assert.equal(s.lastDate.toISOString().slice(0, 10), '2026-04-01');
+  });
+
+  test('accepts unix-second times (short-range snapshot format)', async () => {
+    const { computeSeriesSummary } = await loadChartSummary();
+    const t0 = Math.floor(Date.UTC(2026, 0, 1) / 1000);
+    const s = computeSeriesSummary([
+      { time: t0, value: 2400 },
+      { time: t0 + 90, value: 2410 },
+      { time: t0 + 180, value: 2405 },
+    ]);
+    assert.ok(s);
+    assert.equal(s.points, 3);
+    assert.equal(s.change, 5);
+    assert.equal(s.high, 2410);
+    assert.equal(s.firstDate.getTime(), t0 * 1000);
+  });
+
+  test('filters out invalid points instead of corrupting the stats', async () => {
+    const { computeSeriesSummary } = await loadChartSummary();
+    const s = computeSeriesSummary([
+      { time: '2026-01-01', value: 2000 },
+      { time: 'not-a-date', value: 5000 }, // bad time → dropped
+      { time: '2026-01-02', value: NaN }, // NaN → dropped
+      { time: '2026-01-03', value: -10 }, // non-positive → dropped
+      null, // junk entry → dropped
+      { time: '2026-01-04', value: 2020 },
+    ]);
+    assert.ok(s);
+    assert.equal(s.points, 2);
+    assert.equal(s.change, 20);
+    assert.equal(s.high, 2020);
+    assert.equal(s.low, 2000);
+  });
+
+  test('negative movement produces negative change and pctChange', async () => {
+    const { computeSeriesSummary } = await loadChartSummary();
+    const s = computeSeriesSummary([
+      { time: '2026-01-01', value: 2000 },
+      { time: '2026-01-02', value: 1900 },
+    ]);
+    assert.ok(s);
+    assert.equal(s.change, -100);
+    assert.ok(s.pctChange < 0);
+  });
+
+  test('flags intraday when endpoint times are numeric, not for date strings', async () => {
+    const { computeSeriesSummary } = await loadChartSummary();
+    const t0 = Math.floor(Date.UTC(2026, 0, 1) / 1000);
+    assert.equal(
+      computeSeriesSummary([
+        { time: t0, value: 2400 },
+        { time: t0 + 90, value: 2410 },
+      ]).intraday,
+      true
+    );
+    assert.equal(computeSeriesSummary(SERIES).intraday, false);
+  });
+});
+
+describe('formatChartSummaryText()', () => {
+  test('English summary contains direction, values, and period dates', async () => {
+    const { computeSeriesSummary, formatChartSummaryText } = await loadChartSummary();
+    const text = formatChartSummaryText(computeSeriesSummary(SERIES), 'en', {
+      unitKey: 'chart.summary.unitUsdOz',
+    });
+    assert.ok(text.startsWith('Chart data summary:'), text);
+    assert.ok(text.includes(' up '), text);
+    assert.ok(text.includes('2,050.00'), text); // latest, 2dp en grouping
+    assert.ok(text.includes('2,100.00'), text); // high
+    assert.ok(text.includes('1,950.00'), text); // low
+    assert.ok(text.includes('2026'), text); // period dates present
+    assert.ok(text.includes('%'), text);
+    assert.ok(text.includes('troy ounce'), text); // unit disclosure
+  });
+
+  test('omits the unit sentence when no unitKey is given (custom series)', async () => {
+    const { computeSeriesSummary, formatChartSummaryText } = await loadChartSummary();
+    const text = formatChartSummaryText(computeSeriesSummary(SERIES), 'en');
+    assert.ok(text.startsWith('Chart data summary:'), text);
+    // A custom-injected series may be AED/gram etc. — the summary must not
+    // claim a unit the module cannot verify.
+    assert.ok(!text.includes('troy ounce'), text);
+    assert.ok(!text.includes('USD per'), text);
+  });
+
+  test('downward series uses the "down" direction word', async () => {
+    const { computeSeriesSummary, formatChartSummaryText } = await loadChartSummary();
+    const text = formatChartSummaryText(
+      computeSeriesSummary([
+        { time: '2026-01-01', value: 2000 },
+        { time: '2026-01-02', value: 1900 },
+      ]),
+      'en'
+    );
+    assert.ok(text.includes(' down '), text);
+    assert.ok(!text.includes(' up '), text);
+  });
+
+  test('Arabic summary uses Arabic template and direction word', async () => {
+    const { computeSeriesSummary, formatChartSummaryText } = await loadChartSummary();
+    const text = formatChartSummaryText(computeSeriesSummary(SERIES), 'ar', {
+      unitKey: 'chart.summary.unitUsdOz',
+    });
+    assert.ok(text.includes('ملخص بيانات الرسم البياني'), text);
+    assert.ok(text.includes('صعوداً'), text);
+    assert.ok(text.includes('أوقية تروي'), text); // repo's established troy-ounce term
+  });
+
+  test('a visually-flat series is announced as unchanged, not "up by 0.00"', async () => {
+    const { computeSeriesSummary, formatChartSummaryText } = await loadChartSummary();
+    const flat = computeSeriesSummary([
+      { time: '2026-01-01', value: 2000 },
+      { time: '2026-01-02', value: 2000.001 }, // displays as 0.00 change
+    ]);
+    const en = formatChartSummaryText(flat, 'en');
+    assert.ok(en.includes('effectively unchanged'), en);
+    assert.ok(!en.includes(' up '), en);
+    const ar = formatChartSummaryText(flat, 'ar');
+    assert.ok(ar.includes('دون تغيير'), ar);
+    assert.ok(!ar.includes('صعوداً'), ar);
+  });
+
+  test('null summary yields the explicit no-data sentence in both languages', async () => {
+    const { formatChartSummaryText } = await loadChartSummary();
+    assert.equal(
+      formatChartSummaryText(null, 'en'),
+      'No chart data is available for this range yet.'
+    );
+    assert.equal(
+      formatChartSummaryText(null, 'ar'),
+      'لا تتوفر بيانات للرسم البياني في هذا النطاق بعد.'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the **shared financial chart system** workstream: the canvas chart's data gets a real text equivalent, the time axis localizes in Arabic, and `GoldChart` gains a proper lifecycle — for both consumers (tracker + home) at once. **4 source files + tests, +~400 lines. No pricing logic touched; the tracker engine is untouched.**

## User problem

- The Lightweight-Charts canvas was **invisible to assistive technology**: page wrappers carry a label, but the DATA (trend, change, high/low) had no text equivalent anywhere.
- Arabic users got **English-formatted axis dates** (no `localization` was passed to the chart).
- `setLang()` was a stored-only no-op, and the chart leaked its observers with no `destroy()`.

## What changed

- **New `src/components/chart-summary.js`** — `computeSeriesSummary()` derives points/change/%/high/low from the **exact deduped array handed to `series.setData()`** (no second calculation path); `updateChartSummary()` maintains a visually-hidden `.sr-only` paragraph (correct `lang`/`dir`) inside the chart container. Deliberately **not** a live region (no announcement spam) and no `role=img` (the chart area contains interactive content).
- **`GoldChart`** — passes `localization.locale` (`ar-AE`/`en-AE`, mirroring formatter.js conventions; price digits stay Latin per `formatPrice()` sitewide); refreshes the summary on every render **including the no-data path and the `addPoint()` incremental path**; working `setLang()` (re-localizes + re-renders); `destroy()` disconnects both observers.
- **`home.js`** — the in-page language toggle now calls `_homeChart?.setLang(lang)` (was: chart kept the old language after a switch — found by adversarial review).
- **Trust hardening:** the "Values in USD per troy ounce" sentence is a separate key that GoldChart appends **only for its own USD/oz data paths** — a future `setCustomData()` series in another unit/currency gets no unit claim (verified: `setCustomData` has zero callers today).
- 6 new translation keys EN+AR (flat-series variant included; AR count phrase reworded to sidestep 3–10 plural agreement; the repo's established أوقية تروي term).

## Adversarial review (2 reviewers, both "ship-with-fixes" — all CONFIRMED findings fixed)

| Finding | Status |
| --- | --- |
| Unit sentence could lie for future custom series (major) | ✅ fixed via `unitKey` suppression |
| Home lang toggle never re-localized the chart (major, confirmed) | ✅ fixed in `home.js` |
| `addPoint()` incremental path left SR summary stale (confirmed) | ✅ fixed |
| Intraday dates UTC-pinned vs local axis (confirmed) | ✅ fixed (`intraday` flag → local time) |
| Flat series announced as "up by 0.00" (confirmed) | ✅ fixed (`textFlat` variant) |
| AR plural agreement for 3–10 points (confirmed) | ✅ fixed (reworded) |
| `destroy()` lands without a caller | 📝 accepted: foundation API for the next slice (tracker/home re-mount wiring); documented here |
| No-data path: SR sentence + visible fallback both announce (redundant but consistent) | 📝 accepted: staleness would be worse than redundancy; unifying the pre-existing hardcoded fallback strings into translations.js is queued for slice 2 |

## Verification (exact results, worktree rebased on `main` @ `a452b21`)

- `npm run lint` ✅ · `npm run validate` ✅ · `npm test` → **1630/1630, 0 fail** (12 new) · `npm run build` ✅
- **Browser (built dist, chromium), post-final-code rebuild:** tracker EN → "Chart data summary: from 1 Aug 2024 to 1 Aug 2025, 13 data points. The reference price moved up by 975.00 (39.16%)… Values in USD per troy ounce." · tracker AR → full Arabic, `lang=ar dir=rtl`, localized month names (أغسطس), unit sentence present. Summary updates live on a real UI range-switch; honest no-data sentence when the series is empty.
- Home-chart non-mount in the headless sandbox is **pre-existing** (identical on unmodified baseline) and unrelated to this diff.

## Performance

No new dependencies; `chart-summary.js` rides in the existing lazy chart chunk (verified in the built chunk graph — summary code appears inside `chart-*.js`, loaded only when a chart mounts). Summary regeneration is O(n) over already-rendered points, at most once per render/90s tick.

## Risks / rollback

- Additive presentation-layer change; pricing/freshness logic untouched. Rollback = revert the single commit.
- Known limitation (slice 2): `_showFallback()`'s pre-existing hardcoded EN/AR strings should migrate to `translations.js`; tracker's SVG fallback chart + heatmap RTL tooltip fixes are queued as the next chart-system slices (audit findings A-2/A-5).

## Gold provider bakeoff checklist

N/A — no provider adapters, bakeoff scripts, X guard, or price workflows touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer a11a/i18n only; no pricing or fetch logic. Summary text is derived from displayed data with conservative unit labeling for custom series.
> 
> **Overview**
> Canvas **Lightweight Charts** now expose a **screen-reader text equivalent** of the plotted series: a new `chart-summary` module derives stats from the same points passed to `setData()`, writes a visually hidden `.sr-only` paragraph (not a live region), and adds EN/AR copy including flat-series and optional USD/oz disclosure only for built-in gold data paths.
> 
> **`GoldChart`** wires that summary on full render, no-data, and short-range `addPoint()` updates; sets chart `localization.locale` to `ar-AE` / `en-AE`; makes **`setLang()`** re-apply locale and re-render; stores **`ResizeObserver`** on the instance; and adds **`destroy()`** to disconnect observers and remove the chart. **Home** language toggle now calls **`_homeChart?.setLang(lang)`** so the chart matches the page language.
> 
> Unit tests cover `computeSeriesSummary` and `formatChartSummaryText`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a449d2870bb875346b88ed5b670355b49649e8b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->