### PR TITLE
fix(heatmap): RTL tooltip mirrored 430px away from the pointer — position with physical left

### DIFF
--- a/src/pages/heatmap.js
+++ b/src/pages/heatmap.js
@@ -523,8 +523,12 @@ function showTooltipFor(target, pointerEvent) {
   const maxX = wrapRect.width - tipRect.width - 4;
   const clampedX = Math.max(4, Math.min(x + 12, maxX));
   const clampedY = Math.max(4, Math.min(y - tipRect.height - 10, wrapRect.height - tipRect.height));
-  tip.style.insetInlineStart = `${clampedX}px`;
-  tip.style.insetBlockStart = `${clampedY}px`;
+  // x/y are physical offsets from the wrapper's top-left corner, so position with
+  // physical left/top (matches src/tracker/chart.js). Using inset-inline-start here
+  // would resolve to the RIGHT edge under dir="rtl" and mirror the tooltip away
+  // from the pointer.
+  tip.style.left = `${clampedX}px`;
+  tip.style.top = `${clampedY}px`;
 }
 
 function hideTooltip() {

--- a/tests/e2e/heatmap-rtl-tooltip.spec.js
+++ b/tests/e2e/heatmap-rtl-tooltip.spec.js
@@ -1,0 +1,56 @@
+// Heatmap tooltip must track the pointer in BOTH directions (ltr + rtl).
+//
+// Regression guard: showTooltipFor() computes x as a physical offset from the
+// wrapper's LEFT edge (clientX - wrapRect.left). It must therefore be applied
+// with physical `left`, not `inset-inline-start` — under dir="rtl" the logical
+// property resolves to the RIGHT edge and mirrors the tooltip across the map
+// (observed pre-fix: ~430px away from the pointer at 1280px wide).
+const { test, expect } = require('@playwright/test');
+
+// The mirrored-bug displacement is hundreds of px; the correct offset is ~+12px
+// (clamped near edges). 80px keeps the assertion meaningful without flaking on
+// clamp/subpixel differences.
+const NEAR_POINTER_PX = 80;
+
+for (const { lang, dir } of [
+  { lang: 'ar', dir: 'rtl' },
+  { lang: 'en', dir: 'ltr' },
+]) {
+  test(`tooltip appears near the pointer (${lang}, dir=${dir})`, async ({ page, baseURL }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`${baseURL || ''}/heatmap.html?lang=${lang}`, { waitUntil: 'load' });
+
+    // Deterministic readiness: country regions carry data-code once the map renders.
+    const region = page.locator('#heatmap-map-wrap svg [data-code="SA"]').first();
+    await region.waitFor({ state: 'visible', timeout: 15000 });
+    await expect(page.locator('html')).toHaveAttribute('dir', dir);
+
+    const box = await region.boundingBox();
+    expect(box, 'SA region must have a bounding box').toBeTruthy();
+    const px = box.x + box.width / 2;
+    const py = box.y + box.height / 2;
+
+    // Synthetic pointer movement fires the svg's pointermove handler.
+    await page.mouse.move(px - 5, py - 5);
+    await page.mouse.move(px, py);
+
+    const tip = page.locator('#heatmap-tooltip');
+    await expect(tip).toBeVisible();
+
+    const tipBox = await tip.boundingBox();
+    expect(tipBox, 'tooltip must have a bounding box').toBeTruthy();
+
+    // Tooltip's left edge sits at pointer + ~12px (clamped inside the wrapper).
+    // A mirrored (RTL-buggy) tooltip lands hundreds of px away.
+    expect(
+      Math.abs(tipBox.x - px),
+      `tooltip left edge (${tipBox.x.toFixed(1)}) must be near pointer x (${px.toFixed(1)})`
+    ).toBeLessThanOrEqual(NEAR_POINTER_PX);
+
+    // Positioning must never create horizontal document overflow.
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    );
+    expect(overflow, 'no horizontal document overflow').toBeLessThanOrEqual(0);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes a **measured RTL defect** on the heatmap: under `?lang=ar` (`dir="rtl"`) the country tooltip mirrored across the map — **430px away from the pointer** — because `showTooltipFor()` computed a physical left-edge offset (`clientX - wrapRect.left`) but assigned it via `inset-inline-start`, which resolves to the **right** edge in RTL. Found by the campaign chart audit; implemented by an isolated agent; independently re-verified by the coordinator before opening this PR.

## Fix (2 lines + comment)

Assign `tip.style.left` / `tip.style.top` (physical), matching the pointer-following tooltip convention already used in `src/tracker/chart.js`. The existing clamp math was already in physical left-edge space, so it stays correct in both directions; the keyboard-focus tooltip path shares the same coordinates and is fixed by the same change. CSS sets no competing offsets (verified — `.heatmap-tooltip` has only `position: absolute`).

## Proof

| | AR (`dir=rtl`) before | AR after | EN after |
| --- | --- | --- | --- |
| pointerX → tooltip.x | 767 → **336.7** (dx −430.4, mirrored) | 767 → 780 (dx **+13**) | 767 → 780 (dx +13) |
| document overflow | — | 0px | 0px |

- New deterministic regression spec `tests/e2e/heatmap-rtl-tooltip.spec.js` (synthetic pointer events, no arbitrary sleeps, asserts tooltip within 80px of pointer vs the ~430px bug displacement): **4/4 across `--repeat-each=2`**, re-run independently by the coordinator.
- Full gates re-run on this branch: `lint` ✅ · `stylelint` ✅ · `validate` ✅ · `npm test` **1623/1623** ✅ · `build` ✅.

## Risks / rollback

Low — tooltip now anchors pointer-right (+12px) in both directions, same as the tracker tooltip. If a future design pass wants inline-start-side placement in RTL, that's an enhancement, not a regression. Rollback = revert one commit.

## Gold provider bakeoff checklist

N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated tooltip positioning change with no auth, data, or pricing logic; behavior in LTR should match the prior intent once logical inset is corrected.
> 
> **Overview**
> Fixes the heatmap country tooltip **mirroring ~430px from the pointer** when Arabic sets `dir="rtl"`. `showTooltipFor()` already computes **physical** offsets from the map wrapper’s left edge, but those values were applied via `inset-inline-start` / `inset-block-start`, which in RTL bind to the **right** edge instead of left.
> 
> The tooltip now uses **`left` and `top`**, aligned with the tracker chart tooltip pattern. Existing clamp math is unchanged and applies to pointer hover and keyboard focus.
> 
> Adds **`tests/e2e/heatmap-rtl-tooltip.spec.js`** to assert the tooltip stays within 80px of the pointer for both `ar`/RTL and `en`/LTR, and that horizontal document overflow does not occur.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d225e38cc5c3fa99f508f38ba88fd07846b153a6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->