### PR TITLE
i18n(chart): move fallback + attribution strings to translations.js

### DIFF
--- a/src/components/chart.js
+++ b/src/components/chart.js
@@ -15,6 +15,8 @@
 
 import { getUnifiedHistory, toChartData, filterByRange } from '../lib/historical-data.js';
 import { updateChartSummary } from './chart-summary.js';
+import { TRANSLATIONS } from '../config/translations.js';
+import { translate } from '../lib/i18n.js';
 
 const CHART_CACHE_KEY = 'gold_chart_snapshots';
 const MAX_SNAPSHOTS = 5000; // ~5 days at 90s intervals
@@ -111,6 +113,7 @@ export class GoldChart {
     this._series = null;
     this._ready = false;
     this._LW = null;
+    this._fallbackReason = null;
     this._loadLibrary();
   }
 
@@ -223,14 +226,18 @@ export class GoldChart {
   }
 
   _injectTradingViewAttribution(container) {
-    if (container.querySelector('.chart-tv-attribution')) return;
-    const isAr = this.lang === 'ar';
+    const label = translate(TRANSLATIONS, this.lang, 'chart.attribution.tradingView');
+    const existing = container.querySelector('.chart-tv-attribution');
+    if (existing) {
+      existing.textContent = label;
+      return;
+    }
     const link = document.createElement('a');
     link.className = 'chart-tv-attribution';
     link.href = 'https://www.tradingview.com/';
     link.target = '_blank';
     link.rel = 'noopener noreferrer';
-    link.textContent = isAr ? 'مخططات من TradingView' : 'Charts by TradingView';
+    link.textContent = label;
     container.appendChild(link);
     applyChartTheme(this._chart, this._series);
   }
@@ -238,28 +245,25 @@ export class GoldChart {
   _showFallback(reason) {
     const container = document.getElementById(this.containerId);
     if (!container) return;
-    const msgs = {
-      'load-error':
-        this.lang === 'ar'
-          ? 'تعذّر تحميل المخطط. تحقق من الاتصال.'
-          : 'Chart unavailable. Check your connection.',
-      'no-data':
-        this.lang === 'ar'
-          ? 'لا تتوفر بيانات بعد — ستظهر البيانات عند وصول التحديثات'
-          : 'No data for this range yet — data populates as updates arrive',
-    };
+    // All user-facing strings live in translations.js (chart.fallback.*);
+    // unknown reasons fall back to the honest no-data sentence.
+    this._fallbackReason = reason === 'load-error' ? 'load-error' : 'no-data';
+    const key =
+      this._fallbackReason === 'load-error' ? 'chart.fallback.loadError' : 'chart.fallback.noData';
+    const text = translate(TRANSLATIONS, this.lang, key);
     const existing = container.querySelector('.chart-no-data');
     if (existing) {
-      existing.textContent = msgs[reason] || msgs['no-data'];
+      existing.textContent = text;
       return;
     }
     const msg = document.createElement('div');
     msg.className = 'chart-no-data';
-    msg.textContent = msgs[reason] || msgs['no-data'];
+    msg.textContent = text;
     container.appendChild(msg);
   }
 
   _clearFallback() {
+    this._fallbackReason = null;
     document.getElementById(this.containerId)?.querySelector('.chart-no-data')?.remove();
   }
 
@@ -403,7 +407,21 @@ export class GoldChart {
         localization: { locale: lang === 'ar' ? 'ar-AE' : 'en-AE' },
       });
     }
-    if (this._ready) this._render();
+    // Re-resolve translated DOM strings this component owns: the attribution
+    // link is created once in _init (never rebuilt by _render), and the
+    // load-error fallback lives outside the _render path entirely because the
+    // library never initialized. The no-data fallback re-resolves via
+    // _render() → _showFallback('no-data') updating the existing node.
+    const container = document.getElementById(this.containerId);
+    const attribution = container?.querySelector('.chart-tv-attribution');
+    if (attribution) {
+      attribution.textContent = translate(TRANSLATIONS, lang, 'chart.attribution.tradingView');
+    }
+    if (this._ready) {
+      this._render();
+    } else if (this._fallbackReason) {
+      this._showFallback(this._fallbackReason);
+    }
   }
 
   /**

--- a/src/config/translations.js
+++ b/src/config/translations.js
@@ -190,6 +190,9 @@ export const TRANSLATIONS = {
     'chart.summary.noData': 'No chart data is available for this range yet.',
     'chart.summary.up': 'up',
     'chart.summary.down': 'down',
+    'chart.fallback.loadError': 'Chart unavailable. Check your connection.',
+    'chart.fallback.noData': 'No data for this range yet — data populates as updates arrive',
+    'chart.attribution.tradingView': 'Charts by TradingView',
     'tracker.chart.emptyTitle':
       'Waiting for price data — select a time range above or refresh to load history.',
     'tracker.chart.emptyNote':
@@ -1666,6 +1669,9 @@ export const TRANSLATIONS = {
     'chart.summary.noData': 'لا تتوفر بيانات للرسم البياني في هذا النطاق بعد.',
     'chart.summary.up': 'صعوداً',
     'chart.summary.down': 'هبوطاً',
+    'chart.fallback.loadError': 'تعذّر تحميل المخطط. تحقق من الاتصال.',
+    'chart.fallback.noData': 'لا تتوفر بيانات بعد — ستظهر البيانات عند وصول التحديثات',
+    'chart.attribution.tradingView': 'مخططات من TradingView',
     'tracker.chart.emptyTitle':
       'في انتظار بيانات السعر — اختر نطاقاً زمنياً أعلاه أو حدّث الصفحة لتحميل السجل.',
     'tracker.chart.emptyNote':

--- a/tests/chart-fallback-i18n.test.js
+++ b/tests/chart-fallback-i18n.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+/**
+ * chart-fallback-i18n.test.js
+ *
+ * Guards the i18n relocation of the GoldChart fallback + attribution strings
+ * (src/components/chart.js). Previously `_showFallback` and
+ * `_injectTradingViewAttribution` hardcoded EN/AR copy in inline ternaries;
+ * per repo rule ALL user-facing strings live in src/config/translations.js as
+ * flat dot-keys resolved via translate(). This test proves:
+ *   1. the chart.fallback.* / chart.attribution.* keys exist and are
+ *      non-empty in BOTH the EN and AR tables (pattern follows
+ *      tests/translations-new-keys.spec.test.js);
+ *   2. chart.js references the keys and carries no hardcoded Arabic script
+ *      or English attribution literal (the regression this fix removed);
+ *   3. the visible no-data fallback (chart.fallback.noData) and the SR
+ *      summary sentence (chart.summary.noData) make the same honest
+ *      "no data yet" claim in each language.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+async function loadTranslations() {
+  const url = new URL(
+    'file://' + path.resolve(__dirname, '..', 'src', 'config', 'translations.js')
+  );
+  const mod = await import(url.href);
+  return mod.TRANSLATIONS;
+}
+
+const REQUIRED_KEYS = [
+  'chart.fallback.loadError',
+  'chart.fallback.noData',
+  'chart.attribution.tradingView',
+];
+
+test('chart fallback/attribution keys exist and are non-empty in EN and AR', async () => {
+  const translations = await loadTranslations();
+  for (const key of REQUIRED_KEYS) {
+    for (const lang of ['en', 'ar']) {
+      const value = translations[lang][key];
+      assert.equal(typeof value, 'string', `Missing ${lang.toUpperCase()} key: ${key}`);
+      assert.ok(value.trim().length > 0, `Empty ${lang.toUpperCase()} value for key: ${key}`);
+    }
+  }
+});
+
+test('chart.js resolves these strings via keys — no hardcoded EN/AR literals', () => {
+  const src = fs.readFileSync(
+    path.resolve(__dirname, '..', 'src', 'components', 'chart.js'),
+    'utf8'
+  );
+  for (const key of REQUIRED_KEYS) {
+    assert.ok(src.includes(`'${key}'`), `chart.js must reference translation key ${key}`);
+  }
+  // The AR copy must live in translations.js only — any Arabic script in the
+  // component source means an inline ternary crept back in.
+  assert.ok(
+    !/[؀-ۿ]/.test(src),
+    'chart.js must not contain Arabic-script literals (use translations.js)'
+  );
+  assert.ok(
+    !src.includes('Charts by TradingView'),
+    'attribution text must come from translations.js, not a hardcoded literal'
+  );
+});
+
+test('visible fallback and SR summary no-data copy make the same honest claim', async () => {
+  const translations = await loadTranslations();
+  // EN: both sentences state that no data exists yet — the visible fallback
+  // additionally sets the expectation that data populates as updates arrive.
+  const enVisible = translations.en['chart.fallback.noData'];
+  const enSr = translations.en['chart.summary.noData'];
+  for (const text of [enVisible, enSr]) {
+    assert.ok(
+      /no\b.*\bdata|data.*\bno\b/i.test(text),
+      `EN no-data copy must state absence: ${text}`
+    );
+    assert.ok(/yet/i.test(text), `EN no-data copy must say "yet" (honest, not permanent): ${text}`);
+  }
+  // AR: both open with the same honest "لا تتوفر بيانات" (no data available)
+  // statement and carry "بعد" (yet).
+  const arVisible = translations.ar['chart.fallback.noData'];
+  const arSr = translations.ar['chart.summary.noData'];
+  for (const text of [arVisible, arSr]) {
+    assert.ok(text.includes('لا تتوفر بيانات'), `AR no-data copy must state absence: ${text}`);
+    assert.ok(text.includes('بعد'), `AR no-data copy must say "yet": ${text}`);
+  }
+});


### PR DESCRIPTION
Campaign queue item 13 (WS1 follow-up) — the last hardcoded chart copy moves into the i18n system, re-verified on current main before implementing.

## What

- `src/components/chart.js`: `_showFallback`'s inline EN/AR ternaries ('load-error' / 'no-data') and the TradingView attribution link text now resolve via `translate()` from three new flat keys in `src/config/translations.js` (`chart.fallback.loadError`, `chart.fallback.noData`, `chart.attribution.tradingView` — EN + AR, purely additive after the `chart.summary.*` block from #672). Wording relocated **verbatim** — the existing Arabic was already correct repo Arabic; this is a relocation, not a rewrite.
- Two honest `setLang()` fixes that fell out of the relocation: the attribution link (created once in `_init`, never rebuilt by `_render`) now re-resolves on language switch instead of sticking in the mount language, and a load-error fallback shown before the library initialized now re-renders in the new language via a stored `_fallbackReason` (that node was unreachable from `_render` when `_ready` is false).
- New `tests/chart-fallback-i18n.test.js`: keys exist non-empty in both languages; chart.js carries no residual hardcoded Arabic/attribution literals; the visible no-data copy and the SR `chart.summary.noData` sentence keep making the same honest claim (both EN texts state absence + "yet"; both AR texts contain لا تتوفر بيانات + بعد). Visible and SR copy stay two keys because they already agree in meaning — the visible one adds the populate-expectation clause, the SR one stays the conservative sentence `chart-summary.js` owns.

## Why

Repo rule: all user-facing strings live in `translations.js`. These were the last hardcoded chart strings, and two of them ignored language switches.

## Proof

- Agent run: lint / validate EXIT=0, tests **1650/1650** (3 new), build green, sitemap restored after build; browser proof on built dist — forced the deterministic no-data path (`setCustomData([])`) and strict-equality-checked rendered text against `TRANSLATIONS` in EN, then after a live `setLang('ar')`.
- Coordinator reproduction (independent browser run on the built dist): EN → `No data for this range yet — data populates as updates arrive` / `Charts by TradingView`; after `setLang('ar')` → `لا تتوفر بيانات بعد — ستظهر البيانات عند وصول التحديثات` / `مخططات من TradingView`. New unit test re-run independently: 3/3.

## Risks

Low — string relocation plus two language-switch fixes; no change to chart data paths, SR summary machinery, or existing keys. `translations.js` diff is 6 added lines, nothing reordered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy relocation and small setLang/fallback state changes only; chart data and rendering paths are unchanged.
> 
> **Overview**
> **GoldChart** no longer hardcodes EN/AR for load failures, empty-range messaging, or the TradingView attribution link. Those strings now come from three new keys in `translations.js` (`chart.fallback.loadError`, `chart.fallback.noData`, `chart.attribution.tradingView`) via `translate()`.
> 
> **Language switching** is fixed for DOM the chart creates once: `setLang()` re-applies attribution text, tracks `_fallbackReason` so a pre-init load-error message updates when `_ready` is false, and still refreshes no-data copy through `_render()`.
> 
> **Tests** in `tests/chart-fallback-i18n.test.js` lock in bilingual keys, forbid inline Arabic/attribution literals in `chart.js`, and align no-data wording with `chart.summary.noData`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec15c92f5938e85b7a3e5ff67c470a1e5dc27088. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->