### PR TITLE
feat(home): restore the @GoldTickerLive X follow banner

### DIFF
--- a/styles/pages/home-redesign.css
+++ b/styles/pages/home-redesign.css
@@ -350,11 +350,9 @@
   }
 }
 
-/* Retire the redundant X-follow strip on the homepage (this file loads on home
-   only) — the approved nav has one persistent price pill and no top strips. */
-.x-follow-banner {
-  display: none;
-}
+/* X-follow banner: restored by owner request (2026-07-11) — supersedes the
+   earlier "no top strips" retirement. Markup/assets/strings never left
+   index.html, assets/social/, and translations.js; only this hide rule did. */
 
 /* ═══ Audience-routing band — "What brings you in today?" ═══════════════════ */
 .home-routing--gtl {


### PR DESCRIPTION
## Summary

Restores the **X (Twitter) follow banner** on the homepage, by owner request. The banner (markup in `index.html`, webp assets in `assets/social/`, EN/AR strings in `translations.js`, styles in `home.css`) was **fully intact on `main`** — it was hidden by a single "retire the strip" rule added in `home-redesign.css` during a later homepage pass. This PR removes that one hide rule (net diff: −4 lines CSS, +3 lines comment).

## What the restored banner is

- 56px strip at the very top of the homepage, above the header, linking to **https://x.com/GoldTickerLive** (`rel="noopener noreferrer"`, opens in new tab with that disclosed in the aria-label).
- Keeps the **freshness-honest wording** from its original review cycle: "Gold-price updates and alerts on X" (deliberately **not** "Live" — the X automation posts hourly) / AR "تحديثات وتنبيهات أسعار الذهب على X".
- RTL-aware: mirrored gradient, تابعنا CTA with the arrow pointing the correct direction.

## Design-decision note

The hide rule's rationale was "the approved nav has one persistent price pill and no top strips." The owner has explicitly reversed that ("add back the Twitter banner"); the replacing comment in `home-redesign.css` records the supersession so future passes don't silently re-retire it.

## Verification

- **Browser (built dist, chromium), EN + AR × 1280px + 390px:** banner visible, image loads (5.8KB webp @960w, 15KB @1920w, `srcset`), correct href + localized aria-label and copy, RTL mirroring correct, **0 document overflow** at 390px. Screenshots verified visually in both languages.
- `npm run lint` ✅ · `stylelint` ✅ · `npm run validate` ✅ · `npm test` **1623/1623** ✅ · `npm run build` ✅

## Risks / rollback

One CSS rule removed on a home-only stylesheet; no JS, markup, pricing, or i18n changes. The existing RTL/mobile overflow CI specs cover the homepage at 390px. Rollback = revert one commit.

## Gold provider bakeoff checklist

N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single stylesheet change on the homepage with no JS, markup, or pricing logic touched.
> 
> **Overview**
> **Restores the homepage X follow strip** by deleting the `display: none` override on `.x-follow-banner` in `home-redesign.css`. Markup, assets, and copy were unchanged on `main`; only that home-only hide rule blocked the banner.
> 
> The new comment documents **owner-requested supersession** of the earlier “no top strips” decision (nav price pill rationale), so a future redesign pass is less likely to hide it again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78d1c013356c4d0f9c058e992194a8fe03eb30eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->