### PR TITLE
perf(home): visibility-aware 90s refresh + freshness ticker (stop hidden-tab work)

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -44,6 +44,7 @@ import { animatePrice } from '../lib/price-motion.js';
 import { copyWithToast } from '../lib/copy-toast.js';
 import { mountQuickConvertWidget } from '../components/QuickConvertWidget.js';
 import { initSwUpdateToast } from '../lib/sw-update-toast.js';
+import { startVisibilityAwareRefresh } from '../lib/visibility-refresh.js';
 import { showDataStatusBanner, hideDataStatusBanner } from '../lib/data-status-banner.js';
 import { mountSkeleton } from '../components/skeleton.js';
 import { clear, el, safeHref } from '../lib/safe-dom.js';
@@ -96,8 +97,8 @@ let goldIsFallback = null;
 let goldProviderId = 'primary-provider';
 let _realtimeSnapshot = null;
 let _realtimeEngine = null;
-let _refreshTimer = null;
-let _freshnessTimer = null;
+let _refreshController = null;
+let _freshnessController = null;
 let _quickConvert = null;
 const _sessionPriceHistory = []; // [{price, ts}] — rolling 120-point window for sparkline
 let _homeChart = null; // GoldChart instance for the home-chart section
@@ -344,13 +345,15 @@ function freshnessAgeClass(ageMs) {
 
 /** Tick the freshness timestamp display every second.
  * DOM is only mutated when the displayed text or color class would change,
- * keeping CPU/battery impact minimal on mobile devices.
+ * keeping CPU/battery impact minimal on mobile devices. Visibility-aware: the
+ * ticker pauses while the tab is hidden (nobody sees the label) and repaints
+ * immediately on return to visible via `startVisibilityAwareRefresh`.
  */
 function startFreshnessTimer() {
-  if (_freshnessTimer) clearInterval(_freshnessTimer);
+  _freshnessController?.stop();
   let prevHlcText = '';
   let prevKstripText = '';
-  _freshnessTimer = setInterval(() => {
+  const tick = () => {
     if (!goldPrice || !goldUpdatedAt) return;
     const { ageText, statusText, sourceText, key } = getFreshnessMeta();
     const ageClass = freshnessAgeClass(getLiveFreshness({ updatedAt: goldUpdatedAt, lang }).ageMs);
@@ -373,7 +376,8 @@ function startFreshnessTimer() {
     // Keep the nav pill dot honest as age crosses live→amber→stale thresholds.
     const pillEl = _navPill || document.getElementById('nav-price-pill');
     if (pillEl) updateNavPillDot(pillEl);
-  }, 1_000);
+  };
+  _freshnessController = startVisibilityAwareRefresh(tick, { intervalMs: 1_000 });
 }
 
 // ── Render hero live card ──────────────────────────────────────────────────
@@ -2045,12 +2049,18 @@ async function init() {
   initRealtimeEngine();
   fetchLiveData();
 
-  // FX auto-refresh + canonical re-read (gold liveness handled by realtime engine)
-  if (_refreshTimer) clearInterval(_refreshTimer);
-  _refreshTimer = setInterval(() => {
-    seedCanonicalPrice();
-    fetchLiveData();
-  }, CONSTANTS.GOLD_REFRESH_MS);
+  // FX auto-refresh + canonical re-read (gold liveness handled by realtime engine).
+  // Visibility-aware (same shared helper as market/dubai/shops/invest): the 90 s
+  // cadence pauses while the tab is hidden and runs one immediate catch-up
+  // refresh when the tab returns to visible, so hidden tabs never keep fetching.
+  _refreshController?.stop();
+  _refreshController = startVisibilityAwareRefresh(
+    () => {
+      seedCanonicalPrice();
+      fetchLiveData();
+    },
+    { intervalMs: CONSTANTS.GOLD_REFRESH_MS }
+  );
 
   // Tick the "Updated X sec/min ago" label every second without a full price re-fetch.
   startFreshnessTimer();
@@ -2062,14 +2072,10 @@ async function init() {
   window.addEventListener(
     'pagehide',
     () => {
-      if (_refreshTimer) {
-        clearInterval(_refreshTimer);
-        _refreshTimer = null;
-      }
-      if (_freshnessTimer) {
-        clearInterval(_freshnessTimer);
-        _freshnessTimer = null;
-      }
+      _refreshController?.stop();
+      _refreshController = null;
+      _freshnessController?.stop();
+      _freshnessController = null;
       if (_realtimeEngine) {
         _realtimeEngine.stop();
         _realtimeEngine = null;

--- a/tests/e2e/home-visibility-guard.spec.js
+++ b/tests/e2e/home-visibility-guard.spec.js
@@ -1,0 +1,205 @@
+// @ts-check
+/**
+ * Homepage visibility guard (Verified Work Queue item 20 — HOME half).
+ *
+ * Regression lock: hidden tabs must NOT keep the homepage's 90 s
+ * `seedCanonicalPrice()+fetchLiveData()` refresh interval nor the 1 s
+ * freshness-label ticker alive. Both now run through the shared
+ * `startVisibilityAwareRefresh` helper (`src/lib/visibility-refresh.js`):
+ *   - tab hidden  → the interval is cleared (no background fetches / DOM churn)
+ *   - tab visible → one immediate catch-up refresh, then the cadence restarts
+ *
+ * Determinism (no 90 s waits, no arbitrary sleeps):
+ *   - An init script wraps `setInterval`/`clearInterval` so the test can assert
+ *     the exact lifecycle of the 90 000 ms and 1 000 ms home intervals.
+ *   - Page visibility is emulated by overriding `document.hidden` /
+ *     `document.visibilityState` and dispatching `visibilitychange`
+ *     (`dispatchEvent` runs listeners synchronously, so every assertion about
+ *     "what the handler did" is made inside a single synchronous
+ *     `page.evaluate` block — no interleaving with the realtime engine's
+ *     macrotask-scheduled polls is possible).
+ *   - The visible-catch-up fetch is attributed by tagging fetches initiated
+ *     *synchronously during* the `visibilitychange` dispatch: the canonical
+ *     seed's call chain (`seedCanonicalPrice → getCanonicalSpot(force) →
+ *     fetchGold → fetchWithTimeout → fetch('/data/gold_price.json?t=…')`)
+ *     invokes `fetch` with no intervening timer/await suspension, while the
+ *     untouched realtime engine schedules its visibility-recovery poll via
+ *     `setTimeout` and therefore can never be mis-attributed.
+ *
+ * The realtime engine's own `setVisibility` handling (home.js
+ * `initRealtimeEngine`) is intentionally NOT asserted here — it predates this
+ * guard and keeps its behavior.
+ */
+const { test, expect } = require('@playwright/test');
+
+const REFRESH_MS = 90_000; // CONSTANTS.GOLD_REFRESH_MS (owner-gated constant, read-only)
+const TICKER_MS = 1_000; // freshness-label ticker cadence in home.js
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    // Interval registry: every setInterval registration on the page, with its
+    // delay and live/cleared state. clearInterval marks the record inactive
+    // and still clears the real timer.
+    const registry = [];
+    // @ts-ignore - test instrumentation
+    window.__gtlIntervals = registry;
+    const origSetInterval = window.setInterval.bind(window);
+    const origClearInterval = window.clearInterval.bind(window);
+    // @ts-ignore
+    window.setInterval = function (fn, delay, ...args) {
+      const id = origSetInterval(fn, delay, ...args);
+      registry.push({ id, delay: Number(delay), active: true });
+      return id;
+    };
+    // @ts-ignore
+    window.clearInterval = function (id) {
+      const rec = registry.find((r) => r.id === id && r.active);
+      if (rec) rec.active = false;
+      return origClearInterval(id);
+    };
+
+    // Fetch log: URL + the synchronous attribution tag active at call time.
+    const fetchLog = [];
+    // @ts-ignore
+    window.__gtlFetchLog = fetchLog;
+    const origFetch = window.fetch.bind(window);
+    // @ts-ignore
+    window.fetch = function (input, init) {
+      const url = typeof input === 'string' ? input : (input && input.url) || String(input);
+      // @ts-ignore
+      fetchLog.push({ url, tag: window.__gtlTag || null });
+      return origFetch(input, init);
+    };
+
+    // Visibility emulation: shadow the Document.prototype getters on the
+    // instance and fire visibilitychange synchronously.
+    // @ts-ignore
+    window.__gtlSetVisibility = function (hidden) {
+      Object.defineProperty(document, 'hidden', {
+        configurable: true,
+        get: () => hidden,
+      });
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => (hidden ? 'hidden' : 'visible'),
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+    };
+  });
+});
+
+/** Wait until the canonical seed has populated the nav pill (goldPrice set). */
+async function waitForSeed(page) {
+  await page.waitForFunction(() => {
+    const xau = document.querySelector('[data-nav-xau]');
+    return !!xau && /\$\s?\d/.test(xau.textContent || '');
+  });
+  // state:'attached' — the dot span can be display-hidden at some viewports,
+  // but the freshness tick still rewrites its classes.
+  await page.waitForSelector('.nav-price-pill__dot', { state: 'attached' });
+}
+
+function intervalSnapshot(page) {
+  return page.evaluate(
+    ([refreshMs, tickerMs]) => {
+      // @ts-ignore
+      const all = window.__gtlIntervals;
+      return {
+        activeRefresh: all.filter((r) => r.delay === refreshMs && r.active).length,
+        activeTicker: all.filter((r) => r.delay === tickerMs && r.active).length,
+      };
+    },
+    [REFRESH_MS, TICKER_MS]
+  );
+}
+
+async function runGuardScenario(page, path) {
+  await page.goto(path, { waitUntil: 'load' });
+  await waitForSeed(page);
+
+  // 1. Visible baseline: exactly one live 90 s refresh interval and the 1 s
+  //    freshness ticker are running.
+  const visible = await intervalSnapshot(page);
+  expect(visible.activeRefresh, '90s refresh interval runs while visible').toBe(1);
+  expect(visible.activeTicker, '1s freshness ticker runs while visible').toBe(1);
+
+  // 2. Hide the tab: both intervals must be cleared synchronously by the
+  //    visibilitychange handlers (assertion made in the same evaluate — no
+  //    other page task can interleave).
+  const afterHide = await page.evaluate(
+    ([refreshMs, tickerMs]) => {
+      // @ts-ignore
+      window.__gtlSetVisibility(true);
+      // @ts-ignore
+      const all = window.__gtlIntervals;
+      return {
+        activeRefresh: all.filter((r) => r.delay === refreshMs && r.active).length,
+        activeTicker: all.filter((r) => r.delay === tickerMs && r.active).length,
+      };
+    },
+    [REFRESH_MS, TICKER_MS]
+  );
+  expect(afterHide.activeRefresh, 'hidden tab clears the 90s refresh interval').toBe(0);
+  expect(afterHide.activeTicker, 'hidden tab clears the 1s freshness ticker').toBe(0);
+
+  // 3. Return to visible: synchronously during the dispatch we must observe
+  //    (a) the catch-up canonical fetch, (b) an immediate freshness repaint
+  //    (nav pill dot classes rewritten), and (c) both intervals restarted.
+  const afterShow = await page.evaluate(
+    ([refreshMs, tickerMs]) => {
+      const dot = document.querySelector('.nav-price-pill__dot');
+      if (!dot) return { error: 'nav pill dot missing' };
+      // Sentinels: the freshness tick's updateNavPillDot() removes all three
+      // modifier classes and re-adds at most one, so if the tick ran, at most
+      // one of these survives.
+      dot.classList.add('gtl-dot--cached', 'gtl-dot--stale', 'gtl-dot--fallback');
+
+      // @ts-ignore
+      const fetchLog = window.__gtlFetchLog;
+      // @ts-ignore
+      window.__gtlTag = 'visible-dispatch';
+      // @ts-ignore
+      window.__gtlSetVisibility(false);
+      // @ts-ignore
+      window.__gtlTag = null;
+
+      const catchupGoldFetches = fetchLog.filter(
+        (f) => f.tag === 'visible-dispatch' && f.url.includes('/data/gold_price.json')
+      ).length;
+      const sentinelsLeft = ['gtl-dot--cached', 'gtl-dot--stale', 'gtl-dot--fallback'].filter((c) =>
+        dot.classList.contains(c)
+      ).length;
+      // @ts-ignore
+      const all = window.__gtlIntervals;
+      return {
+        error: null,
+        catchupGoldFetches,
+        sentinelsLeft,
+        activeRefresh: all.filter((r) => r.delay === refreshMs && r.active).length,
+        activeTicker: all.filter((r) => r.delay === tickerMs && r.active).length,
+      };
+    },
+    [REFRESH_MS, TICKER_MS]
+  );
+  expect(afterShow.error).toBeNull();
+  expect(
+    afterShow.catchupGoldFetches,
+    'returning to visible fires one immediate canonical catch-up fetch'
+  ).toBe(1);
+  expect(
+    afterShow.sentinelsLeft,
+    'freshness label/dot repaints immediately on return to visible'
+  ).toBeLessThanOrEqual(1);
+  expect(afterShow.activeRefresh, '90s refresh interval restarts, exactly once').toBe(1);
+  expect(afterShow.activeTicker, '1s freshness ticker restarts, exactly once').toBe(1);
+}
+
+test.describe('home visibility guard — hidden tabs stop fetching', () => {
+  test('EN: 90s refresh + 1s ticker pause while hidden, catch up on return', async ({ page }) => {
+    await runGuardScenario(page, '/');
+  });
+
+  test('AR: same guard behavior on the Arabic homepage', async ({ page }) => {
+    await runGuardScenario(page, '/?lang=ar');
+  });
+});


### PR DESCRIPTION
Campaign queue item 20, home half (audit F, medium) — the homepage's 90-second FX/canonical refresh ran with no visibility guard, so hidden tabs kept fetching forever, and the 1-second freshness ticker kept repainting a label nobody could see.

## What

`src/pages/home.js` routes both timers through the repo's **existing** tested helper `startVisibilityAwareRefresh` (`src/lib/visibility-refresh.js`) — pause on hidden, one immediate catch-up + restart on return to visible:

- The 90s `seedCanonicalPrice()` + `fetchLiveData()` interval (was `home.js:2050`, unguarded).
- The 1s freshness-label ticker (pauses hidden; repaints immediately on visible).

**Deliberate deviation from the audit's suggested body-guard flag, for consistency:** discovery showed this exact problem already has one blessed implementation used by market/dubai/shops/invest (e.g. `market.js:285`, `invest.js:1303`) with equivalent inline semantics in calculator/portfolio/compare/heatmap — home was the *only* unguarded snapshot surface, and the helper's docstring already names the homepage family. A bespoke flag variant would have been a ninth pattern with semantics found nowhere else. The realtime engine's own visibility handling (`home.js:1734`) is untouched; visible-tab cadence is unchanged; zero new strings. The tracker half of item 20 stays a separate slice (its files are owned by open PR #688).

New `tests/e2e/home-visibility-guard.spec.js` (EN + AR): deterministic via an `addInitScript` setInterval/clearInterval registry + synchronous visibilitychange dispatch — asserts hidden clears both intervals synchronously, return-to-visible fires exactly one synchronous catch-up `gold_price.json` fetch (tag-attributed, race-free vs the engine's macrotask polls), repaints the freshness dot immediately, and restarts exactly one 90s + one 1s interval. No product test hooks, no constants.js changes, no sleeps.

## Proof

- Reproduced 2/2 on unmodified main: both intervals stayed active while hidden; manually invoking the captured 90s callback while hidden fired a real fetch; the 1s tick kept rewriting nav-pill dot classes. The committed spec **fails 2/2 on the baseline dist** at "hidden tab clears the 90s refresh interval" — detection proven.
- Agent gates: lint / quality / validate PASS, tests **1656/1656**, build PASS, spec 8/8 across two full runs.
- Coordinator reproduction: independent spec run 4/4 (with `--repeat-each=2`).
- Honesty note on method: visibility was emulated at the JS level (property override + dispatched event); the true 90s cadence and OS-level tab throttling were established via interval-state + manual tick rather than waiting 90 real seconds.

## Risks

Behavior change is confined to hidden tabs (no fetches, no label repaints) and the moment of return (one catch-up refresh — which home effectively already did via the engine's visibility recovery). Visible-tab behavior is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmAnRRP9o3xYAdqxggP62U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is limited to hidden-tab polling and DOM ticks plus one catch-up on focus; visible-tab cadence and the realtime engine are unchanged.
> 
> **Overview**
> **Stops background work on the homepage when the tab is hidden** by routing the two previously unguarded timers through the shared `startVisibilityAwareRefresh` helper (same pattern as market/dubai/shops/invest).
> 
> The **90s** `seedCanonicalPrice()` + `fetchLiveData()` loop and the **1s** freshness label/nav-pill ticker no longer run while `document.hidden`; returning to visible triggers **one immediate catch-up** refresh/tick, then restarts the cadence. Timer handles are replaced with stoppable controllers cleaned up on `pagehide`. The realtime pricing engine’s visibility behavior is **unchanged**.
> 
> Adds **`tests/e2e/home-visibility-guard.spec.js`** (EN `/` and AR `/?lang=ar`) to lock interval lifecycle and synchronous catch-up canonical fetch on tab show.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d54c5ad6fb4b293d6e2d26f9e6ded4c07fd6d7c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->