### PR TITLE
fix(a11y): stop tracker live-region spam — announce changes, not churn

### DIFF
--- a/src/pages/tracker-pro.js
+++ b/src/pages/tracker-pro.js
@@ -895,6 +895,20 @@ function formatReadoutPrice(value, currency) {
   return currency ? `${formatted} ${currency}` : `$${formatted}`;
 }
 
+/**
+ * Live-region hygiene (audit E): #tp-hero-readout is aria-live="polite" and
+ * syncHeroReadout runs on every realtime snapshot. Assigning textContent always
+ * replaces the text node — even when the new string is identical — which makes
+ * screen readers re-announce unchanged values on every poll. Only write when
+ * the string actually changed, so the final value is still announced exactly
+ * once per real change.
+ */
+function setTextIfChanged(node, text) {
+  if (!node) return;
+  const next = text == null ? '' : String(text);
+  if (node.textContent !== next) node.textContent = next;
+}
+
 function syncHeroReadout() {
   const spotEl = document.getElementById('tp-readout-spot-value');
   const selectedEl = document.getElementById('tp-readout-selected-value');
@@ -911,22 +925,27 @@ function syncHeroReadout() {
     spot,
   });
 
-  if (spotLabelEl) spotLabelEl.textContent = trackerTx('readout.spotLabel');
+  setTextIfChanged(spotLabelEl, trackerTx('readout.spotLabel'));
   if (selectedLabelEl) {
-    selectedLabelEl.textContent =
+    setTextIfChanged(
+      selectedLabelEl,
       trackerTx('readout.selectedLabel', {
         karat: state.selectedKarat,
         currency: state.selectedCurrency,
-      }) || `${state.selectedKarat}K · ${state.selectedCurrency}`;
+      }) || `${state.selectedKarat}K · ${state.selectedCurrency}`
+    );
   }
   if (spotEl) {
-    spotEl.textContent = spot
-      ? `$${spot.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
-      : '—';
+    setTextIfChanged(
+      spotEl,
+      spot
+        ? `$${spot.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+        : '—'
+    );
     spotEl.removeAttribute('aria-busy');
   }
   if (selectedEl) {
-    selectedEl.textContent = formatReadoutPrice(selectedPrice, state.selectedCurrency);
+    setTextIfChanged(selectedEl, formatReadoutPrice(selectedPrice, state.selectedCurrency));
     selectedEl.removeAttribute('aria-busy');
   }
   if (unitNoteEl) {
@@ -938,11 +957,9 @@ function syncHeroReadout() {
           : state.selectedUnit === 'tola'
             ? 'Tola'
             : 'Kg';
-    unitNoteEl.textContent = trackerTx(`controls.unit${unitKey}`) || state.selectedUnit;
+    setTextIfChanged(unitNoteEl, trackerTx(`controls.unit${unitKey}`) || state.selectedUnit);
   }
-  if (metaHeading) {
-    metaHeading.textContent = trackerTx('commandMeta.heading');
-  }
+  setTextIfChanged(metaHeading, trackerTx('commandMeta.heading'));
 }
 
 function syncUnitSegmented() {

--- a/src/tracker/hero.js
+++ b/src/tracker/hero.js
@@ -38,7 +38,7 @@ function renderPriceChangeStrip(spot, dayOpenSpot) {
   if (!strip) return;
   if (!spot || !dayOpenSpot || dayOpenSpot <= 0) {
     strip.hidden = true;
-    strip.textContent = '';
+    if (strip.textContent) strip.textContent = '';
     return;
   }
   const delta = spot - dayOpenSpot;
@@ -47,29 +47,31 @@ function renderPriceChangeStrip(spot, dayOpenSpot) {
   // change cells (all percent-based). Classifying the strip on the dollar amount
   // let a sub-0.01% move read as ▲ here but • flat next to it.
   const dir = classifyDelta(pct);
-  strip.hidden = false;
-  strip.classList.remove(
-    'tracker-price-change-strip--up',
-    'tracker-price-change-strip--down',
-    'tracker-price-change-strip--flat'
-  );
-  strip.classList.add(`tracker-price-change-strip--${dir}`);
-  strip.setAttribute('role', 'status');
-  strip.setAttribute('aria-live', 'polite');
-  if (dir === 'flat') {
-    setText(strip, tx('heroChangeStripFlat'));
-    return;
-  }
   const sign = dir === 'up' ? '+' : '−';
-  setText(
-    strip,
-    tx('heroChangeStrip', {
-      sign: DIRECTION_GLYPH[dir],
-      // bidiIsolate: keep the leading sign attached to the digits in RTL (audit E)
-      amount: bidiIsolate(`${sign}$${Math.abs(delta).toFixed(2)}`),
-      pct: Math.abs(pct).toFixed(2),
-    })
-  );
+  const text =
+    dir === 'flat'
+      ? tx('heroChangeStripFlat')
+      : tx('heroChangeStrip', {
+          sign: DIRECTION_GLYPH[dir],
+          // bidiIsolate: keep the leading sign attached to the digits in RTL (audit E)
+          amount: bidiIsolate(`${sign}$${Math.abs(delta).toFixed(2)}`),
+          pct: Math.abs(pct).toFixed(2),
+        });
+  strip.hidden = false;
+  const dirClass = `tracker-price-change-strip--${dir}`;
+  if (!strip.classList.contains(dirClass)) {
+    strip.classList.remove(
+      'tracker-price-change-strip--up',
+      'tracker-price-change-strip--down',
+      'tracker-price-change-strip--flat'
+    );
+    strip.classList.add(dirClass);
+  }
+  // Live-region hygiene (audit E): the strip is role="status" aria-live="polite"
+  // in the markup. renderHero + patchHeroLiveTick both call this on every pass;
+  // rewriting identical text re-announces it to screen readers, so only write
+  // when the string actually changed.
+  if (strip.textContent !== text) setText(strip, text);
 }
 
 function buildStackItem(title, copy, badge = null) {

--- a/tests/e2e/tracker-live-region-hygiene.spec.js
+++ b/tests/e2e/tracker-live-region-hygiene.spec.js
@@ -1,0 +1,176 @@
+// Screen-reader live-region hygiene on the tracker (audit E).
+//
+// The tracker refreshes prices continuously. Live regions must announce FINAL values once per
+// real change — never per-frame animation values, per-second countdown ticks, or unchanged
+// re-renders. This spec encodes, in a real browser (EN + AR):
+//
+//   1. Churny surfaces are NOT live regions:
+//      • #tp-countdown rewrites every second → no aria-live/aria-atomic (readable on focus).
+//      • #tp-karat-table price cells are animated per-frame by countUp → no aria-live on the
+//        tbody (a data table is reachable by normal table navigation).
+//      • #tp-summary-list is rebuilt wholesale on every render pass → no aria-live.
+//      Deliberate announcers stay intact: #tp-refresh-badge (role=status, refresh completion),
+//      #tp-alert-live-region (alert triggers), #tp-hero-readout (final price values).
+//
+//   2. Write hygiene inside the remaining live regions, measured with a MutationObserver over
+//      bounded observation windows (childList + characterData records = what SRs re-announce):
+//      • unchanged data (auto-polls + a manual refresh) → ZERO writes;
+//      • a real price change (+25 USD/oz served offline via route interception) → exactly ONE
+//        write per value node (spot + selected), and the new values actually render.
+//
+// No network dependence: /data/gold_price.json is served same-origin by the test web server and
+// the price change is injected with page.route. Offline degraded freshness states are expected.
+const { test, expect } = require('@playwright/test');
+
+const SURFACES = ['/tracker.html', '/tracker.html?lang=ar'];
+
+// Regions that must still be polite live regions, observed for write hygiene.
+const OBSERVED = {
+  heroReadout: '#tp-hero-readout',
+  spotVal: '#tp-readout-spot-value',
+  selVal: '#tp-readout-selected-value',
+  strip: '#tp-price-change-strip',
+};
+
+async function waitForSpotRender(page) {
+  await page.waitForFunction(
+    () => /\d/.test(document.getElementById('tp-readout-spot-value')?.textContent || ''),
+    null,
+    { timeout: 20_000 }
+  );
+}
+
+function installObservers(page) {
+  return page.evaluate((sels) => {
+    window.__liveWrites = {};
+    for (const [name, sel] of Object.entries(sels)) {
+      const node = document.querySelector(sel);
+      if (!node) continue;
+      window.__liveWrites[name] = 0;
+      new MutationObserver((records) => {
+        for (const r of records) {
+          if (r.type === 'childList' || r.type === 'characterData') {
+            window.__liveWrites[name] += 1;
+          }
+        }
+      }).observe(node, { childList: true, characterData: true, subtree: true });
+    }
+  }, OBSERVED);
+}
+
+const grabWrites = (page) => page.evaluate(() => ({ ...window.__liveWrites }));
+const resetWrites = (page) =>
+  page.evaluate(() => {
+    for (const key of Object.keys(window.__liveWrites)) window.__liveWrites[key] = 0;
+  });
+
+test.describe('Tracker live-region hygiene (audit E)', () => {
+  for (const path of SURFACES) {
+    test(`churny surfaces are not live regions; deliberate announcers intact: ${path}`, async ({
+      page,
+      baseURL,
+    }) => {
+      await page.goto((baseURL || '') + path, { waitUntil: 'load' });
+      await waitForSpotRender(page);
+
+      // Ticking countdown must never be a live region (it rewrites every second).
+      const countdown = page.locator('#tp-countdown');
+      await expect(countdown).toHaveCount(1);
+      expect(await countdown.getAttribute('aria-live')).toBeNull();
+      expect(await countdown.getAttribute('aria-atomic')).toBeNull();
+
+      // countUp-animated data table must never be a live region.
+      const karatBody = page.locator('#tp-karat-table');
+      await expect(karatBody).toHaveCount(1);
+      expect(await karatBody.getAttribute('aria-live')).toBeNull();
+
+      // Wholesale-rebuilt Live desk list must never be a live region.
+      const summary = page.locator('#tp-summary-list');
+      await expect(summary).toHaveCount(1);
+      expect(await summary.getAttribute('aria-live')).toBeNull();
+
+      // Deliberate announcement channels must survive the cleanup:
+      // refresh completion (freshness + timestamp) …
+      const refreshBadge = page.locator('#tp-refresh-badge');
+      expect(await refreshBadge.getAttribute('role')).toBe('status');
+      expect(await refreshBadge.getAttribute('aria-live')).toBe('polite');
+      // … triggered price alerts …
+      const alertRegion = page.locator('#tp-alert-live-region');
+      expect(await alertRegion.getAttribute('aria-live')).toBe('polite');
+      // … and the final spot/selected values themselves.
+      const readout = page.locator('#tp-hero-readout');
+      expect(await readout.getAttribute('aria-live')).toBe('polite');
+    });
+
+    test(`live regions: zero writes when unchanged, one write per real change: ${path}`, async ({
+      page,
+      baseURL,
+    }) => {
+      test.setTimeout(60_000);
+      await page.goto((baseURL || '') + path, { waitUntil: 'load' });
+      await waitForSpotRender(page);
+      // Bounded settle window: let boot renders/animations finish before instrumenting.
+      await page.waitForTimeout(1500);
+
+      await installObservers(page);
+
+      // ── Unchanged data: manual refresh + auto-polls within a bounded 8 s window ──
+      await page.click('#tp-refresh-btn');
+      await page.waitForTimeout(8000);
+      const unchanged = await grabWrites(page);
+      expect(unchanged.heroReadout, 'unchanged re-renders must not touch #tp-hero-readout').toBe(0);
+      expect(unchanged.strip, 'unchanged re-renders must not touch #tp-price-change-strip').toBe(0);
+
+      // ── Real price change: +25 USD/oz served offline via route interception ──
+      const baseSpotText = await page
+        .locator('#tp-readout-spot-value')
+        .evaluate((node) => node.textContent);
+      const body = await page.evaluate(async () => {
+        const res = await fetch('/data/gold_price.json');
+        return res.text();
+      });
+      const data = JSON.parse(body);
+      const newSpot = (data.xau_usd_per_oz || data.gold.ounce_usd) + 25;
+      data.xau_usd_per_oz = newSpot;
+      data.gold.ounce_usd = newSpot;
+      data.fetched_at_utc = new Date().toISOString();
+      data.timestamp_utc = new Date().toISOString();
+
+      await resetWrites(page);
+      await page.route('**/data/gold_price.json*', (route) =>
+        route.fulfill({ contentType: 'application/json', body: JSON.stringify(data) })
+      );
+      await page.click('#tp-refresh-btn');
+
+      // The hero readout always formats spot in en-US (both EN and AR pages).
+      const expectedSpotText = `$${newSpot.toLocaleString('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })}`;
+      await expect(page.locator('#tp-readout-spot-value')).toHaveText(expectedSpotText, {
+        timeout: 10_000,
+      });
+      expect(expectedSpotText).not.toBe(baseSpotText);
+      // Bounded settle window: countUp caps at 800 ms, directional flash at 1 s.
+      await page.waitForTimeout(1600);
+
+      const changed = await grabWrites(page);
+      // Final values are announced exactly once per real value change — no animation churn.
+      expect(changed.spotVal, 'spot value: one live write per real change').toBe(1);
+      expect(changed.selVal, 'selected value: one live write per real change').toBe(1);
+      expect(
+        changed.heroReadout,
+        'no other writer may churn the hero readout live region'
+      ).toBeLessThanOrEqual(2);
+      expect(changed.strip, 'day-change strip: at most one write per change').toBeLessThanOrEqual(
+        1
+      );
+
+      // Information is preserved: the (non-live) karat table still updated to the new price.
+      const karat24 = await page
+        .locator('[data-karat-price="24"]')
+        .evaluate((node) => node.textContent.trim());
+      expect(karat24).toMatch(/^\d+(\.\d{2})?$/);
+    });
+  }
+});

--- a/tracker.html
+++ b/tracker.html
@@ -403,7 +403,10 @@
               <span class="tracker-hint-text tracker-hint-keyboard" id="tp-hero-hints" aria-hidden="true">
                 <kbd>R</kbd> refresh · <kbd>H</kbd> live · <kbd>C</kbd> compare · <kbd>?</kbd> help
               </span>
-              <span class="tracker-hint-text tracker-hint-countdown" id="tp-countdown" aria-live="polite" aria-atomic="true"></span>
+              <!-- Live-region hygiene (audit E): the countdown rewrites every second — a polite
+                   live region here would announce forever. Refresh completion is announced by
+                   #tp-refresh-badge (role="status"); the countdown stays readable on focus. -->
+              <span class="tracker-hint-text tracker-hint-countdown" id="tp-countdown"></span>
             </div>
           </div>
 
@@ -411,10 +414,13 @@
           <aside class="tracker-hero-aside" aria-label="Quick reference">
             <div class="tracker-side-card">
               <h2 class="tracker-side-heading" id="tp-live-summary-heading">Live desk</h2>
+              <!-- Live-region hygiene (audit E): renderHero rebuilds this list wholesale on
+                   every render pass, so aria-live re-announced the whole Live desk each refresh
+                   even when nothing changed. Freshness changes are announced by
+                   #tp-refresh-badge (role="status"); the list stays reachable by navigation. -->
               <div
                 class="tracker-side-list"
                 id="tp-summary-list"
-                aria-live="polite"
                 aria-labelledby="tp-live-summary-heading"
               ></div>
             </div>
@@ -765,7 +771,11 @@
                     <th scope="col" data-i18n="karat.colVs24k">vs 24K</th>
                   </tr>
                 </thead>
-                <tbody id="tp-karat-table" aria-live="polite" aria-atomic="false"></tbody>
+                <!-- Live-region hygiene (audit E): this is a data table whose price cells are
+                     animated per-frame by countUp — aria-live here made screen readers announce
+                     dozens of intermediate values per refresh. Rows stay reachable by normal
+                     table navigation; refresh completion is announced by #tp-refresh-badge. -->
+                <tbody id="tp-karat-table"></tbody>
               </table>
             </div>
           </aside>


### PR DESCRIPTION
Campaign queue item 16 (audit E, high). Screen-reader users on the tracker were flooded: measured on unmodified main with MutationObserver instrumentation (2 identical runs, built dist):

- **168 (EN) / 182 (AR)** childList+characterData mutations inside the `aria-live` karat `<tbody>` per changed refresh — countUp animates price cells frame-by-frame inside a live region.
- **21–22** countdown announcements in a 2.5s refresh-churn window (`#tp-countdown` was `aria-live="polite" aria-atomic="true"` and rewrites every second by design).
- **5** identical-text writes into the live `#tp-hero-readout` per **unchanged** snapshot, plus a wholesale `#tp-summary-list` rebuild re-announcing the whole "Live desk" every render pass.

## What (zero new strings; SR users keep all final values)

- `tracker.html`: `aria-live` removed from the karat data `<tbody>`, the per-second countdown, and the wholesale-rebuilt summary list — all remain fully navigable; each removal carries a comment pointing at the announcer that covers it. Refresh completion **is** announced by the existing `#tp-refresh-badge` `role="status"` (verified: `applyStatusBadge`, freshness.js:68–75; the existing unit test `tracker-dom.test.js` already encodes that contract).
- `src/tracker/hero.js`: the still-live hero readout and price-change strip now only write when the text actually changed (`setTextIfChanged` / changed-text+class guards); the strip also stops re-setting its `role`/`aria-live` attributes per call (declared in markup).
- `src/pages/tracker-pro.js`: countdown updater unchanged visually; write-guards on re-renders.
- The deliberate alert announcer at `tracker-pro.js:1034` is untouched and spec-asserted intact. `count-up.js` untouched — no countUp target remains inside any live region.

New `tests/e2e/tracker-live-region-hygiene.spec.js` (EN + AR): asserts the three regions carry no `aria-live`, unchanged re-renders produce zero live-region writes over a bounded observation window, a real injected price change produces exactly one write per value node, and the refresh badge + alert regions keep their live semantics.

## Audit corrections (honesty)

- The audit's claim that hero countUp targets sit in live regions was **partially wrong**: `tp-mobile-price-value` and the hero stat values are NOT inside any live region — only the karat tbody was a live countUp target. Fixed what's real.
- After: countdown **0** announced writes (still ticks visually), karat refresh **0** live-region-visible writes (animation intact), unchanged snapshots **0** writes; a real +$25/oz change produces exactly 1 write per value node.

## Proof

- Agent gates: lint / quality / validate PASS, tests **1656/1656**, build PASS, spec 8/8 (`--repeat-each=2`).
- Coordinator reproduction: spec **4/4 pass** on the fixed dist AND **4/4 fail** on an unmodified-main baseline dist — the spec provably detects the defect it guards against.

## Risks

Attribute removals + write guards only; no visual change (countUp animation and countdown tick remain). If any removed region turns out to carry announcements someone relied on, the summary/table content is still reachable by normal SR navigation, and the refresh badge remains the single, calm announcer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Accessibility-only markup and write guards; visuals and countUp behavior unchanged. Removed regions remain navigable; refresh and alert live regions are preserved.
> 
> **Overview**
> Stops screen-reader **live-region spam** on the gold tracker by removing `aria-live` from surfaces that update constantly (per-second countdown, `countUp`-animated karat table body, wholesale-rebuilt Live desk list) while keeping intentional announcers (`#tp-hero-readout`, `#tp-refresh-badge`, alerts).
> 
> **`tracker.html`** drops live-region attributes on `#tp-countdown`, `#tp-summary-list`, and `#tp-karat-table` with inline comments pointing at `#tp-refresh-badge` for refresh completion.
> 
> **`src/pages/tracker-pro.js`** adds `setTextIfChanged` and routes hero readout updates through it so unchanged polls do not re-announce spot/selected labels and values.
> 
> **`src/tracker/hero.js`** updates the day-change strip only when text or direction class actually changes, and avoids clearing/rewriting `role`/`aria-live` on every render.
> 
> **`tests/e2e/tracker-live-region-hygiene.spec.js`** (EN + AR) asserts churny nodes are not live regions, deliberate channels remain, zero DOM writes on unchanged refresh, and one write per value node on a real +$25/oz change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6358d5e2589827192ce6242d56d17180bca6bbc8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->