### PR TITLE
fix(portfolio): value holdings from the cached canonical spot at boot (honest freshness)

### DIFF
--- a/src/pages/portfolio.js
+++ b/src/pages/portfolio.js
@@ -315,6 +315,57 @@ function savePortfolio() {
 }
 
 // ── Live data ─────────────────────────────────────────────────────────────────
+// Set once the forced canonical refresh has delivered a snapshot; from then on
+// the boot seed below must never overwrite the (possibly Live) refreshed state.
+let liveRefreshLanded = false;
+
+/**
+ * Boot seed, synchronous half (audit D): value holdings immediately from the
+ * last persisted gold price — the same localStorage slots the refresh path
+ * writes via `cache.saveGoldPrice()` — instead of blocking first paint on the
+ * forced round-trip (which also waits on the external FX API). Age-gated by
+ * `getFreshBootGoldPrice` (home / tracker boot pattern) so a multi-day-old
+ * price never occupies the valuations. Always labelled 'cached/fallback' with
+ * the payload's REAL timestamp — the badge renders Cached/Stale, never Live.
+ */
+function seedSpotFromBootCache() {
+  if (STATE.spotUsdPerOz) return;
+  const cached = cache.getFreshBootGoldPrice();
+  if (!cached?.price) return;
+  STATE.spotUsdPerOz = cached.price;
+  STATE.goldPriceUsdPerOz = cached.price;
+  STATE.freshness.goldUpdatedAt = cached.updatedAt || null;
+  STATE.spotSource = 'cached/fallback';
+}
+
+/**
+ * Boot seed, async half (audit D): read the canonical resolver WITHOUT force —
+ * the SAME memoized `/data/gold_price.json` snapshot the site shell's ticker
+ * baseline resolves at mount (F-1: one snapshot for every surface, never a
+ * parallel fetch). It typically lands in milliseconds, so holdings get an
+ * honest cached valuation while the forced refresh (gold + external FX) is
+ * still in flight. The seed never claims Live: `spotSource` stays
+ * 'cached/fallback' and the freshness badge shows the snapshot's real
+ * timestamp/state; `fetchLiveData()` upgrades values + freshness in place when
+ * it lands. If the resolver fails and no cache exists, the honest
+ * "Waiting for live prices…" first paint is preserved untouched.
+ */
+async function seedSpotFromCanonicalSnapshot() {
+  try {
+    const snap = await getCanonicalSpot();
+    // A late seed must never overwrite the forced refresh's fresher result,
+    // and a failed snapshot must never fabricate a value.
+    if (liveRefreshLanded || !snap?.ok) return;
+    STATE.spotUsdPerOz = snap.spotUsdPerOz;
+    STATE.goldPriceUsdPerOz = snap.spotUsdPerOz;
+    STATE.freshness.goldUpdatedAt = snap.freshness.updatedAt || null;
+    STATE.spotSource = 'cached/fallback';
+    render();
+  } catch {
+    // Resolver unavailable — keep whatever honest state is already rendered.
+  }
+}
+
 async function fetchLiveData() {
   try {
     // F-1: read spot from the shared canonical resolver (same memoized snapshot as
@@ -326,6 +377,7 @@ async function fetchLiveData() {
     ]);
     if (snapRes.status === 'fulfilled' && snapRes.value?.ok) {
       const snap = snapRes.value;
+      liveRefreshLanded = true;
       STATE.spotUsdPerOz = snap.spotUsdPerOz;
       STATE.goldPriceUsdPerOz = snap.spotUsdPerOz;
       STATE.freshness.goldUpdatedAt = snap.freshness.updatedAt || new Date().toISOString();
@@ -1067,6 +1119,9 @@ function render() {
 async function init() {
   cache.loadState(STATE);
   loadPortfolio();
+  // Audit D: returning visitors get valuations on the very first render, from
+  // the honest age-gated localStorage price (labelled cached, never Live).
+  seedSpotFromBootCache();
 
   const urlLang = new URLSearchParams(location.search).get('lang');
   if (urlLang === 'ar' || urlLang === 'en') STATE.lang = urlLang;
@@ -1091,6 +1146,10 @@ async function init() {
 
   applyLang();
   render();
+  // Audit D: fire-and-forget boot seed from the shared canonical snapshot
+  // (already being resolved by the shell's ticker baseline) so holdings render
+  // an honest cached valuation while the forced refresh below is in flight.
+  seedSpotFromCanonicalSnapshot();
   await fetchLiveData();
 
   let refreshTimer = setInterval(fetchLiveData, CONSTANTS.GOLD_REFRESH_MS);

--- a/tests/e2e/portfolio-boot-cached-spot.spec.js
+++ b/tests/e2e/portfolio-boot-cached-spot.spec.js
@@ -1,0 +1,150 @@
+// Portfolio boot cached-spot guard (Verified Work Queue item 10, audit D).
+//
+// The portfolio must value holdings from the canonical cached snapshot at boot
+// instead of blocking first paint on the forced refresh round-trip (which also
+// waits on the external FX API): the shared ticker already shows a cached price
+// on the same page, so "Waiting for live prices…" next to it is a divergence.
+//
+// Encodes three promises:
+//   1. EN + AR: with the local /data/gold_price.json snapshot available,
+//      holdings valuations are non-empty shortly after load (bounded
+//      auto-retrying waits — no sleeps) even while the forced refresh never
+//      lands (its requests are aborted by the route below).
+//   2. Honest freshness: when the source was the cached/fallback boot seed,
+//      the badge never claims Live — it shows cached / stale (or the closed
+//      overlay), always with the snapshot's real timestamp.
+//   3. Honest empty path preserved: with empty storage AND a blocked /data
+//      route, "Waiting for live prices…" stays — no fabricated values.
+const { test, expect } = require('@playwright/test');
+
+const KEY = 'gtl_portfolio_v1';
+const MONEY_RE = /\d[\d,]*\.\d{2}/; // formatPrice always emits en-US digits
+const WAITING_EN = 'Waiting for live prices…';
+const WAITING_AR = 'بانتظار الأسعار الحية…';
+// Never-Live states the cached boot seed may honestly render: cached/stale by
+// age, or the shared market-closed overlay on weekends.
+const HONEST_SEED_STATES = ['cached', 'stale', 'fallback', 'closed'];
+
+const PORTFOLIO = {
+  version: 1,
+  currency: 'AED',
+  holdings: [
+    {
+      id: 'h_spec_boot_1',
+      label: 'Spec bangle',
+      weightGrams: 20,
+      karat: '22',
+      purchaseDate: '2025-11-02',
+      costTotal: 9000,
+      costCurrency: 'AED',
+      createdAt: '2025-11-02T10:00:00.000Z',
+    },
+  ],
+};
+
+// Service workers could satisfy /data requests outside page.route interception;
+// block them so the routes below fully control the data plane.
+test.use({ serviceWorkers: 'block' });
+
+/**
+ * Let the FIRST /data/gold_price.json read (the shell/seed canonical baseline)
+ * succeed, then abort every later one — so the forced refresh can never land
+ * and never upgrade the seed to Live. External FX is aborted outright. What
+ * remains rendered is exactly the boot-seed state this spec asserts on.
+ */
+async function routeCachedOnly(page) {
+  let goldRequests = 0;
+  await page.route('**/data/gold_price.json*', (route) => {
+    goldRequests += 1;
+    if (goldRequests === 1) return route.continue();
+    return route.abort();
+  });
+  await page.route('**/open.er-api.com/**', (route) => route.abort());
+}
+
+async function seedPortfolio(page) {
+  await page.addInitScript(
+    ([key, value]) => localStorage.setItem(key, JSON.stringify(value)),
+    [KEY, PORTFOLIO]
+  );
+}
+
+async function expectSeededValuation(page, waitingText) {
+  const valueCard = page.locator('#portfolio-summary .portfolio-card').first();
+  // Bounded auto-retrying wait: the seed resolves from the local snapshot in
+  // well under this budget; no fixed sleeps.
+  await expect(valueCard).toContainText(MONEY_RE, { timeout: 10000 });
+  await expect(valueCard).not.toContainText(waitingText);
+
+  // Per-holding reference value renders too (not the '—' placeholder).
+  await expect(page.locator('#portfolio-holdings .portfolio-table tbody tr').first()).toContainText(
+    MONEY_RE
+  );
+
+  // Spot badge carries the seeded price…
+  await expect(page.locator('#portfolio-spot-price')).toContainText(/\$\d/);
+  // …and the freshness label NEVER claims Live for a cached/fallback source,
+  // while still carrying real metadata (never blank / not 'unavailable').
+  const state = await page.locator('#portfolio-freshness').getAttribute('data-state');
+  expect(HONEST_SEED_STATES, `freshness state "${state}" must be honest`).toContain(state);
+}
+
+test.describe('Portfolio boot seeds valuations from the cached canonical spot', () => {
+  test('EN: holdings valued shortly after load; freshness never claims Live', async ({
+    page,
+    baseURL,
+  }) => {
+    await routeCachedOnly(page);
+    await seedPortfolio(page);
+    await page.goto((baseURL || '') + '/portfolio.html', { waitUntil: 'domcontentloaded' });
+    await expectSeededValuation(page, WAITING_EN);
+  });
+
+  test('AR: holdings valued shortly after load; freshness never claims Live', async ({
+    page,
+    baseURL,
+  }) => {
+    await routeCachedOnly(page);
+    await seedPortfolio(page);
+    await page.goto((baseURL || '') + '/portfolio.html?lang=ar', {
+      waitUntil: 'domcontentloaded',
+    });
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expectSeededValuation(page, WAITING_AR);
+  });
+
+  test('honest path preserved: no snapshot + no cache keeps "Waiting for live prices…"', async ({
+    page,
+    baseURL,
+  }) => {
+    // Fresh context = empty storage (no gold cache). Block the /data route
+    // entirely: the resolver has nothing honest to return, so no value may be
+    // fabricated.
+    let goldAborts = 0;
+    await page.route('**/data/gold_price.json*', (route) => {
+      goldAborts += 1;
+      return route.abort();
+    });
+    await page.route('**/open.er-api.com/**', (route) => route.abort());
+    await seedPortfolio(page); // holdings exist — only the price is missing
+
+    await page.goto((baseURL || '') + '/portfolio.html', { waitUntil: 'domcontentloaded' });
+
+    const valueCard = page.locator('#portfolio-summary .portfolio-card').first();
+    await expect(valueCard).toContainText(WAITING_EN, { timeout: 10000 });
+
+    // Deterministic settle signal instead of a sleep: the canonical baseline
+    // round and the forced-refresh round each retry the data file 3 times —
+    // once >= 6 aborts have happened, every boot fetch path has exhausted.
+    await expect
+      .poll(() => goldAborts, { timeout: 30000, message: 'both fetch rounds must exhaust' })
+      .toBeGreaterThanOrEqual(6);
+
+    // Still honestly waiting — no fabricated valuation, no fabricated badge.
+    await expect(valueCard).toContainText(WAITING_EN);
+    await expect(valueCard).not.toContainText(MONEY_RE);
+    await expect(page.locator('#portfolio-spot-price')).toHaveText('—');
+    const state = await page.locator('#portfolio-freshness').getAttribute('data-state');
+    expect(['unavailable', 'closed'], `state "${state}" must not claim data`).toContain(state);
+  });
+});


### PR DESCRIPTION
Campaign queue item 10 (audit D) — the portfolio page showed "Waiting for live prices…" for holdings while the shared ticker on the same page already displayed a cached price. Reproduced twice on unmodified main: the ticker had a value at **t=+369ms** while holdings stayed empty for the entire 12.5s observation window, because first valued render was blocked behind `Promise.allSettled` with the external FX API (8s timeouts + backoff).

## What

Two additive boot seeds in `src/pages/portfolio.js`, both honest, zero new strings:

1. **Sync half**: `seedSpotFromBootCache()` before first render — reads the age-gated `cache.getFreshBootGoldPrice()` (the exact boot pattern home and tracker already use at `home.js:1718/2019`, `tracker-pro.js:1427`), so returning visitors get valuations on the very first paint. A multi-day-old price never passes the age gate.
2. **Async half**: fire-and-forget **non-forced** `getCanonicalSpot()` — the same memoized `/data/gold_price.json` snapshot the site shell's ticker resolves at mount (F-1 preserved: one snapshot for every surface, no parallel fetch). Typically lands in milliseconds.

Both label the state `spotSource='cached/fallback'` with the snapshot's **real** timestamp — the freshness badge renders Cached/Stale/Closed with true age, never "Live". A `liveRefreshLanded` guard ensures a late seed can never overwrite the forced refresh's fresher result, and a failed snapshot never fabricates a value: with no cache and no snapshot, the honest "Waiting for live prices…" state is preserved untouched.

New `tests/e2e/portfolio-boot-cached-spot.spec.js` (3 tests): EN seeded valuation + badge-never-claims-Live, AR/RTL same, and the honest empty path (blocked `/data` + empty storage stays "Waiting…" after both fetch rounds exhaust — deterministic abort-settle signal, no sleeps; service workers blocked so routing fully controls the data plane).

## Proof

- Before (unmodified main, ×2): holdings unvalued for ≥12.5s despite cached spot on screen. After: holdings valued at **t=+356ms** (8,921.52 AED from cached spot), badge EN "Closed · 13 min. ago" / AR "مغلق · قبل 13 دقيقة".
- Agent gates: lint / quality / validate PASS, tests **1656/1656**, build PASS, spec 6/6 (`--repeat-each=2`).
- Coordinator reproduction: independent spec run 6/6. (First attempt failed 2/3 because the final rebuild had recreated `dist/` without the deploy-only `data/` directory — the documented plain-build behavior, not a code defect; restoring `data/` reproduced the agent's result exactly.)

## Risks

Additive only; the forced-refresh path is unchanged apart from setting the guard flag. The one behavioral delta is strictly the intended fix: cached-but-honest first paint instead of a blank wait. Calculator shares the same unseeded-boot class of issue but is deliberately outside this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive boot seeding on the portfolio page only; forced refresh behavior is unchanged aside from a guard flag, with E2E coverage for honest cached vs empty states.
> 
> **Overview**
> Fixes portfolio holdings staying on **"Waiting for live prices…"** while the page ticker already shows a cached spot — valuations no longer wait on the forced `getCanonicalSpot({ force: true })` + FX round-trip before first paint.
> 
> **`portfolio.js`** adds two boot paths before/alongside `fetchLiveData`: sync **`seedSpotFromBootCache()`** (age-gated `getFreshBootGoldPrice` from localStorage) and async **`seedSpotFromCanonicalSnapshot()`** (non-forced shared `getCanonicalSpot()`). Both set `spotSource` to **`cached/fallback`** with the snapshot’s real timestamp so the freshness badge never shows Live until the existing forced refresh succeeds; **`liveRefreshLanded`** blocks late seeds from overwriting fresher live data.
> 
> New Playwright spec **`portfolio-boot-cached-spot.spec.js`** covers EN/AR valued-from-cache with honest freshness, and the no-cache + blocked `/data` path that must keep waiting with no fabricated prices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d085a61bc1294506d42cd1b7c8b0401dba5a064e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->