### PR TITLE
fix(i18n): bidi-isolate signed deltas so RTL cannot reorder leading signs

### DIFF
--- a/src/components/MarketSummaryTicker.js
+++ b/src/components/MarketSummaryTicker.js
@@ -18,6 +18,7 @@
  */
 
 import { el, clear } from '../lib/safe-dom.js';
+import { bidiIsolate } from '../lib/formatter.js';
 
 let _tickerEl = null;
 let _lang = 'en';
@@ -144,7 +145,9 @@ export function updateMarketSummaryTicker(data = {}) {
   if (data.changePct != null) {
     const changeItems = _tickerEl.querySelectorAll('.mst-item--spot .mst-item__change');
     const sign = data.changePct >= 0 ? '▲' : '▼';
-    const changeText = `${sign}${Math.abs(data.changePct).toFixed(2)}%`;
+    // bidiIsolate: the direction glyph is bidi-neutral like a leading sign — keep
+    // it attached to the digits in RTL (audit E)
+    const changeText = bidiIsolate(`${sign}${Math.abs(data.changePct).toFixed(2)}%`);
     changeItems.forEach((el) => {
       el.textContent = changeText;
     });

--- a/src/lib/formatter.js
+++ b/src/lib/formatter.js
@@ -143,6 +143,32 @@ export function formatPercentChange(change, base) {
 }
 
 /**
+ * Wrap a rendered string in Unicode bidi isolates: LRI (U+2066) … PDI (U+2069).
+ *
+ * Why (audit E — RTL displacement of leading signs): signed delta strings like
+ * `"+12.3%"` or `"−$36.30"` are Latin-digit numerics whose leading `+`/`−` is a
+ * bidi-neutral character. Embedded in an RTL (Arabic) paragraph, the Unicode
+ * bidi algorithm resolves that sign to the paragraph direction and displaces
+ * it to the other side of the digits — the user sees `"12.3%+"`. Wrapping the
+ * final signed string in a left-to-right isolate pins its internal order
+ * (correct for Latin-digit numerics) while keeping it a first-class isolate in
+ * the surrounding RTL flow. Harmless in LTR (English) context, so callers wrap
+ * unconditionally.
+ *
+ * Only use this on strings assigned to the DOM (textContent / text nodes /
+ * aria-labels). Never on strings that feed clipboard, share, CSV, or other
+ * plain-text exports — invisible control characters leak into pasted text.
+ *
+ * @param {string|null|undefined} text  Final display string.
+ * @returns {string|null|undefined}  Isolated string; `null`/`undefined`/`''`
+ *   pass through unchanged.
+ */
+export function bidiIsolate(text) {
+  if (text === null || text === undefined || text === '') return text;
+  return `\u2066${text}\u2069`;
+}
+
+/**
  * Format a UTC timestamp as a short date string (`"Apr 24"` style).
  * Defaults to `Asia/Dubai`.
  * Returns `'—'` for missing or invalid inputs.

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -485,7 +485,8 @@ function renderHeroCard() {
     const signStr = absChg >= 0 ? '+' : '−';
     const absFmt = fmt.formatPrice(Math.abs(absChg), 'USD', 2);
     const pctFmt = Math.abs(pctChg).toFixed(2);
-    changeEl.textContent = `${signStr}${absFmt}  ${signStr}${pctFmt}%`;
+    // bidiIsolate: keep the leading sign attached to the digits in RTL (audit E)
+    changeEl.textContent = fmt.bidiIsolate(`${signStr}${absFmt}  ${signStr}${pctFmt}%`);
     changeEl.className = 'hlc-change ' + (absChg >= 0 ? 'badge-up' : 'badge-down');
     changeEl.hidden = false;
   }
@@ -666,7 +667,8 @@ function renderPriceTrend() {
 
     const isUp = pctChange >= 0;
     const sign = isUp ? '+' : '';
-    const pctStr = `${sign}${pctChange.toFixed(1)}%`;
+    // bidiIsolate: keep the leading sign attached to the digits in RTL (audit E)
+    const pctStr = fmt.bidiIsolate(`${sign}${pctChange.toFixed(1)}%`);
     const priceStr = `$${curr.price.toLocaleString('en', { maximumFractionDigits: 0 })}`;
     const aedStr = `AED ${aedPerGram.toFixed(2)}`;
 
@@ -952,7 +954,12 @@ function renderGCCGrid() {
       const sign = chg >= 0 ? '+' : '';
       const cls = chg >= 0 ? 'badge-up' : 'badge-down';
       headerChildren.push(
-        el('span', { class: `gcc-change badge ${cls}` }, `${sign}${chg.toFixed(2)}%`)
+        // bidiIsolate: keep the leading sign attached to the digits in RTL (audit E)
+        el(
+          'span',
+          { class: `gcc-change badge ${cls}` },
+          fmt.bidiIsolate(`${sign}${chg.toFixed(2)}%`)
+        )
       );
     }
 
@@ -1556,7 +1563,8 @@ function renderMarketInsight() {
   const yearEl = document.getElementById('mi-year-value');
   if (yearEl && Number.isFinite(yearAgo?.price) && yearAgo.price > 0) {
     const pct = ((spot - yearAgo.price) / yearAgo.price) * 100;
-    yearEl.textContent = (pct >= 0 ? '+' : '−') + Math.abs(pct).toFixed(1) + '%';
+    // bidiIsolate: keep the leading sign attached to the digits in RTL (audit E)
+    yearEl.textContent = fmt.bidiIsolate((pct >= 0 ? '+' : '−') + Math.abs(pct).toFixed(1) + '%');
     yearEl.classList.toggle('market-insight__value--up', pct >= 0);
     yearEl.classList.toggle('market-insight__value--down', pct < 0);
   }

--- a/src/pages/portfolio.js
+++ b/src/pages/portfolio.js
@@ -19,7 +19,7 @@ import { CONSTANTS, COUNTRIES, KARATS, TRANSLATIONS } from '../config/index.js';
 import * as api from '../lib/api.js';
 import * as cache from '../lib/cache.js';
 import { getCanonicalSpot } from '../lib/spot-resolver.js';
-import { formatPrice } from '../lib/formatter.js';
+import { bidiIsolate, formatPrice } from '../lib/formatter.js';
 import { mountSharedShell } from '../components/site-shell.js';
 import { injectBreadcrumbs } from '../components/breadcrumbs.js';
 import { updateTicker } from '../components/ticker.js';
@@ -264,15 +264,20 @@ function fmtMoney(value, currency) {
   if (value == null || Number.isNaN(value)) return t().unavailable;
   return formatPrice(value, currency, currencyDecimals(currency));
 }
+// DOM-display only (via gainNodes) — bidiIsolate keeps the leading sign attached
+// to the digits in RTL (audit E). CSV/JSON exports use holdingsToCsv/serialize
+// paths and never see these strings.
 function fmtSigned(value, currency) {
   if (value == null || Number.isNaN(value)) return t().unavailable;
   const sign = value > 0 ? '+' : value < 0 ? '−' : '';
-  return `${sign}${formatPrice(Math.abs(value), currency, currencyDecimals(currency))}`;
+  return bidiIsolate(
+    `${sign}${formatPrice(Math.abs(value), currency, currencyDecimals(currency))}`
+  );
 }
 function fmtSignedPct(value) {
   if (value == null || Number.isNaN(value)) return '';
   const sign = value > 0 ? '+' : value < 0 ? '−' : '';
-  return `(${sign}${Math.abs(value).toFixed(1)}%)`;
+  return bidiIsolate(`(${sign}${Math.abs(value).toFixed(1)}%)`);
 }
 
 /**

--- a/src/tracker/_ctx.js
+++ b/src/tracker/_ctx.js
@@ -1,5 +1,6 @@
 // tracker/_ctx.js — shared render context for tracker submodules
 import { TRANSLATIONS } from '../config/index.js';
+import { bidiIsolate } from '../lib/formatter.js';
 
 export let _state = null;
 export let _el = null;
@@ -44,9 +45,12 @@ export function formatUnitLabel(unit) {
   return unit;
 }
 
+// DOM-display only (decision cues + chart stat cards) — bidiIsolate keeps the
+// leading sign attached to the digits in RTL (audit E). The share/clipboard
+// brief (events.js) builds its own plain strings and never uses this.
 export function formatPercent(value) {
   if (!Number.isFinite(value)) return '—';
-  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+  return bidiIsolate(`${value >= 0 ? '+' : ''}${value.toFixed(2)}%`);
 }
 
 // Direction of a price delta with an explicit *flat* band, so a change that

--- a/src/tracker/chart.js
+++ b/src/tracker/chart.js
@@ -10,6 +10,7 @@ import {
 } from '../lib/historical-data.js';
 import { pulseFreshness } from '../lib/freshness-pulse.js';
 import { getFreshnessModel } from './freshness.js';
+import { bidiIsolate } from '../lib/formatter.js';
 
 /**
  * Derive the provenance + freshness label for the synthetic "current price" row
@@ -410,7 +411,8 @@ export function renderChart() {
       cards.push(
         buildStatCard(
           tx('historical.summary.ytdLabel'),
-          `${stats.ytdChange >= 0 ? '+' : ''}${stats.ytdChange.toFixed(1)}%`,
+          // bidiIsolate: keep the leading sign attached to the digits in RTL (audit E)
+          bidiIsolate(`${stats.ytdChange >= 0 ? '+' : ''}${stats.ytdChange.toFixed(1)}%`),
           tx('historical.summary.ytdHint')
         )
       );
@@ -418,7 +420,8 @@ export function renderChart() {
       cards.push(
         buildStatCard(
           tx('historical.summary.yoyLabel'),
-          `${stats.yoyChange >= 0 ? '+' : ''}${stats.yoyChange.toFixed(1)}%`,
+          // bidiIsolate: keep the leading sign attached to the digits in RTL (audit E)
+          bidiIsolate(`${stats.yoyChange >= 0 ? '+' : ''}${stats.yoyChange.toFixed(1)}%`),
           tx('historical.summary.yoyHint')
         )
       );

--- a/src/tracker/hero.js
+++ b/src/tracker/hero.js
@@ -12,6 +12,7 @@ import {
   DIRECTION_GLYPH,
 } from './_ctx.js';
 import { clear, el, setText } from '../lib/safe-dom.js';
+import { bidiIsolate } from '../lib/formatter.js';
 import {
   mountSkeleton,
   skeletonNode,
@@ -64,7 +65,8 @@ function renderPriceChangeStrip(spot, dayOpenSpot) {
     strip,
     tx('heroChangeStrip', {
       sign: DIRECTION_GLYPH[dir],
-      amount: `${sign}$${Math.abs(delta).toFixed(2)}`,
+      // bidiIsolate: keep the leading sign attached to the digits in RTL (audit E)
+      amount: bidiIsolate(`${sign}$${Math.abs(delta).toFixed(2)}`),
       pct: Math.abs(pct).toFixed(2),
     })
   );

--- a/src/tracker/planner.js
+++ b/src/tracker/planner.js
@@ -1,6 +1,7 @@
 import { KARATS } from '../config/index.js';
 import { clear, el } from '../lib/safe-dom.js';
 import { tx, _currentSpot, _el, _priceFor, _state } from './_ctx.js';
+import { bidiIsolate } from '../lib/formatter.js';
 
 export function renderPresets() {
   if (!_el.presetList) return;
@@ -127,7 +128,11 @@ export function renderPlanners() {
         ),
         resultItem(
           tx('planner.gainLoss'),
-          `${gainPrefix}${gainLoss.toFixed(2)} ${_state.selectedCurrency} (${gainLoss >= 0 ? '+' : ''}${gainLossPercent.toFixed(1)}%)`,
+          // bidiIsolate: keep the leading sign attached to the digits in RTL (audit E).
+          // DOM-only — this string never feeds clipboard/share/export.
+          bidiIsolate(
+            `${gainPrefix}${gainLoss.toFixed(2)} ${_state.selectedCurrency} (${gainLoss >= 0 ? '+' : ''}${gainLossPercent.toFixed(1)}%)`
+          ),
           { color: gainColor }
         )
       );

--- a/tests/bidi-isolate.test.js
+++ b/tests/bidi-isolate.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// bidiIsolate() — audit E: RTL bidi reordering of signed deltas.
+// A leading +/− before Latin digits is a bidi-neutral character; in an RTL
+// (Arabic) paragraph the Unicode bidi algorithm displaces it to the far side
+// of the digits ("+12.3%" renders as "12.3%+"). bidiIsolate() wraps the final
+// display string in LRI (U+2066) … PDI (U+2069) so its internal order is
+// pinned left-to-right while remaining an isolate in the surrounding flow.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const LRI = '\u2066';
+const PDI = '\u2069';
+
+async function loadFormatter() {
+  const url = new URL('file://' + path.resolve(__dirname, '..', 'src', 'lib', 'formatter.js'));
+  return import(url.href);
+}
+
+describe('bidiIsolate', () => {
+  test('wraps a signed percent in LRI…PDI', async () => {
+    const { bidiIsolate } = await loadFormatter();
+    assert.equal(bidiIsolate('+12.3%'), `${LRI}+12.3%${PDI}`);
+  });
+
+  test('wraps a minus-signed amount in LRI…PDI', async () => {
+    const { bidiIsolate } = await loadFormatter();
+    assert.equal(bidiIsolate('−36.30'), `${LRI}−36.30${PDI}`);
+    assert.equal(bidiIsolate('−$36.30'), `${LRI}−$36.30${PDI}`);
+  });
+
+  test('wraps glyph-prefixed deltas (▲/▼ are bidi-neutral like signs)', async () => {
+    const { bidiIsolate } = await loadFormatter();
+    assert.equal(bidiIsolate('▼1.25%'), `${LRI}▼1.25%${PDI}`);
+  });
+
+  test('passes null, undefined, and empty string through unchanged', async () => {
+    const { bidiIsolate } = await loadFormatter();
+    assert.equal(bidiIsolate(null), null);
+    assert.equal(bidiIsolate(undefined), undefined);
+    assert.equal(bidiIsolate(''), '');
+  });
+
+  test('wraps placeholder strings too (harmless for neutral text)', async () => {
+    const { bidiIsolate } = await loadFormatter();
+    assert.equal(bidiIsolate('—'), `${LRI}—${PDI}`);
+  });
+
+  test('output contains exactly one LRI and one PDI, balanced', async () => {
+    const { bidiIsolate } = await loadFormatter();
+    const out = bidiIsolate('+0.89%');
+    assert.equal(out.at(0), LRI);
+    assert.equal(out.at(-1), PDI);
+    assert.equal([...out].filter((c) => c === LRI).length, 1);
+    assert.equal([...out].filter((c) => c === PDI).length, 1);
+  });
+});

--- a/tests/e2e/rtl-signed-delta-isolation.spec.js
+++ b/tests/e2e/rtl-signed-delta-isolation.spec.js
@@ -1,0 +1,84 @@
+// @ts-check
+// Audit E — RTL bidi reordering of signed deltas.
+//
+// In Arabic (RTL) context a signed delta like "+$36.30" visually reorders to
+// "$36.30+" because the leading sign is bidi-neutral and gets displaced by the
+// Unicode bidi algorithm. The fix wraps every DOM-rendered signed delta in
+// LRI (U+2066) … PDI (U+2069) via bidiIsolate() — unconditionally, in EN too
+// (invisible and harmless in LTR).
+//
+// This spec is network-independent: the spot price comes from the committed
+// local /data/gold_price.json snapshot, and the day-open reference is seeded
+// into localStorage (1% below spot, so the day change is always a non-flat,
+// signed delta) before the page loads.
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const LRI = '\u2066';
+const PDI = '\u2069';
+const ISOLATED_DELTA = new RegExp(`${LRI}[^${PDI}]*\\d[^${PDI}]*${PDI}`);
+
+function readLocalSpot() {
+  const raw = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'data', 'gold_price.json'),
+    'utf-8'
+  );
+  const spot = JSON.parse(raw).xau_usd_per_oz;
+  if (!Number.isFinite(spot) || spot <= 0) {
+    throw new Error('data/gold_price.json has no usable xau_usd_per_oz');
+  }
+  return spot;
+}
+
+async function seedDayOpen(page) {
+  const dayOpen = Math.round(readLocalSpot() * 0.99 * 100) / 100;
+  await page.addInitScript((price) => {
+    const dubaiDate = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Dubai' });
+    window.localStorage.setItem('gold_day_open', JSON.stringify({ price, dubaiDate }));
+  }, dayOpen);
+}
+
+test.describe('Signed deltas are bidi-isolated (audit E)', () => {
+  test('tracker ?lang=ar renders the day-change delta wrapped in LRI…PDI', async ({
+    page,
+    baseURL,
+  }) => {
+    await seedDayOpen(page);
+    await page.goto((baseURL || '') + '/tracker.html?lang=ar', { waitUntil: 'load' });
+
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+
+    const strip = page.locator('#tp-price-change-strip');
+    await strip.waitFor({ state: 'attached', timeout: 20000 });
+    // Auto-retrying: waits until the strip has rendered its signed delta.
+    await expect(strip).toHaveText(ISOLATED_DELTA, { timeout: 20000 });
+
+    const text = await strip.textContent();
+    expect(text).toContain(LRI);
+    expect(text).toContain(PDI);
+    // The signed amount itself must sit inside the isolate, not outside it.
+    expect(text).toMatch(new RegExp(`${LRI}[+−]\\$?\\d`));
+  });
+
+  test('tracker ?lang=en still renders the delta (isolation chars allowed in EN)', async ({
+    page,
+    baseURL,
+  }) => {
+    await seedDayOpen(page);
+    await page.goto((baseURL || '') + '/tracker.html?lang=en', { waitUntil: 'load' });
+
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+
+    const strip = page.locator('#tp-price-change-strip');
+    await strip.waitFor({ state: 'attached', timeout: 20000 });
+    await expect(strip).toHaveText(ISOLATED_DELTA, { timeout: 20000 });
+
+    const text = await strip.textContent();
+    // EN keeps the isolate wrapper too — simpler, and invisible in LTR.
+    expect(text).toContain(LRI);
+    expect(text).toContain(PDI);
+    // Human-visible content is intact around the control characters.
+    expect(text.replace(new RegExp(`[${LRI}${PDI}]`, 'g'), '')).toMatch(/[+−]\$\d/);
+  });
+});

--- a/tests/market-summary-ticker.test.js
+++ b/tests/market-summary-ticker.test.js
@@ -202,7 +202,8 @@ test('updateMarketSummaryTicker formats prices, change direction, market state, 
     );
     assert.deepEqual(
       ticker.querySelectorAll('.mst-item--spot .mst-item__change').map((node) => node.textContent),
-      ['▼1.25%', '▼1.25%']
+      // LRI…PDI (U+2066/U+2069) — bidiIsolate() pins the glyph+digits order in RTL (audit E)
+      ['\u2066▼1.25%\u2069', '\u2066▼1.25%\u2069']
     );
     assert.ok(
       ticker


### PR DESCRIPTION
Campaign queue item 17 (audit E, high). In Arabic (RTL) flow, the leading +/− of a Latin-digit delta is bidi-neutral, so the Unicode bidi algorithm displaces it to the far side of the digits — "+$36.30" renders as "$36.30+". The audit prescribed "bidi isolation in the shared delta formatter"; investigation found there **is no shared delta formatter** — deltas are hand-built at nine scattered sites (and `formatPercentChange()` in formatter.js is dead code with zero consumers, left untouched).

## What

- New `bidiIsolate()` in `src/lib/formatter.js` — wraps a final display string in LRI (U+2066) … PDI (U+2069), with JSDoc explaining the audit-E failure mode and warning never to use it on clipboard/CSV/share strings.
- Applied to every DOM-rendered signed-delta site: home hero day-change, monthly trend cards, GCC country badges, market-insight 12-month stat (`home.js`); portfolio `fmtSigned`/`fmtSignedPct` (DOM-only via gainNodes); tracker chart YTD/YoY stat cards; tracker planner gain/loss result; tracker hero day-change strip; tracker `_ctx.formatPercent` (transitively covers decision cues + chart change card); market summary ticker spot-change (the ▲/▼ glyph is bidi-neutral like a sign).
- **Deliberately NOT wrapped** (audited): tracker share brief (`events.js` builds its own plain `toFixed` strings), the preset copy-URL path (copies `location.href`), portfolio CSV/JSON exports (`holdingsToCsv`/`serializePortfolio` never consume these formatters). No invisible control characters can leak into pasted or exported text. Aria-labels were kept isolate-free — every wrap targets visible text nodes.
- Tests: new `tests/bidi-isolate.test.js` (6 unit tests), new `tests/e2e/rtl-signed-delta-isolation.spec.js` (network-free: committed snapshot + seeded day-open), one assertion updated in `tests/market-summary-ticker.test.js` (semantic value unchanged, now expects the isolate wrapper).

## Proof

- **Reproduced twice pre-fix, measured, on the built dist**: tracker `#tp-price-change-strip` in `?lang=ar` had `direction:rtl`, zero isolation chars, and the sign glyph measured RIGHT of the digits via `Range.getBoundingClientRect` (signX 1121.3 > digitX 1081.6). Post-fix: signX 1081.5 < digitX 1095.9 (sign correctly precedes digits) and the string carries U+2066/U+2069; EN rendering unchanged (signX 166.2 < digitX 180.6).
- Agent gates: lint / validate PASS, tests **1653/1653**, build PASS, spec 4/4 (`--repeat-each=2`).
- Coordinator reproduction (independent runs): unit tests 9/9, e2e spec 2/2; clipboard/export exclusion claims re-audited by tracing every consumer.

## Honest caveats

- Home `#hlc-change` computes `direction:ltr` even in AR (CSS pins it), so its defect is currently masked — wrapped anyway for defense-in-depth; the visually-proven reorder is the tracker strip.
- Chart YTD/YoY and portfolio/planner sites can't render deltas offline in-browser; their defect is the identical string construction, covered by the shared helper + unit tests.
- EN keeps the isolate chars (unconditional wrap) — invisible, harmless, simpler; the EN e2e test asserts exactly that.

## Risks

Isolation chars now appear in `textContent` of these elements — future exact-string assertions must include U+2066/U+2069 (one existing test updated). If a wrapped string were ever rerouted into copy/export text the invisible chars would leak; the JSDoc warns against this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only i18n fix with clear export exclusions; main follow-on is tests or assertions that compare exact `textContent` must account for U+2066/U+2069.
> 
> **Overview**
> Fixes **audit E**: in Arabic (`dir=rtl`), bidi-neutral leading signs on Latin-digit deltas (e.g. `+12.3%`, `−$36.30`, `▲1.25%`) were visually reordering so the sign appeared after the number.
> 
> Adds **`bidiIsolate()`** in `formatter.js`, wrapping display strings in Unicode LRI…PDI (U+2066/U+2069) with JSDoc limiting use to **DOM text only** (not clipboard, CSV, share, or exports).
> 
> Call sites now wrap hand-built signed deltas on **home** (hero day change, trend cards, GCC badges, 12‑month insight), **portfolio** (`fmtSigned` / `fmtSignedPct` for gain UI), **tracker** (hero change strip, chart YTD/YoY stats, planner gain/loss, shared `formatPercent`), and **market summary ticker** spot change. Wrapping is **unconditional** (EN included; invisible in LTR).
> 
> **Tests:** new unit tests for `bidiIsolate`, Playwright RTL/LTR tracker strip spec, and updated market-summary-ticker expectations for isolate characters in `textContent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66991d74ae3b49d371514b7cd937ec2346327382. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->