### PR TITLE
fix(tracker): mobile karat-ladder columns were unreachable — restore scroll, stop grid blowout

### DIFF
--- a/styles/pages/tracker-pro.css
+++ b/styles/pages/tracker-pro.css
@@ -3417,7 +3417,10 @@ td.tracker-chg-flat {
   .tracker-main-grid,
   .tracker-utility-grid,
   .tracker-two-up {
-    grid-template-columns: 1fr;
+    /* minmax(0, 1fr), not bare 1fr: a bare 1fr track is minmax(auto, 1fr),
+       so a wide child (the 480px-min karat table) blows the single column
+       out past the viewport and its content becomes unreachable. */
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .tracker-watchlist-grid {
@@ -3504,7 +3507,7 @@ td.tracker-chg-flat {
   }
 
   .tracker-main-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .tracker-panel-side {
@@ -4504,7 +4507,13 @@ td.tracker-chg-flat {
 .tracker-ladder-table-wrap {
   border-radius: var(--radius-lg);
   border: 1.5px solid var(--border-subtle);
-  overflow: hidden;
+
+  /* overflow-x: auto (from the shared scroll rule above) must survive here:
+     `overflow: hidden` made the 480px-min-width karat table unreachable at
+     mobile widths — the vs-24K / day-change columns were clipped with no
+     scroll path. Corner rounding still clips: auto clips to the padding box
+     exactly like hidden. */
+  overflow-y: hidden;
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 50%);
 }
 

--- a/tests/e2e/tracker-karat-ladder-scroll.spec.js
+++ b/tests/e2e/tracker-karat-ladder-scroll.spec.js
@@ -1,0 +1,61 @@
+const { test, expect } = require('@playwright/test');
+
+// Regression guard for the mobile karat-ladder clip.
+//
+// Bug: `.tracker-ladder-table-wrap` declared `overflow: auto` in the shared
+// scroll rule but a later block overrode it with `overflow: hidden`, while the
+// mobile single-column grid used a bare `1fr` track (= minmax(auto, 1fr)), so
+// the 480px-min-width karat table blew the column out past the viewport. Net
+// effect at 390px: the vs-24K / day-change columns were clipped with NO scroll
+// path anywhere in the ancestor chain — data silently unreachable, invisible
+// to document-overflow checks because the page-level clip swallowed it.
+//
+// This spec locks the fix in both languages: the wrap fits the viewport, is
+// horizontally scrollable, and the last column is actually reachable.
+
+const MOBILE = { width: 390, height: 844 };
+
+test.describe('Tracker karat ladder @390px', () => {
+  test.use({ viewport: MOBILE });
+
+  for (const lang of ['en', 'ar']) {
+    test(`karat columns reachable via wrap scroll [${lang}]`, async ({ page }) => {
+      await page.goto(`/tracker.html${lang === 'ar' ? '?lang=ar' : ''}`);
+      await page.waitForSelector('body[data-tracker-shell-ready="true"]', { timeout: 15000 });
+      if (lang === 'ar') {
+        await page.waitForFunction(() => document.documentElement.dir === 'rtl', undefined, {
+          timeout: 10000,
+        });
+      }
+
+      const state = await page.evaluate(() => {
+        const wrap = document.querySelector('.tracker-ladder-table-wrap');
+        const table = wrap?.querySelector('table');
+        if (!wrap || !table) return { found: false };
+        const cs = getComputedStyle(wrap);
+        const wrapRect = wrap.getBoundingClientRect();
+        const cells = table.querySelectorAll('tr:first-child th, tr:first-child td');
+        const lastCell = cells[cells.length - 1];
+        // Scroll the wrap fully toward the overflow side (RTL scrolls negative).
+        wrap.scrollLeft =
+          document.documentElement.dir === 'rtl' ? -wrap.scrollWidth : wrap.scrollWidth;
+        const after = lastCell.getBoundingClientRect();
+        return {
+          found: true,
+          overflowX: cs.overflowX,
+          wrapFitsViewport: wrapRect.left >= -1 && wrapRect.right <= window.innerWidth + 1,
+          wrapScrollable: wrap.scrollWidth > wrap.clientWidth,
+          lastColReachable: after.left >= -1 && after.right <= window.innerWidth + 1,
+          docOverflow: document.documentElement.scrollWidth - window.innerWidth,
+        };
+      });
+
+      expect(state.found, 'ladder table present').toBeTruthy();
+      expect(state.overflowX, 'wrap must scroll, not clip').toBe('auto');
+      expect(state.wrapFitsViewport, 'wrap itself must not exceed the viewport').toBeTruthy();
+      expect(state.wrapScrollable, 'table wider than wrap → wrap scrolls').toBeTruthy();
+      expect(state.lastColReachable, 'last karat column reachable after scroll').toBeTruthy();
+      expect(state.docOverflow, 'no document-level overflow').toBeLessThanOrEqual(1);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes a **browser-confirmed mobile data-access defect** on the flagship tracker: at 390px the karat ladder's `vs-24K` / day-change columns were silently clipped with **no scroll path anywhere** — invisible to document-overflow checks because the page-level clip swallowed it. CSS-only fix + an EN/AR regression spec. Found by the campaign's table audit (Agent B), independently reproduced twice before fixing.

## Root cause (two stacked bugs)

1. `.tracker-ladder-table-wrap` declares `overflow: auto` in the shared scroll rule (`tracker-pro.css:2015`) but a later block overrode it with `overflow: hidden` (`:4507`) — the wrap could never scroll.
2. The mobile single-column grid used bare `1fr` tracks (= `minmax(auto, 1fr)`), so the 480px-min-width table blew the column out to **514px at a 390px viewport**; every ancestor was `overflow-x: visible` under the page-level clip → `lastColReachable: false`.

## Fix

- Drop the `overflow: hidden` override (keep `overflow-y: hidden`; corner rounding still clips — `auto` clips to the padding box exactly like `hidden`).
- Mobile tracks: `1fr` → `minmax(0, 1fr)` (the shared ≤1100px rule also covers `tracker-utility-grid`/`two-up`, which gain the same protection).

## Proof

| | Before (unmodified main) | After |
| --- | --- | --- |
| wrap `overflow-x` | `hidden` | `auto` |
| wrap vs viewport | 480px @ 390px (clipped) | fits viewport |
| last karat column | **unreachable** | reachable after wrap scroll |
| document overflow | 0 (deceptively) | 0 |

- Verified EN **and** AR (RTL scroll direction handled: `scrollLeft` negative in RTL).
- New `tests/e2e/tracker-karat-ladder-scroll.spec.js`: **4/4 across `--repeat-each=2`** (chromium vs built dist). Rides the existing "Playwright smoke" CI job.
- `npm run lint` ✅ · `stylelint` ✅ · `npm run validate` ✅ · `npm test` **1618/1618** ✅ · `npm run build` ✅

## Risks / rollback

CSS-only (2 rules) + one test file; no JS or pricing surface touched. `minmax(0,1fr)` is strictly safer than `1fr` for single-column stacks. Rollback = revert one commit.

## Gold provider bakeoff checklist

N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout/overflow tweaks plus a new e2e spec; no JS or pricing logic changes. `minmax(0, 1fr)` is a standard fix for grid min-content blowout.
> 
> **Overview**
> Fixes a **mobile data-access bug** on the tracker karat ladder (~390px): **vs-24K / day-change columns were clipped with no way to scroll**, so pricing columns looked fine in overflow checks but were unreachable in the UI.
> 
> **CSS (`tracker-pro.css`):** Single-column breakpoints (≤1100px and ≤768px for `tracker-main-grid`) now use **`minmax(0, 1fr)`** instead of bare **`1fr`**, so a wide table no longer expands the grid past the viewport. On **`.tracker-ladder-table-wrap`**, the later **`overflow: hidden`** override is removed in favor of **`overflow-y: hidden`**, preserving horizontal **`overflow-x: auto`** from the shared scroll rule so the wrap can scroll.
> 
> **Tests:** Adds **`tests/e2e/tracker-karat-ladder-scroll.spec.js`** — Playwright checks at 390px for **EN and AR** (RTL `scrollLeft`) that the wrap fits the viewport, scrolls horizontally, and the last column is reachable without document-level overflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00e4f48f6697e6e838d9852bd93ddf0a216597a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->