### PR TITLE
fix(a11y): real table semantics for the shops-compare modal

### DIFF
--- a/src/components/shops-compare.js
+++ b/src/components/shops-compare.js
@@ -259,11 +259,11 @@ export function openCompareModal() {
         <button type="button" class="shops-compare-modal-close" aria-label="${t('close')}">×</button>
       </div>
       <div class="shops-compare-modal-body">
-        <table class="shops-compare-table">
+        <table class="shops-compare-table" aria-labelledby="shops-compare-modal-title">
           <thead>
             <tr>
-              <th></th>
-              ${shops.map((s) => `<th><strong>${esc(s.name)}</strong><br><small>${esc(s.market)}</small></th>`).join('')}
+              <td></td>
+              ${shops.map((s) => `<th scope="col"><strong>${esc(s.name)}</strong><br><small>${esc(s.market)}</small></th>`).join('')}
             </tr>
           </thead>
           <tbody>
@@ -271,7 +271,7 @@ export function openCompareModal() {
               .map(
                 (row) => `
               <tr>
-                <td class="shops-compare-row-label">${t(row.key)}</td>
+                <th scope="row" class="shops-compare-row-label">${t(row.key)}</th>
                 ${shops.map((s) => `<td>${row.fn(s)}</td>`).join('')}
               </tr>
             `

--- a/styles/components/shops-map.css
+++ b/styles/components/shops-map.css
@@ -364,7 +364,9 @@
   color: var(--color-text-muted);
 }
 
-.shops-compare-row-label {
+/* Row labels are <th scope="row">; the extra specificity keeps this rule
+   winning over `.shops-compare-table th` (column-header sizing) above. */
+.shops-compare-table .shops-compare-row-label {
   font-weight: 600;
   color: var(--color-text-muted);
   font-size: var(--text-xs);

--- a/tests/e2e/shops-compare-table-a11y.spec.js
+++ b/tests/e2e/shops-compare-table-a11y.spec.js
@@ -1,0 +1,81 @@
+const { test, expect } = require('@playwright/test');
+
+// Regression guard for the shops compare-modal table semantics (audit B).
+//
+// The modal table rendered its row labels as `<td class="shops-compare-row-label">`,
+// its column headers as bare `<th>` without `scope="col"`, its corner cell as an
+// empty `<th>`, and carried no accessible name — so screen readers navigating a
+// shop column never heard which attribute (Location / Market / …) a cell
+// belonged to. Fix: row labels are `<th scope="row">`, column headers carry
+// `scope="col"`, the corner is a plain `<td>`, and the table is named via
+// `aria-labelledby="shops-compare-modal-title"` (the dialog's visible,
+// localized title — no new strings).
+//
+// This spec drives the real UI (select shops on the grid, open the compare
+// modal from the sticky bar) in EN and AR and locks all four fixes. Shops
+// render from bundled local data, so no network is required. Sticky overlays
+// (header spot bar, mobile bottom nav) intercept pointer clicks at 390px, so
+// shop selection dispatches DOM clicks on the real buttons — the page's own
+// listeners still run.
+
+const MOBILE = { width: 390, height: 844 };
+
+async function openCompareModal(page, lang) {
+  await page.goto(`/shops.html${lang === 'ar' ? '?lang=ar' : ''}`);
+  if (lang === 'ar') {
+    await page.waitForFunction(() => document.documentElement.dir === 'rtl', undefined, {
+      timeout: 10000,
+    });
+  }
+  await page.waitForSelector('[data-compare-shop-id]', { state: 'attached', timeout: 10000 });
+  await page.$$eval('[data-compare-shop-id]', (btns) => btns.slice(0, 3).forEach((b) => b.click()));
+  await page.waitForSelector('.shops-compare-bar-go:not([disabled])', {
+    state: 'attached',
+    timeout: 10000,
+  });
+  await page.$eval('.shops-compare-bar-go', (b) => b.click());
+  await page.waitForSelector('.shops-compare-table', { state: 'attached', timeout: 10000 });
+}
+
+test.describe('Shops compare modal table semantics', () => {
+  test.use({ viewport: MOBILE });
+
+  for (const lang of ['en', 'ar']) {
+    test(`[${lang}] row headers, column scopes, corner cell, table name`, async ({ page }) => {
+      await openCompareModal(page, lang);
+
+      const r = await page.evaluate(() => {
+        const table = document.querySelector('.shops-compare-table');
+        const bodyRows = [...table.querySelectorAll('tbody tr')];
+        const headCells = [...table.querySelectorAll('thead tr > *')];
+        const corner = headCells[0];
+        const colHeads = headCells.slice(1);
+        const labelId = table.getAttribute('aria-labelledby');
+        const labelEl = labelId && document.getElementById(labelId);
+        return {
+          bodyRowCount: bodyRows.length,
+          badRowLabels: bodyRows.filter((tr) => {
+            const first = tr.firstElementChild;
+            return !(first.tagName === 'TH' && first.getAttribute('scope') === 'row');
+          }).length,
+          colHeadCount: colHeads.length,
+          badColHeads: colHeads.filter(
+            (c) => !(c.tagName === 'TH' && c.getAttribute('scope') === 'col')
+          ).length,
+          cornerTag: corner.tagName,
+          labelId,
+          labelText: labelEl ? labelEl.textContent.trim() : '',
+          labelIsModalTitle: labelId === 'shops-compare-modal-title' && !!labelEl,
+        };
+      });
+
+      expect(r.bodyRowCount, 'compare table renders attribute rows').toBeGreaterThan(0);
+      expect(r.badRowLabels, 'every tbody row starts with th[scope=row]').toBe(0);
+      expect(r.colHeadCount, 'one column header per compared shop').toBe(3);
+      expect(r.badColHeads, 'every shop column header is th[scope=col]').toBe(0);
+      expect(r.cornerTag, 'corner cell must not be a header').toBe('TD');
+      expect(r.labelIsModalTitle, 'table named by the visible modal title').toBeTruthy();
+      expect(r.labelText.length, 'accessible name resolves to non-empty text').toBeGreaterThan(0);
+    });
+  }
+});


### PR DESCRIPTION
Table-workstream opener (campaign queue item 9, audit B) — the shops-compare modal table announced nothing useful to screen readers. All four defects re-confirmed in-browser on the live modal before fixing.

## What

`src/components/shops-compare.js` (4 markup fixes, no behavior change):
- Row labels `<td>` → `<th scope="row">` — navigating a shop's column now announces which attribute each value belongs to.
- Column headers get `scope="col"`.
- The empty corner cell `<th>` → `<td>`.
- The table gets `aria-labelledby="shops-compare-modal-title"` — an accessible name from the existing visible title, zero new strings.

`styles/components/shops-map.css`: one selector bumped (`.shops-compare-row-label` → `.shops-compare-table .shops-compare-row-label`) so the label styling keeps out-specifying the generic `th` sizing rule now that labels are `th` — no visual change.

New `tests/e2e/shops-compare-table-a11y.spec.js`: drives the real UI (select shops, open modal) in EN and AR at 390px, asserts rowheader/columnheader roles, corner-cell type, and the resolving accessible name. No sleeps, no network dependence.

## Scroll-region verdict (checked per the #679 pattern)

`.shops-compare-modal-body` is **not** a scroll region at 390px or 1280px, so the region/tabindex pattern was correctly not applied there. However, at 390px the mobile media query makes the **table itself** the horizontal scroller (`display:block; overflow-x:auto`, scrollWidth 645 vs clientWidth 350) and it is not keyboard-focusable — the same class of issue #679 fixed elsewhere, but resolving it needs restyling (a wrapper div or moving overflow to the modal body). Deliberately deferred to the upcoming table styling/`.ds-table` slice rather than smuggled into a semantics fix.

## Proof

- Agent gates: lint / stylelint / validate PASS, tests 1647/1647, build PASS, spec **8/8** (4/4 × 2, second run against a final rebuilt dist); Chromium aria snapshot shows the table with rowheader/columnheader roles and the resolving name.
- Coordinator reproduction (independent spec run on the built dist): 2/2.
- `quality` clean apart from the 3 pre-existing prettier files being fixed in #681.

## Risks

Markup-semantics only; the one CSS edit is a specificity-preserving selector bump with identical computed styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markup and a specificity-only CSS tweak in a modal table; no auth, data, or business-logic changes.
> 
> **Overview**
> **Improves screen-reader navigation** in the shops compare modal by fixing how the comparison table is marked up, without changing compare behavior or visuals.
> 
> The compare table now uses **`aria-labelledby`** pointing at the existing modal title, **row labels as `th scope="row"`**, **shop columns as `th scope="col"`**, and an empty **corner `td`** instead of a stray header cell. **`shops-map.css`** only raises selector specificity for `.shops-compare-row-label` so label styling still wins over generic `th` rules after labels became `th` elements.
> 
> Adds **`tests/e2e/shops-compare-table-a11y.spec.js`** to open the real compare flow in **EN and AR** at 390px and assert those four semantics fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d33f2d632e133fd3c6e3929f11e224764854f94. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->