### PR TITLE
feat(market): deterministic "Today's movement, described" panel (zero-infra, no LLM)

### DIFF
--- a/market.html
+++ b/market.html
@@ -371,6 +371,25 @@
               </p>
             </div>
 
+            <!-- Deterministic movement description — filled by buildMarketAnalysis()
+                 (src/analysis/market-analysis.js): template text derived from the
+                 same reference figures shown above. Rules-based, descriptive only;
+                 hidden until real data exists. -->
+            <div class="mkt-analysis" id="mkt-analysis" hidden aria-hidden="true">
+              <p class="mkt-analysis-label">
+                <span data-lang-block="en">Today's movement, described</span>
+                <span data-lang-block="ar" lang="ar" dir="rtl">وصف حركة اليوم</span>
+                <span class="mkt-analysis-chip">
+                  <span data-lang-block="en">Generated from the numbers above · rules-based</span>
+                  <span data-lang-block="ar" lang="ar" dir="rtl"
+                    >نص آلي من الأرقام أعلاه · قواعد ثابتة</span
+                  >
+                </span>
+              </p>
+              <p class="mkt-analysis-body" id="mkt-analysis-body"></p>
+              <p class="mkt-analysis-disclaimer" id="mkt-analysis-disclaimer"></p>
+            </div>
+
             <ol class="mkt-worked-flow">
               <li class="mkt-worked-node">
                 <span class="mkt-worked-step">

--- a/src/analysis/market-analysis.js
+++ b/src/analysis/market-analysis.js
@@ -22,13 +22,14 @@ const FORECAST_PATTERNS =
 const CAUSE_PATTERNS =
   /\b(because|due to|driven by|on the back of|thanks to|owing to|as a result of)\b/i;
 
-/** Movement magnitude bands by absolute % change — descriptive only, never predictive. */
+/** Movement magnitude bands by absolute % change — descriptive only, never predictive.
+ *  `en` is the adverb form; `enAdj` the adjective used in "a … move". */
 const MAGNITUDE = [
-  { key: 'unchanged', max: 0.05, en: 'unchanged', ar: 'دون تغيير' },
-  { key: 'little-changed', max: 0.25, en: 'little changed', ar: 'شبه مستقر' },
-  { key: 'modest', max: 1, en: 'modestly', ar: 'بشكل طفيف' },
-  { key: 'notable', max: 2.5, en: 'notably', ar: 'بشكل ملحوظ' },
-  { key: 'sharp', max: Infinity, en: 'sharply', ar: 'بشكل حاد' },
+  { key: 'unchanged', max: 0.05, en: 'unchanged', enAdj: 'unchanged', ar: 'دون تغيير' },
+  { key: 'little-changed', max: 0.25, en: 'little changed', enAdj: 'small', ar: 'شبه مستقر' },
+  { key: 'modest', max: 1, en: 'modestly', enAdj: 'modest', ar: 'بشكل طفيف' },
+  { key: 'notable', max: 2.5, en: 'notably', enAdj: 'notable', ar: 'بشكل ملحوظ' },
+  { key: 'sharp', max: Infinity, en: 'sharply', enAdj: 'sharp', ar: 'بشكل حاد' },
 ];
 
 function pickLang(lang) {
@@ -116,7 +117,7 @@ export function buildMarketAnalysis(input = {}, options = {}) {
       sentences.push(
         lang === 'ar'
           ? `وهو ${fmtUsd(Math.abs(absChange))} (${fmtPct(pctChange)}) ${dir.ar} القراءة المرجعية السابقة، متغيرًا ${band.ar}.`
-          : `That is ${fmtUsd(Math.abs(absChange))} (${fmtPct(pctChange)}) ${dir.en} the previous reference reading — a ${band.en} move.`
+          : `That is ${fmtUsd(Math.abs(absChange))} (${fmtPct(pctChange)}) ${dir.en} the previous reference reading — a ${band.enAdj} move.`
       );
     }
   }

--- a/src/pages/market.js
+++ b/src/pages/market.js
@@ -24,6 +24,7 @@ import { applyMarketClosedOverlay } from '../lib/live-status.js';
 import { startVisibilityAwareRefresh } from '../lib/visibility-refresh.js';
 import { parseLastGoldPriceSnapshot } from '../lib/quote-providers/last-gold-price-parse.js';
 import { referenceMove } from '../lib/reference-move.js';
+import { buildMarketAnalysis } from '../analysis/market-analysis.js';
 import { CONSTANTS } from '../config/index.js';
 import {
   formatNumber,
@@ -115,6 +116,7 @@ function renderWorked() {
   }
 
   renderMove();
+  renderAnalysis();
   card.removeAttribute('aria-busy');
 }
 
@@ -161,6 +163,49 @@ function renderMove() {
 
   panel.hidden = false;
   panel.removeAttribute('aria-hidden');
+}
+
+/**
+ * "Today's movement, described" — the deterministic, template-based movement
+ * description from src/analysis/market-analysis.js, fed with the SAME
+ * reference figures the worked example above it displays (canonical snapshot
+ * + last recorded reference). No LLM, no forecasts, no invented causes; the
+ * builder's own assertDescriptiveOnly() contract is CI-locked in
+ * tests/market-analysis.test.js. Panel stays hidden until real data exists.
+ */
+function renderAnalysis() {
+  const box = document.getElementById('mkt-analysis');
+  const body = document.getElementById('mkt-analysis-body');
+  const disclaimer = document.getElementById('mkt-analysis-disclaimer');
+  if (!box || !body || !disclaimer) return;
+
+  const snap = STATE.snapshot;
+  const analysis = buildMarketAnalysis(
+    {
+      price: snap?.ok ? snap.spotUsdPerOz : null,
+      previous: STATE.prior?.price,
+      timestamp: snap?.freshness?.updatedAt || null,
+    },
+    { lang: STATE.lang }
+  );
+
+  if (analysis.status !== 'ok') {
+    box.hidden = true;
+    box.setAttribute('aria-hidden', 'true');
+    return;
+  }
+
+  // Sentences arrive pre-localized for STATE.lang (headline is sentences[0]).
+  body.textContent = analysis.sentences.join(' ');
+  disclaimer.textContent = analysis.disclaimer;
+  for (const node of [body, disclaimer]) {
+    node.setAttribute('lang', STATE.lang);
+    node.setAttribute('dir', STATE.lang === 'ar' ? 'rtl' : 'ltr');
+  }
+  // The data timestamp is already visible in the freshness pill above the
+  // worked example — the same snapshot feeds both, so it is not repeated here.
+  box.hidden = false;
+  box.removeAttribute('aria-hidden');
 }
 
 /**

--- a/styles/pages/market-redesign.css
+++ b/styles/pages/market-redesign.css
@@ -186,6 +186,53 @@
   font-style: italic;
 }
 
+/* "Today's movement, described" — deterministic template panel. */
+.mkt-analysis {
+  margin-top: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border-subtle, var(--color-border));
+  border-inline-start: 3px solid var(--color-gold);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-2, var(--color-surface));
+}
+
+.mkt-analysis-label {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5em;
+  margin: 0 0 0.45em;
+  font-size: var(--gtl-meta);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.mkt-analysis-chip {
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: normal;
+  font-size: var(--gtl-meta);
+  color: var(--color-text-faint);
+  border: 1px solid var(--color-border-subtle, var(--color-border));
+  border-radius: 999px;
+  padding: 0.1em 0.7em;
+}
+
+.mkt-analysis-body {
+  margin: 0;
+  color: var(--color-text);
+  line-height: 1.65;
+}
+
+.mkt-analysis-disclaimer {
+  margin: 0.6em 0 0;
+  font-size: var(--gtl-meta);
+  color: var(--color-text-faint);
+  font-style: italic;
+}
+
 /* Flow of nodes + operators. */
 .mkt-worked-flow {
   list-style: none;


### PR DESCRIPTION
## Summary

Ships the AI-architecture audit's **top-ranked zero-infrastructure feature**: `buildMarketAnalysis()` — the deterministic, template-based, bilingual, descriptive-only movement narrator — existed, was CI-tested, and was **wired into zero pages**. It now powers a "Today's movement, described" panel on the market page, fed with the **same reference figures the worked example above it displays**. No LLM, no backend, no invented causes, no forecasts (the module's `assertDescriptiveOnly()` contract stays CI-locked).

## What changed

- **`market.html`** — new `.mkt-analysis` block inside the worked-example card. Static bilingual title + method chip ("Generated from the numbers above · rules-based") via the page's existing `data-lang-block` pattern → **zero new translation keys**. Hidden until real data exists.
- **`src/pages/market.js`** — `renderAnalysis()` feeds the builder from the canonical snapshot + last recorded reference + snapshot freshness timestamp; renders pre-localized sentences/disclaimer with correct `lang`/`dir`; re-renders on language toggle via the existing `renderWorked()` path; `textContent`-only writes.
- **`styles/pages/market-redesign.css`** — token-based panel (gold inline-start accent, `surface-2`, meta chip); logical properties, RTL-safe.
- **`src/analysis/market-analysis.js`** — grammar fix surfaced by first real use: magnitude bands stored adverbs ("modestly") but the sentence slot needs adjectives → "a **modest** move" (new `enAdj` forms; Arabic unaffected; module tests pin `movement.key` only — **9/9 still pass**, no test churn).

## Proof (built dist + data statics, chromium)

- **EN @1280:** *"Gold reference price: $4,121.40 per ounce. That is $36.30 (0.87%) lower than the previous reference reading — a modest move."* + full reference/not-advice disclaimer — figures **exactly match** the worked example above it.
- **AR @1280:** full Arabic (السعر المرجعي للذهب… متغيرًا بشكل طفيف), `lang=ar dir=rtl`, Arabic disclaimer.
- **390px:** 0 document overflow. Panel stays hidden when no snapshot resolves (honest empty state — no fake content).
- Gates: `lint` ✅ · `stylelint` ✅ · `validate` ✅ · `npm test` **1623/1623** ✅ · `build` ✅.

## Trust framing

- Descriptive only — states what the numbers are, never why, never what's next. Explicitly labeled as rules-based generated text. Carries the spot-linked reference disclaimer. Timestamp isn't duplicated because the same snapshot's freshness pill sits directly above.
- Existing `rtl-mobile-public-surface-coverage` CI spec already guards this page's RTL/overflow/a11y basics.

## Risks / rollback

Additive panel; pricing math untouched. All four files disjoint from every open PR. Rollback = revert one commit.

## Gold provider bakeoff checklist

N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive presentation layer on descriptive template text; spot/pricing math unchanged and output stays CI-guarded for non-forecast language.
> 
> **Overview**
> Adds a **"Today's movement, described"** panel to the market page’s live worked-example card, powered by the existing `buildMarketAnalysis()` templates (no LLM, no backend).
> 
> **`market.html`** introduces a hidden `#mkt-analysis` block with bilingual title and a rules-based method chip via existing `data-lang-block` markup.
> 
> **`src/pages/market.js`** adds `renderAnalysis()`, which runs on the same canonical spot and last recorded reference as the movement UI, writes sentences and disclaimer with `textContent`, sets `lang`/`dir`, and keeps the panel hidden when analysis is unavailable; it runs from `renderWorked()` so language toggles refresh the copy.
> 
> **`styles/pages/market-redesign.css`** styles the panel to match the movement block (gold accent, surface chip).
> 
> **`src/analysis/market-analysis.js`** fixes English copy by adding `enAdj` on magnitude bands so phrasing reads **"a modest move"** instead of reusing adverbs like "modestly".
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616b60f157e8db29b92f751aa743c5659c0e7e45. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->