### PR TITLE
fix(i18n): un-mirror the AR jump-chart arrow; add Arabic twin to the market disclaimer

### DIFF
--- a/market.html
+++ b/market.html
@@ -853,10 +853,15 @@
       </section>
 
       <div class="mkt-foot">
-        <p class="mkt-disclaimer">
+        <p class="mkt-disclaimer" data-lang-block="en">
           This page is for education only and is not financial advice. Prices shown elsewhere on Gold
           Ticker Live are spot-linked reference estimates, not live dealer quotes; retail and
           jewellery prices add making charges, premiums and tax on top of the reference.
+        </p>
+        <p class="mkt-disclaimer" data-lang-block="ar" lang="ar" dir="rtl">
+          هذه الصفحة لأغراض تعليمية فقط وليست نصيحة مالية. الأسعار المعروضة في بقية صفحات Gold Ticker
+          Live تقديرات مرجعية مرتبطة بالسعر الفوري وليست تسعيرات تجار لحظية؛ وتضيف أسعار التجزئة
+          والمجوهرات أجور المصنعية والعلاوات والضريبة فوق السعر المرجعي.
         </p>
       </div>
     </main>

--- a/src/pages/tracker-pro.js
+++ b/src/pages/tracker-pro.js
@@ -289,7 +289,9 @@ function localizeStaticTrackerCopy() {
   if (jumpChart) {
     const arrow = document.createElement('span');
     arrow.setAttribute('aria-hidden', 'true');
-    arrow.textContent = state.lang === 'ar' ? '←' : '↓';
+    // The link scrolls DOWN the page in both languages — a vertical direction
+    // never mirrors in RTL, so the arrow is always '↓'.
+    arrow.textContent = '↓';
     jumpChart.replaceChildren(trackerTx('actions.viewChart'), ' ', arrow);
     jumpChart.setAttribute('aria-label', trackerTx('actions.jumpChartLabel'));
   }

--- a/tests/e2e/tracker-jump-arrow-market-disclaimer.spec.js
+++ b/tests/e2e/tracker-jump-arrow-market-disclaimer.spec.js
@@ -1,0 +1,120 @@
+const { test, expect } = require('@playwright/test');
+
+// Regression guards for two small bilingual-correctness defects.
+//
+// 1. tracker.html: the #tp-jump-chart button ("View chart") scrolls DOWN the
+//    page in both languages, but the boot-time copy rewrite mirrored its arrow
+//    to '←' for Arabic. Vertical directions never mirror in RTL — the arrow
+//    must be '↓' in both locales.
+//
+// 2. market.html: the footer disclaimer was a bare English <p> with no lang
+//    attribute and no Arabic twin, on a page whose bilingual pattern is twin
+//    data-lang-block="en" / data-lang-block="ar" blocks toggled purely by CSS
+//    on html[lang]. This locks the twin-block structure and the CSS flip.
+//
+// External APIs are unreachable in CI/sandbox runs; nothing below depends on
+// live network data — only static markup and the boot-time copy rewrite.
+
+const AR_JUMP_LABEL = 'عرض الرسم — الانتقال إلى الرسم البياني المباشر';
+const EN_JUMP_LABEL = 'View chart — jump to the live price chart';
+
+// The tracker boot rewrites #tp-jump-chart via replaceChildren(text, ' ', span),
+// so after the rewrite the arrow <span> is the link's LAST child node (the
+// static HTML keeps a trailing whitespace text node instead). Waiting on that
+// plus the localized aria-label observes the rewrite itself — no arbitrary sleeps.
+async function waitForJumpChartRewrite(page, expectedLabel) {
+  await page.waitForFunction(
+    (label) => {
+      const btn = document.getElementById('tp-jump-chart');
+      if (!btn) return false;
+      const last = btn.lastChild;
+      if (!last || last.nodeType !== 1 || last.tagName !== 'SPAN') return false;
+      return btn.getAttribute('aria-label') === label;
+    },
+    expectedLabel,
+    { timeout: 15000 }
+  );
+}
+
+async function readJumpArrow(page) {
+  return page.evaluate(() => {
+    const btn = document.getElementById('tp-jump-chart');
+    const span = btn && btn.querySelector('span[aria-hidden="true"]');
+    return span ? span.textContent : null;
+  });
+}
+
+test.describe('Tracker jump-to-chart arrow is vertical in both languages', () => {
+  test('tracker.html?lang=ar: arrow is ↓, not a mirrored ←', async ({ page }) => {
+    await page.goto('/tracker.html?lang=ar');
+    // Wait for the tracker boot to rewrite the button with the Arabic label.
+    await waitForJumpChartRewrite(page, AR_JUMP_LABEL);
+    const arrow = await readJumpArrow(page);
+    expect(arrow, 'AR arrow must not be the horizontal RTL mirror').not.toBe('←');
+    expect(arrow, 'link scrolls down the page, so the arrow is ↓').toBe('↓');
+  });
+
+  test('tracker.html (EN default): arrow is ↓', async ({ page }) => {
+    await page.goto('/tracker.html');
+    await waitForJumpChartRewrite(page, EN_JUMP_LABEL);
+    const arrow = await readJumpArrow(page);
+    expect(arrow).toBe('↓');
+  });
+});
+
+test.describe('Market disclaimer twin data-lang blocks', () => {
+  const readBlocks = (page) =>
+    page.evaluate(() => {
+      const en = document.querySelector('.mkt-foot .mkt-disclaimer[data-lang-block="en"]');
+      const ar = document.querySelector('.mkt-foot .mkt-disclaimer[data-lang-block="ar"]');
+      return {
+        enExists: !!en,
+        arExists: !!ar,
+        arLang: ar ? ar.getAttribute('lang') : null,
+        arDir: ar ? ar.getAttribute('dir') : null,
+        enText: en ? en.textContent.trim() : '',
+        arText: ar ? ar.textContent.trim() : '',
+        enVisible: !!en && en.offsetParent !== null,
+        arVisible: !!ar && ar.offsetParent !== null,
+        enDisplay: en ? getComputedStyle(en).display : null,
+        arDisplay: ar ? getComputedStyle(ar).display : null,
+      };
+    });
+
+  test('market.html (default EN): both twins present, EN visible, AR hidden', async ({ page }) => {
+    await page.goto('/market.html');
+    // The AR twin is display:none by default — wait for attachment, not visibility.
+    await page.waitForSelector('.mkt-foot .mkt-disclaimer[data-lang-block="ar"]', {
+      state: 'attached',
+      timeout: 10000,
+    });
+    const r = await readBlocks(page);
+    expect(r.enExists, 'EN disclaimer twin must exist').toBeTruthy();
+    expect(r.arExists, 'AR disclaimer twin must exist').toBeTruthy();
+    expect(r.arLang, 'AR twin carries lang="ar"').toBe('ar');
+    expect(r.arDir, 'AR twin carries dir="rtl"').toBe('rtl');
+    expect(r.enText).toContain('not financial advice');
+    expect(r.arText).toContain('ليست نصيحة مالية');
+    expect(r.arText).toContain('السعر المرجعي');
+    expect(r.enVisible, 'EN twin visible on the English page').toBeTruthy();
+    expect(r.arDisplay, 'AR twin hidden on the English page').toBe('none');
+    expect(r.arVisible).toBeFalsy();
+  });
+
+  test('market.html?lang=ar: AR twin visible, EN hidden', async ({ page }) => {
+    await page.goto('/market.html?lang=ar');
+    await page.waitForFunction(() => document.documentElement.lang === 'ar', undefined, {
+      timeout: 10000,
+    });
+    await page.waitForSelector('.mkt-foot .mkt-disclaimer[data-lang-block="en"]', {
+      state: 'attached',
+      timeout: 10000,
+    });
+    const r = await readBlocks(page);
+    expect(r.enExists).toBeTruthy();
+    expect(r.arExists).toBeTruthy();
+    expect(r.arVisible, 'AR twin visible on the Arabic page').toBeTruthy();
+    expect(r.enDisplay, 'EN twin hidden on the Arabic page').toBe('none');
+    expect(r.enVisible).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Campaign queue item 22 (audit E, medium) — two small bilingual-trust fixes, re-verified on current main before implementing.

## What

- `src/pages/tracker-pro.js`: the tracker's "View chart" (`#tp-jump-chart`) arrow is now always `↓`. The link scrolls **down** the page in both languages; `←` was a wrong RTL mirror of a vertical direction — an Arabic reader was pointed left toward nothing.
- `market.html`: the footer compliance disclaimer was a bare English paragraph with no `lang` attribute — invisible in meaning to Arabic readers on a money page. Converted to the page's existing twin `data-lang-block="en"` / `data-lang-block="ar" lang="ar" dir="rtl"` pattern (zero JS, zero new translation keys). The Arabic copy reuses the site's established vocabulary (لأغراض تعليمية فقط وليست نصيحة مالية · تقديرات مرجعية مرتبطة بالسعر الفوري · أجور المصنعية والعلاوات والضريبة فوق السعر المرجعي) sourced from compare.html and translations.js — meaning preserved exactly: education-only, spot-linked reference estimates not dealer quotes, retail adds making charges/premiums/tax.
- New `tests/e2e/tracker-jump-arrow-market-disclaimer.spec.js`: asserts `↓` (never `←`) after the tracker boot rewrite in AR and EN, and that exactly the active-language disclaimer twin is visible with and without `?lang=ar`. No sleeps, no live-network dependence.

## Why

Spot≠retail honesty must reach Arabic readers with the same force as English ones, and directional UI must not blind-mirror vertical arrows in RTL.

## Proof

- Implementation agent run: lint / stylelint / validate EXIT=0, tests 1647/1647, build green, new spec **8/8** vs built dist (`--repeat-each=2`, chromium).
- Coordinator reproduction (independent run of the spec on the built dist): **4/4 passed**.
- `prettier --check` clean on all touched files (the 3 pre-existing debt files are being cleared separately in #681 — deliberately not folded in here).

## Risks

Copy-level only. The arrow change deletes a branch; the disclaimer change is additive static HTML on the page's existing CSS toggle. If tracker boot ever stops rewriting the button, the spec times out and flags it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and static markup only; behavior is covered by new e2e tests with no API or auth changes.
> 
> **Overview**
> Fixes two bilingual UX issues: the tracker **View chart** control and the market page footer disclaimer.
> 
> **Tracker:** `#tp-jump-chart` now always shows **↓** after boot-time copy rewrite. Arabic had incorrectly used **←** as an RTL mirror even though the link scrolls down the page; vertical direction does not flip in RTL.
> 
> **Market:** The footer disclaimer is split into twin **`data-lang-block="en"`** / **`data-lang-block="ar"`** paragraphs (with `lang="ar"` and `dir="rtl"` on the Arabic block), matching the rest of `market.html` and CSS language toggling—no new JS or translation keys.
> 
> **Tests:** New Playwright spec asserts the jump arrow in EN and AR after rewrite, and that only the active-language disclaimer twin is visible on `market.html` with and without `?lang=ar`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010ce9265b70b6a1902132f15576140ed029e971. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->