### PR TITLE
fix(portfolio): honest per-cause messaging on the "Vs. cost" card

### DIFF
--- a/src/config/translations.js
+++ b/src/config/translations.js
@@ -130,6 +130,12 @@ export const TRANSLATIONS = {
     'nav.glossary': 'Glossary',
     'nav.market': 'How Gold Is Priced',
     'nav.portfolio': 'Portfolio',
+    /* ── Portfolio · "Vs. cost" card null-gain causes ── */
+    'portfolio.gainAwaitingPrice':
+      'Waiting for live prices — this appears once today’s reference price loads.',
+    'portfolio.gainCostCurrencyDiffers':
+      'Costs were entered in a different currency — switch the display currency to match them to compare.',
+    'portfolio.gainAddCosts': 'Add purchase costs to see this',
     'nav.dubai': 'Dubai & UAE Gold Price',
     'nav.country': 'Country',
     'breadcrumbs.ariaLabel': 'Breadcrumb',
@@ -1591,6 +1597,12 @@ export const TRANSLATIONS = {
     'nav.glossary': 'مسرد المصطلحات',
     'nav.market': 'كيف يُسعَّر الذهب',
     'nav.portfolio': 'المحفظة',
+    /* ── Portfolio · "Vs. cost" card null-gain causes ── */
+    'portfolio.gainAwaitingPrice':
+      'بانتظار الأسعار الحية — تظهر المقارنة فور تحميل السعر المرجعي لليوم.',
+    'portfolio.gainCostCurrencyDiffers':
+      'أُدخلت التكاليف بعملة مختلفة — بدّل عملة العرض لتطابقها حتى تظهر المقارنة.',
+    'portfolio.gainAddCosts': 'أضف تكاليف الشراء لعرض هذه المقارنة',
     'nav.dubai': 'سعر الذهب في دبي والإمارات',
     'nav.country': 'الدولة',
     'breadcrumbs.ariaLabel': 'مسار التنقل',

--- a/src/pages/portfolio.js
+++ b/src/pages/portfolio.js
@@ -15,7 +15,7 @@
  * this file wires it to storage, live data and the shared shell.
  */
 
-import { CONSTANTS, COUNTRIES, KARATS } from '../config/index.js';
+import { CONSTANTS, COUNTRIES, KARATS, TRANSLATIONS } from '../config/index.js';
 import * as api from '../lib/api.js';
 import * as cache from '../lib/cache.js';
 import { getCanonicalSpot } from '../lib/spot-resolver.js';
@@ -36,6 +36,7 @@ import {
   parsePortfolio,
   serializePortfolio,
   summarizePortfolio,
+  gainUnavailableReason,
   computeTimeline,
   holdingsToCsv,
 } from './portfolio/portfolio-core.js';
@@ -85,7 +86,6 @@ const T = {
     cardGain: 'Vs. cost',
     cardGainHint: 'Against today’s reference value',
     cardGainMixed: 'Not totalled across different cost currencies',
-    cardGainNoCost: 'Add costs to see this',
     chartTitle: 'Portfolio value over time',
     chartNote:
       'Reference value replayed from daily price snapshots saved by this browser — days without a visit have no snapshot.',
@@ -168,7 +168,6 @@ const T = {
     cardGain: 'مقارنة بالتكلفة',
     cardGainHint: 'مقابل القيمة المرجعية لليوم',
     cardGainMixed: 'لا يُجمع عبر عملات تكلفة مختلفة',
-    cardGainNoCost: 'أضف التكاليف لعرض هذا الرقم',
     chartTitle: 'قيمة المحفظة عبر الوقت',
     chartNote:
       'قيمة مرجعية مُعادة الحساب من لقطات الأسعار اليومية المحفوظة في هذا المتصفح — الأيام بلا زيارة لا تحتوي لقطة.',
@@ -248,6 +247,11 @@ const STATE = {
 
 function t() {
   return T[STATE.lang] || T.en;
+}
+/** Shared-dictionary lookup (src/config/translations.js), EN fallback. */
+function tr(key) {
+  const dict = TRANSLATIONS[STATE.lang] || TRANSLATIONS.en;
+  return dict[key] || TRANSLATIONS.en[key] || key;
 }
 function todayIso() {
   return new Date().toISOString().slice(0, 10);
@@ -523,9 +527,18 @@ function renderSummary(summary) {
       )
     );
   } else {
-    host.appendChild(
-      card(dict.cardGain, [summary.mixedCostCurrencies ? dict.cardGainMixed : dict.cardGainNoCost])
-    );
+    // One card, three unrelated causes — name the real one instead of always
+    // claiming costs are missing (honest-freshness rule).
+    const reason = gainUnavailableReason(summary, currency);
+    const message =
+      reason === 'mixed-cost-currencies'
+        ? dict.cardGainMixed
+        : reason === 'cost-currency-differs'
+          ? tr('portfolio.gainCostCurrencyDiffers')
+          : reason === 'price-pending'
+            ? tr('portfolio.gainAwaitingPrice')
+            : tr('portfolio.gainAddCosts');
+    host.appendChild(card(dict.cardGain, [message]));
   }
 }
 

--- a/src/pages/portfolio/portfolio-core.js
+++ b/src/pages/portfolio/portfolio-core.js
@@ -249,6 +249,39 @@ export function summarizePortfolio(holdings, spotUsdPerOz, rates, displayCurrenc
 }
 
 /**
+ * Why is the portfolio-level "vs. cost" figure unavailable? Distinguishes the
+ * unrelated causes that {@link summarizePortfolio} collapses into `gain: null`
+ * so the UI can explain honestly instead of always saying "add costs":
+ *
+ *   'mixed-cost-currencies' — costs span several currencies; never totalled.
+ *   'no-cost'               — at least one holding has no purchase cost.
+ *   'cost-currency-differs' — costs are in one currency, but not the display
+ *                             currency; historic costs are never FX-converted.
+ *   'price-pending'         — the live reference price / FX rate has not
+ *                             loaded yet, so there is no current value.
+ *
+ * Pure classification only — no valuation logic is repeated or changed.
+ *
+ * @param {object} summary  Result of {@link summarizePortfolio}.
+ * @param {string} displayCurrency
+ * @returns {string|null}  A cause code, or `null` when a gain figure exists
+ *   (or there is nothing to explain).
+ */
+export function gainUnavailableReason(summary, displayCurrency) {
+  if (!summary || summary.gain || !summary.count) return null;
+  if (summary.mixedCostCurrencies) return 'mixed-cost-currencies';
+  if (summary.hasMissingCost) return 'no-cost';
+  const costCurrencies = Object.keys(summary.costByCurrency || {});
+  if (costCurrencies.length === 1 && costCurrencies[0] !== displayCurrency) {
+    return 'cost-currency-differs';
+  }
+  // Costs are complete and in the display currency — the only remaining
+  // blocker in summarizePortfolio() is `currentDisplay == null` (price/FX
+  // still pending).
+  return 'price-pending';
+}
+
+/**
  * Portfolio reference value over time, replayed against the daily snapshots
  * this browser has saved (`cache.saveHistorySnapshot` — date, XAU/USD price,
  * FX rates). Only holdings already purchased on a snapshot's date count, so

--- a/tests/portfolio-cost-messaging.test.js
+++ b/tests/portfolio-cost-messaging.test.js
@@ -1,0 +1,159 @@
+/**
+ * Tests for the "Vs. cost" card null-gain cause classification
+ * (`gainUnavailableReason` in src/pages/portfolio/portfolio-core.js) and the
+ * EN/AR parity of the three honest strings it maps to.
+ *
+ * Previously one string ("Add costs to see this") covered three unrelated
+ * causes: live price still pending, cost currency differing from the display
+ * currency, and a genuinely missing cost. These tests pin the classification
+ * so the UI can never again claim costs are missing when they are not.
+ *
+ * Follows the tests/formatter-locale.test.js dynamic-import pattern so the
+ * shipped ES modules are exercised directly.
+ */
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+async function loadCore() {
+  const url = new URL(
+    'file://' + path.resolve(__dirname, '..', 'src', 'pages', 'portfolio', 'portfolio-core.js')
+  );
+  return import(url.href);
+}
+
+async function loadTranslations() {
+  const url = new URL(
+    'file://' + path.resolve(__dirname, '..', 'src', 'config', 'translations.js')
+  );
+  return import(url.href);
+}
+
+function holding(overrides = {}) {
+  return {
+    id: 'h1',
+    label: 'Test bangle',
+    weightGrams: 10,
+    karat: '22',
+    purchaseDate: '2026-01-15',
+    costTotal: 1000,
+    costCurrency: 'AED',
+    createdAt: '2026-01-15T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const SPOT = 2400; // USD per troy oz — any positive value; no assertions on math.
+const RATES = {}; // AED and USD resolve without live FX (peg / identity).
+
+describe('gainUnavailableReason()', () => {
+  test('price pending: cost entered + matching currency but no spot price yet', async () => {
+    const { summarizePortfolio, gainUnavailableReason } = await loadCore();
+    const summary = summarizePortfolio([holding()], 0, RATES, 'AED');
+    assert.equal(summary.gain, null);
+    assert.equal(gainUnavailableReason(summary, 'AED'), 'price-pending');
+  });
+
+  test('price pending: spot loaded but display-currency FX rate missing', async () => {
+    const { summarizePortfolio, gainUnavailableReason } = await loadCore();
+    // SAR costs, SAR display, but no SAR rate loaded → currentDisplay is null.
+    const summary = summarizePortfolio(
+      [holding({ costCurrency: 'SAR' })],
+      SPOT,
+      {},
+      'SAR'
+    );
+    assert.equal(summary.gain, null);
+    assert.equal(gainUnavailableReason(summary, 'SAR'), 'price-pending');
+  });
+
+  test('cost currency differs from display currency', async () => {
+    const { summarizePortfolio, gainUnavailableReason } = await loadCore();
+    const summary = summarizePortfolio([holding({ costCurrency: 'USD' })], SPOT, RATES, 'AED');
+    assert.equal(summary.gain, null);
+    assert.equal(summary.mixedCostCurrencies, false);
+    assert.equal(gainUnavailableReason(summary, 'AED'), 'cost-currency-differs');
+  });
+
+  test('currency mismatch wins over pending price (durable cause first)', async () => {
+    const { summarizePortfolio, gainUnavailableReason } = await loadCore();
+    const summary = summarizePortfolio([holding({ costCurrency: 'USD' })], 0, RATES, 'AED');
+    assert.equal(gainUnavailableReason(summary, 'AED'), 'cost-currency-differs');
+  });
+
+  test('genuinely missing cost', async () => {
+    const { summarizePortfolio, gainUnavailableReason } = await loadCore();
+    const summary = summarizePortfolio([holding({ costTotal: 0 })], SPOT, RATES, 'AED');
+    assert.equal(summary.gain, null);
+    assert.equal(gainUnavailableReason(summary, 'AED'), 'no-cost');
+  });
+
+  test('missing cost reported even while price is pending (user action first)', async () => {
+    const { summarizePortfolio, gainUnavailableReason } = await loadCore();
+    const summary = summarizePortfolio([holding({ costTotal: 0 })], 0, RATES, 'AED');
+    assert.equal(gainUnavailableReason(summary, 'AED'), 'no-cost');
+  });
+
+  test('mixed cost currencies keep their dedicated cause', async () => {
+    const { summarizePortfolio, gainUnavailableReason } = await loadCore();
+    const summary = summarizePortfolio(
+      [holding(), holding({ id: 'h2', costCurrency: 'USD' })],
+      SPOT,
+      RATES,
+      'AED'
+    );
+    assert.equal(summary.gain, null);
+    assert.equal(summary.mixedCostCurrencies, true);
+    assert.equal(gainUnavailableReason(summary, 'AED'), 'mixed-cost-currencies');
+  });
+
+  test('returns null when a gain figure exists', async () => {
+    const { summarizePortfolio, gainUnavailableReason } = await loadCore();
+    const summary = summarizePortfolio([holding()], SPOT, RATES, 'AED');
+    assert.ok(summary.gain, 'gain must be computed for the happy path');
+    assert.equal(gainUnavailableReason(summary, 'AED'), null);
+  });
+
+  test('returns null for an empty portfolio (nothing to explain)', async () => {
+    const { summarizePortfolio, gainUnavailableReason } = await loadCore();
+    const summary = summarizePortfolio([], SPOT, RATES, 'AED');
+    assert.equal(gainUnavailableReason(summary, 'AED'), null);
+  });
+});
+
+describe('vs-cost card translations', () => {
+  const KEYS = [
+    'portfolio.gainAwaitingPrice',
+    'portfolio.gainCostCurrencyDiffers',
+    'portfolio.gainAddCosts',
+  ];
+
+  test('EN and AR both define all three cause strings', async () => {
+    const { TRANSLATIONS } = await loadTranslations();
+    for (const lang of ['en', 'ar']) {
+      for (const key of KEYS) {
+        const value = TRANSLATIONS[lang][key];
+        assert.equal(typeof value, 'string', `${lang} ${key} must exist`);
+        assert.ok(value.trim().length > 0, `${lang} ${key} must not be empty`);
+      }
+    }
+  });
+
+  test('the three causes read as three distinct messages in each language', async () => {
+    const { TRANSLATIONS } = await loadTranslations();
+    for (const lang of ['en', 'ar']) {
+      const values = KEYS.map((key) => TRANSLATIONS[lang][key]);
+      assert.equal(new Set(values).size, KEYS.length, `${lang} strings must be distinct`);
+    }
+  });
+
+  test('Arabic strings are actually Arabic', async () => {
+    const { TRANSLATIONS } = await loadTranslations();
+    for (const key of KEYS) {
+      assert.match(TRANSLATIONS.ar[key], /[؀-ۿ]/, `${key} must contain Arabic script`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a **trust/UX defect** found by the campaign's portfolio audit: the "Vs. cost" card said **"Add costs to see this" even when a cost WAS entered** — one string covered three unrelated causes of a null gain. Users who had already entered costs were falsely told to add them. Implemented by an isolated agent; independently re-verified by the coordinator (code review + full gates + browser reproduction) before opening this PR.

## Root cause

`summarizePortfolio()` collapses three unrelated situations into `gain: null`, and the card rendered the same "add costs" string for all of them:
1. live reference price / FX **still loading** (every first paint),
2. costs entered in a **different currency** than the display currency (historic costs are deliberately never FX-converted),
3. genuinely **no cost** entered.

## Fix

- New **pure classifier** `gainUnavailableReason(summary, displayCurrency)` in `portfolio-core.js` — reads only `summarizePortfolio` output, changes **no valuation math** (precedence: mixed-currencies → no-cost → currency-differs → price-pending; the `summary.gain` truthiness check is safe because gain is `null` or an object, never a bare 0 — verified).
- Three honest cause-specific strings, EN+AR (`portfolio.gainAwaitingPrice` / `gainCostCurrencyDiffers` / `gainAddCosts`), added to `translations.js`; rendered via safe-dom text nodes.

## Verification (agent's proof + coordinator's independent re-verification)

- `npm run lint` ✅ · `npm run validate` ✅ · `npm test` → **1635/1635, 0 fail** (12 new cause/precedence/EN-AR tests; existing 16 portfolio-core tests untouched and green) · `npm run build` ✅
- **Coordinator browser repro** (built dist, chromium, correctly-shaped `gtl_portfolio_v1` seed, offline → price pending): EN shows *"Waiting for live prices — this appears once today's reference price loads."*, AR shows *"بانتظار الأسعار الحية…"*; the old misleading string is gone. Agent additionally verified the currency-differs and zero-cost states EN+AR (8/8).

## Notes / risks

- Low risk: no calculation changed; classifier is read-only; strings are additive keys (translations.js region is far from PR #672's chart keys — no textual conflict expected).
- The price-pending string persists if the fetch permanently fails — honest, and the adjacent freshness badge conveys the failure state.
- Known follow-up (queued): portfolio still keeps a local T-dict for older strings; consolidating it into `translations.js` is a separate slice.

## Gold provider bakeoff checklist

N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and a pure classifier only; no portfolio calculations change. Risk is limited to wrong cause ordering or missing translation keys.
> 
> **Overview**
> Fixes a trust issue on the portfolio **Vs. cost** summary card: when gain was null, the UI always said to add costs even when costs were already entered.
> 
> Adds **`gainUnavailableReason`** in `portfolio-core.js`—read-only classification over `summarizePortfolio` output (mixed currencies → missing cost → cost currency ≠ display currency → live price/FX pending). **Valuation math is unchanged.**
> 
> The card now picks one message: existing mixed-currency copy, or new EN/AR keys in `translations.js` (`portfolio.gainAwaitingPrice`, `gainCostCurrencyDiffers`, `gainAddCosts`) via a small `tr()` helper in `portfolio.js`. Local `cardGainNoCost` strings are removed.
> 
> **`tests/portfolio-cost-messaging.test.js`** locks precedence and translation parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de8a84e33157da64a085b306c71bb19605094961. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->