### PR TITLE
fix(tracker): SVG chart tooltip works for touch — pointermove instead of mousemove

### DIFF
--- a/src/tracker/chart.js
+++ b/src/tracker/chart.js
@@ -327,12 +327,15 @@ export function renderChart() {
   }
 
   // Keep the module-level snapshot up to date so the once-registered
-  // mousemove handler always uses the latest rows without re-attaching.
+  // pointermove handler always uses the latest rows without re-attaching.
   _latestChartRows = rows;
 
   if (_el.chartWrap && !_chartListenersAttached) {
     _chartListenersAttached = true;
-    _el.chartWrap.addEventListener('mousemove', (e) => {
+    // pointermove (not mousemove) so touch users can inspect points on the
+    // SVG first-paint chart before GoldChart lazy-loads — same listener
+    // pattern as the heatmap (src/pages/heatmap.js).
+    _el.chartWrap.addEventListener('pointermove', (e) => {
       if (!_el.tooltip || _latestChartRows.length < 2) return;
       const rect = _el.chart.getBoundingClientRect();
       const x = e.clientX - rect.left;
@@ -351,9 +354,17 @@ export function renderChart() {
       tooltip.style.top = '0px';
       tooltip.style.display = 'block';
     });
-    _el.chartWrap.addEventListener('mouseleave', () => {
+    const hideChartTooltip = () => {
       if (_el.tooltip) _el.tooltip.style.display = 'none';
+    };
+    _el.chartWrap.addEventListener('pointerleave', hideChartTooltip);
+    // Touch/pen: the pointer "leaves" by lifting the finger or by the browser
+    // taking over (scroll) — hide in both cases so the tooltip can't stick
+    // around. Mouse keeps hovering through clicks, so it only hides on leave.
+    _el.chartWrap.addEventListener('pointerup', (e) => {
+      if (e.pointerType !== 'mouse') hideChartTooltip();
     });
+    _el.chartWrap.addEventListener('pointercancel', hideChartTooltip);
   }
 
   if (_el.chartStats) {


### PR DESCRIPTION
## Summary

The tracker's first-paint **SVG chart tooltip was mouse-only** (`mousemove`/`mouseleave`), so touch users had no way to inspect chart points before GoldChart lazy-loads — and no way at all if the chart library fails, which is exactly the fallback's purpose. Found by the chart + a11y audits (A-6 / E-medium); re-verified first-hand before fixing.

## Fix (one listener block)

Switch to `pointermove`/`pointerleave` — the same convention the heatmap already uses — plus touch/pen-only `pointerup` and `pointercancel` hiding so a lifted finger or a browser-takeover scroll can't leave a stuck tooltip. Mouse behavior is unchanged: hover shows, click keeps (no flicker), leave hides. Keyboard access remains served by the stats cards + aria-live source label (the chart wrap's existing described-by note).

## Proof (built dist, chromium with `hasTouch`, GoldChart chunk blocked to keep the SVG active, 1Y range for real baseline rows)

| Interaction | Result |
| --- | --- |
| touch `pointermove` | tooltip shows with real provenance: `$2878.00 · 2/1/2025 · LBMA-baseline · monthly` |
| touch `pointerup` | tooltip hides ✅ |
| mouse move / click / leave | shows / **keeps** / hides ✅ |

Gates: `lint` ✅ · `validate` ✅ · `npm test` **1623/1623** ✅ · `build` ✅.

## Honest scope note

Audit E's companion finding (tracker skip-link `#main-content` vs `<main id="tracker-app">`) was **re-verified as not present on current main** — the skip-link already targets `#tracker-app`. Dropped rather than shipped as a no-op.

## Risks / rollback

One event-listener block in the SVG fallback renderer; no data, pricing, or GoldChart path touched. Rollback = revert one commit.

## Gold provider bakeoff checklist

N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single listener block in the SVG fallback chart UI; no pricing, data, or GoldChart paths touched.
> 
> **Overview**
> The tracker’s **SVG first-paint chart** tooltip now uses the **Pointer Events** API instead of mouse-only listeners, so touch and pen users can inspect points before GoldChart loads (and when GoldChart never loads).
> 
> **`mousemove` / `mouseleave`** on the chart wrap become **`pointermove` / `pointerleave`**, aligned with the heatmap. Tooltip content and positioning logic are unchanged. A shared **`hideChartTooltip`** helper hides on leave; **`pointerup`** (non-mouse only) and **`pointercancel`** prevent stuck tooltips after lift or scroll takeover, while mouse hover/click behavior stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8d0f69f849c085ee7f9bef2d91cb3a20c798291. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->