### PR TITLE
fix(a11y): make the 20 scrollable data-table wraps keyboard-operable

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -309,9 +309,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-1">
               <table class="edu-table">
-                <caption class="edu-table-caption">Gold compared with silver</caption>
+                <caption class="edu-table-caption" id="compare-tcap-1">Gold compared with silver</caption>
                 <thead>
                   <tr>
                     <th scope="col">Feature</th>
@@ -370,9 +370,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-2">
               <table class="edu-table">
-                <caption class="edu-table-caption">مقارنة الذهب بالفضة</caption>
+                <caption class="edu-table-caption" id="compare-tcap-2">مقارنة الذهب بالفضة</caption>
                 <thead>
                   <tr>
                     <th scope="col">العنصر</th>
@@ -437,9 +437,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-3">
               <table class="edu-table">
-                <caption class="edu-table-caption">Gold compared with Bitcoin</caption>
+                <caption class="edu-table-caption" id="compare-tcap-3">Gold compared with Bitcoin</caption>
                 <thead>
                   <tr>
                     <th scope="col">Feature</th>
@@ -497,9 +497,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-4">
               <table class="edu-table">
-                <caption class="edu-table-caption">مقارنة الذهب بالبيتكوين</caption>
+                <caption class="edu-table-caption" id="compare-tcap-4">مقارنة الذهب بالبيتكوين</caption>
                 <thead>
                   <tr>
                     <th scope="col">العنصر</th>
@@ -563,9 +563,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-5">
               <table class="edu-table">
-                <caption class="edu-table-caption">Gold compared with cash</caption>
+                <caption class="edu-table-caption" id="compare-tcap-5">Gold compared with cash</caption>
                 <thead>
                   <tr>
                     <th scope="col">Feature</th>
@@ -622,9 +622,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-6">
               <table class="edu-table">
-                <caption class="edu-table-caption">مقارنة الذهب بالنقد</caption>
+                <caption class="edu-table-caption" id="compare-tcap-6">مقارنة الذهب بالنقد</caption>
                 <thead>
                   <tr>
                     <th scope="col">العنصر</th>
@@ -688,9 +688,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-7">
               <table class="edu-table">
-                <caption class="edu-table-caption">Gold compared with stocks</caption>
+                <caption class="edu-table-caption" id="compare-tcap-7">Gold compared with stocks</caption>
                 <thead>
                   <tr>
                     <th scope="col">Feature</th>
@@ -747,9 +747,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-8">
               <table class="edu-table">
-                <caption class="edu-table-caption">مقارنة الذهب بالأسهم</caption>
+                <caption class="edu-table-caption" id="compare-tcap-8">مقارنة الذهب بالأسهم</caption>
                 <thead>
                   <tr>
                     <th scope="col">العنصر</th>
@@ -813,9 +813,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-9">
               <table class="edu-table">
-                <caption class="edu-table-caption">Gold compared with real estate</caption>
+                <caption class="edu-table-caption" id="compare-tcap-9">Gold compared with real estate</caption>
                 <thead>
                   <tr>
                     <th scope="col">Feature</th>
@@ -872,9 +872,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-10">
               <table class="edu-table">
-                <caption class="edu-table-caption">مقارنة الذهب بالعقارات</caption>
+                <caption class="edu-table-caption" id="compare-tcap-10">مقارنة الذهب بالعقارات</caption>
                 <thead>
                   <tr>
                     <th scope="col">العنصر</th>
@@ -938,9 +938,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-11">
               <table class="edu-table">
-                <caption class="edu-table-caption">Physical gold compared with gold ETFs</caption>
+                <caption class="edu-table-caption" id="compare-tcap-11">Physical gold compared with gold ETFs</caption>
                 <thead>
                   <tr>
                     <th scope="col">Feature</th>
@@ -1003,9 +1003,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-12">
               <table class="edu-table">
-                <caption class="edu-table-caption">مقارنة الذهب المادي بصناديق الذهب المتداولة</caption>
+                <caption class="edu-table-caption" id="compare-tcap-12">مقارنة الذهب المادي بصناديق الذهب المتداولة</caption>
                 <thead>
                   <tr>
                     <th scope="col">العنصر</th>
@@ -1075,9 +1075,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-13">
               <table class="edu-table">
-                <caption class="edu-table-caption">Gold karats compared</caption>
+                <caption class="edu-table-caption" id="compare-tcap-13">Gold karats compared</caption>
                 <thead>
                   <tr>
                     <th scope="col">Karat</th>
@@ -1139,9 +1139,9 @@
               </article>
             </div>
 
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="compare-tcap-14">
               <table class="edu-table">
-                <caption class="edu-table-caption">مقارنة أعيرة الذهب</caption>
+                <caption class="edu-table-caption" id="compare-tcap-14">مقارنة أعيرة الذهب</caption>
                 <thead>
                   <tr>
                     <th scope="col">العيار</th>

--- a/heatmap.html
+++ b/heatmap.html
@@ -427,7 +427,7 @@
             <p class="edu-eyebrow">Correlations</p>
             <h2 class="edu-heading" id="assets-h-en">Asset relationships</h2>
             <p class="edu-lede">How gold has often related to other markets. <span class="edu-chip">General tendencies</span> These are patterns observed in the past, not fixed rules — relationships weaken, strengthen, or reverse over time.</p>
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="assets-h-en">
               <table class="edu-table">
                 <thead>
                   <tr>
@@ -485,7 +485,7 @@
             <p class="edu-eyebrow">الارتباطات</p>
             <h2 class="edu-heading" id="assets-h-ar">علاقات الأصول</h2>
             <p class="edu-lede">كيف ارتبط الذهب غالباً بأسواق أخرى. <span class="edu-chip">ميول عامة</span> هذه أنماط رُصدت في الماضي، وليست قواعد ثابتة — إذ تضعف العلاقات أو تقوى أو تنعكس مع الوقت.</p>
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="assets-h-ar">
               <table class="edu-table">
                 <thead>
                   <tr>

--- a/portfolio.html
+++ b/portfolio.html
@@ -358,9 +358,9 @@
             <p class="edu-eyebrow">Illustrative examples</p>
             <h2 class="edu-heading" id="example-portfolios-heading">Example portfolios</h2>
             <p class="edu-lede">The combinations below are illustrative examples to make the idea concrete. They are not recommendations and are not tailored to anyone's circumstances.</p>
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="portfolio-tcap-1">
               <table class="edu-table">
-                <caption class="edu-table-caption">Illustrative example portfolios — not recommendations.</caption>
+                <caption class="edu-table-caption" id="portfolio-tcap-1">Illustrative example portfolios — not recommendations.</caption>
                 <thead>
                   <tr>
                     <th scope="col">Profile</th>
@@ -402,9 +402,9 @@
             <p class="edu-eyebrow">أمثلة توضيحية</p>
             <h2 class="edu-heading" id="example-portfolios-heading-ar">نماذج محافظ توضيحية</h2>
             <p class="edu-lede">التركيبات التالية أمثلة توضيحية لتقريب الفكرة. وهي ليست توصيات وليست مفصّلة على ظروف أحد.</p>
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="portfolio-tcap-2">
               <table class="edu-table">
-                <caption class="edu-table-caption">نماذج محافظ توضيحية — وليست توصيات.</caption>
+                <caption class="edu-table-caption" id="portfolio-tcap-2">نماذج محافظ توضيحية — وليست توصيات.</caption>
                 <thead>
                   <tr>
                     <th scope="col">الحالة</th>
@@ -488,9 +488,9 @@
             <p class="edu-eyebrow">Two ways to hold</p>
             <h2 class="edu-heading" id="physical-vs-etf-heading">Physical gold vs gold ETFs for allocation</h2>
             <p class="edu-lede">The two hold quite differently. ETF availability, taxes and rules vary by country, and none of this is a recommendation — just a comparison to help you understand the trade-offs.</p>
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="portfolio-tcap-3">
               <table class="edu-table">
-                <caption class="edu-table-caption">Illustrative comparison — ETF availability, taxes and rules vary by country; not a recommendation.</caption>
+                <caption class="edu-table-caption" id="portfolio-tcap-3">Illustrative comparison — ETF availability, taxes and rules vary by country; not a recommendation.</caption>
                 <thead>
                   <tr>
                     <th scope="col">Factor</th>
@@ -532,9 +532,9 @@
             <p class="edu-eyebrow">طريقتان للاقتناء</p>
             <h2 class="edu-heading" id="physical-vs-etf-heading-ar">الذهب المادي مقابل صناديق الذهب المتداولة للتخصيص</h2>
             <p class="edu-lede">تختلف الطريقتان اختلافاً كبيراً في الاقتناء. ويتباين توفّر الصناديق المتداولة وضرائبها وأحكامها من دولة إلى أخرى، ولا شيء من هذا توصية — بل مقارنة تساعدك على فهم الموازنات.</p>
-            <div class="edu-table-wrap">
+            <div class="edu-table-wrap" role="region" tabindex="0" aria-labelledby="portfolio-tcap-4">
               <table class="edu-table">
-                <caption class="edu-table-caption">مقارنة توضيحية — يختلف توفّر الصناديق والضرائب والأحكام حسب الدولة، وهذا ليس توصية.</caption>
+                <caption class="edu-table-caption" id="portfolio-tcap-4">مقارنة توضيحية — يختلف توفّر الصناديق والضرائب والأحكام حسب الدولة، وهذا ليس توصية.</caption>
                 <thead>
                   <tr>
                     <th scope="col">العامل</th>

--- a/tests/e2e/scrollable-table-a11y.spec.js
+++ b/tests/e2e/scrollable-table-a11y.spec.js
@@ -1,0 +1,98 @@
+const { test, expect } = require('@playwright/test');
+
+// Regression guard for keyboard access to horizontally scrollable data tables.
+//
+// axe flagged `scrollable-region-focusable` on all 20 static `.edu-table-wrap`
+// containers (14 compare, 4 portfolio, 2 heatmap): the wraps scroll on
+// overflow but were not focusable, so keyboard users could not reach clipped
+// columns. Fix: every wrap carries `tabindex="0" role="region"` and an
+// `aria-labelledby` that resolves to visible localized text (table captions on
+// compare/portfolio, section headings on heatmap) — no new strings, bilingual
+// for free. The global `:focus-visible` baseline (base.css) supplies the ring.
+//
+// This spec locks: (1) every wrap on each page is focusable + named, and
+// (2) a real keyboard scroll works on an overflowing wrap at 390px, in the
+// direction RTL/LTR actually overflows.
+
+const MOBILE = { width: 390, height: 844 };
+
+const PAGES = [
+  { path: '/compare.html', wraps: 14 },
+  { path: '/portfolio.html', wraps: 4 },
+  { path: '/heatmap.html', wraps: 2 },
+];
+
+test.describe('Scrollable table keyboard access', () => {
+  test.use({ viewport: MOBILE });
+
+  for (const { path, wraps } of PAGES) {
+    for (const lang of ['en', 'ar']) {
+      test(`${path} [${lang}]: all ${wraps} wraps focusable and named`, async ({ page }) => {
+        await page.goto(`${path}${lang === 'ar' ? '?lang=ar' : ''}`);
+        if (lang === 'ar') {
+          await page.waitForFunction(() => document.documentElement.dir === 'rtl', undefined, {
+            timeout: 10000,
+          });
+        }
+        await page.waitForSelector('.edu-table-wrap', { state: 'attached', timeout: 10000 });
+
+        const r = await page.evaluate(() => {
+          const list = [...document.querySelectorAll('.edu-table-wrap')];
+          const bad = list.filter((w) => {
+            const lid = w.getAttribute('aria-labelledby');
+            const target = lid && document.getElementById(lid);
+            return !(
+              w.getAttribute('tabindex') === '0' &&
+              w.getAttribute('role') === 'region' &&
+              target &&
+              target.textContent.trim().length > 0
+            );
+          });
+          return { total: list.length, badCount: bad.length };
+        });
+        expect(r.total, `${path} wrap count`).toBe(wraps);
+        expect(r.badCount, 'wraps missing tabindex/role/resolving label').toBe(0);
+      });
+    }
+  }
+
+  test('keyboard arrow scrolls an overflowing wrap (EN/LTR)', async ({ page }) => {
+    await page.goto('/compare.html');
+    await page.waitForSelector('.edu-table-wrap', { state: 'attached', timeout: 10000 });
+    const focused = await page.evaluate(() => {
+      const wrap = [...document.querySelectorAll('.edu-table-wrap')].find(
+        (w) => w.offsetParent !== null && w.scrollWidth > w.clientWidth
+      );
+      if (!wrap) return false;
+      wrap.focus();
+      return document.activeElement === wrap;
+    });
+    expect(focused, 'an overflowing wrap must be focusable').toBeTruthy();
+    await page.keyboard.press('ArrowRight');
+    await expect
+      .poll(async () => page.evaluate(() => Math.abs(document.activeElement.scrollLeft)))
+      .toBeGreaterThan(0);
+  });
+
+  test('keyboard arrow scrolls an overflowing wrap (AR/RTL)', async ({ page }) => {
+    await page.goto('/compare.html?lang=ar');
+    await page.waitForFunction(() => document.documentElement.dir === 'rtl', undefined, {
+      timeout: 10000,
+    });
+    await page.waitForSelector('.edu-table-wrap', { state: 'attached', timeout: 10000 });
+    const focused = await page.evaluate(() => {
+      const wrap = [...document.querySelectorAll('.edu-table-wrap')].find(
+        (w) => w.offsetParent !== null && w.scrollWidth > w.clientWidth
+      );
+      if (!wrap) return false;
+      wrap.focus();
+      return document.activeElement === wrap;
+    });
+    expect(focused, 'an overflowing wrap must be focusable').toBeTruthy();
+    // RTL content overflows toward the left, so ArrowLeft is the scroll key.
+    await page.keyboard.press('ArrowLeft');
+    await expect
+      .poll(async () => page.evaluate(() => Math.abs(document.activeElement.scrollLeft)))
+      .toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **only serious-level axe finding** from the campaign a11y audit: all 20 static `.edu-table-wrap` scroll containers (14 `compare.html`, 4 `portfolio.html`, 2 `heatmap.html`) scrolled on overflow but were **not keyboard-focusable** — keyboard users could not reach clipped columns (`scrollable-region-focusable`, WCAG 2.1.1). Attribute-only HTML change + regression spec.

## Fix (no new strings, no CSS, no JS)

Each wrap now carries `tabindex="0" role="region"` and an `aria-labelledby` resolving to **existing visible localized text**:
- compare/portfolio → the table's own `<caption>` (given ids `compare-tcap-N` / `portfolio-tcap-N`) — bilingual names for free, since captions are already localized per section;
- heatmap → the adjacent section headings' existing ids (`assets-h-en` / `assets-h-ar`).

The focus ring comes from the existing global `:focus-visible` baseline in `base.css` (verified — no styling change needed).

## Proof

| Check | Before | After |
| --- | --- | --- |
| axe `scrollable-region-focusable` (390px, EN+AR) | 20 nodes | **0 violations** |
| wraps focusable + named | 0/20 | 20/20 |
| keyboard scroll (EN, ArrowRight) | impossible | scrolls ✅ |
| keyboard scroll (AR/RTL, ArrowLeft) | impossible | scrolls 40px ✅ (RTL overflows leftward — verified, not assumed) |

- New `tests/e2e/scrollable-table-a11y.spec.js`: **16/16 across `--repeat-each=2`** (8 structural EN/AR page checks + 2 real keyboard-scroll tests). One spec-authoring bug was found and fixed during stabilization (`waitForSelector` visibility vs. the hidden inactive-language section → `state: 'attached'`); the failure was systematic, not flaky, and is documented in the commit.
- `npm run lint` ✅ · `npm run validate` ✅ · `npm test` **1623/1623** ✅ · `npm run build` ✅

## Risks / rollback

Attribute-only markup change; `portfolio.html` is disjoint from open PR #677 (which owns `src/pages/portfolio.js`). Rollback = revert one commit.

## Gold provider bakeoff checklist

N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Attribute-only markup on static educational pages with no logic, auth, or data changes; risk is limited to minor accessibility semantics.
> 
> **Overview**
> Fixes **scrollable-region-focusable** (WCAG 2.1.1) for all **20** horizontally scrollable `.edu-table-wrap` containers on `compare.html`, `portfolio.html`, and `heatmap.html`.
> 
> Each wrap now has **`tabindex="0"`**, **`role="region"`**, and **`aria-labelledby`** wired to **existing** visible copy—table **captions** (new ids on compare/portfolio) or **section headings** on heatmap—so keyboard users can focus the region and reach clipped columns without new strings or styling changes.
> 
> Adds **`tests/e2e/scrollable-table-a11y.spec.js`** to assert every wrap is focusable and labeled in EN/AR at mobile width, and that arrow keys actually scroll an overflowing wrap in LTR and RTL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e52f4b1b4189d4ac0cee174b750736ebe1362cb8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->