### PR TITLE
refactor(motion): remove 4 dead keyframes with zero consumers (P08)

### DIFF
--- a/styles/partials/motion-advanced.css
+++ b/styles/partials/motion-advanced.css
@@ -170,57 +170,10 @@
   }
 }
 
-/* ── Slide-in from start (used for stat values) ── */
-@keyframes slide-in-start {
-  from {
-    opacity: 0;
-    transform: translateX(-16px);
-  }
-
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-/* ── Fade-scale for modal/card entries ── */
-@keyframes fade-scale-in {
-  from {
-    opacity: 0;
-    transform: scale(0.94);
-  }
-
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-/* ── Gold shimmer sweep (applied to price values on update) ── */
-@keyframes gold-sweep {
-  0% {
-    background-position: -200% center;
-  }
-
-  100% {
-    background-position: 200% center;
-  }
-}
-
-/* ── Entrance for home section headings on scroll ── */
-@keyframes heading-reveal {
-  from {
-    opacity: 0;
-    transform: translateY(12px);
-    letter-spacing: 0.05em;
-  }
-
-  to {
-    opacity: 1;
-    transform: none;
-    letter-spacing: inherit;
-  }
-}
+/* P08 (design overhaul): removed 4 keyframes that had no consumers anywhere in
+   styles/, src/, or HTML — slide-in-start, fade-scale-in, gold-sweep,
+   heading-reveal. gold-sweep also animated background-position (banned:
+   transform/opacity only). Re-add only together with a real consumer. */
 
 /* ── Stagger variants with deeper initial offset ── */
 [data-stagger='deep'] > * {


### PR DESCRIPTION
## Summary

Design-overhaul phase **P08** (see `docs/plans/2026-07-12_design-overhaul-30-phase-execution.md` on the overhaul branch): deletes the 4 `@keyframes` in `styles/partials/motion-advanced.css` that have **zero consumers** anywhere in `styles/`, `src/`, or the committed HTML — `slide-in-start`, `fade-scale-in`, `gold-sweep`, `heading-reveal`. They were declared in the Phase 45 animation pass but never wired to a selector.

`gold-sweep` additionally animated `background-position`, which the motion guardrails ban (transform/opacity only) — so wiring it was never an option. A tombstone comment marks the removal so these only return together with a real consumer.

## Implementation notes

- One file, deletion-only (plus the tombstone comment). `card-lift-in` and every other keyframe with real consumers is untouched.
- Consumer check: `grep -rn 'slide-in-start\|fade-scale-in\|gold-sweep\|heading-reveal' styles/ src/ *.html` → only the definitions themselves (now only the tombstone comment).

## Checklist
- [x] `npm ci` and lint/stylelint (pre-commit hook: stylelint --fix + prettier, clean)
- [x] `npm run build` ✓ (CSS parse gate)
- [x] `npm test` → **1647 pass / 0 fail**
- [ ] Playwright smoke — covered by CI (`Audit assets, run Playwright` job); no runtime behavior changed (dead code removal)

## Gold provider bakeoff checklist

N/A — presentation-layer CSS only; no provider adapters, bakeoff scripts, X guard, or price workflows touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcgWLq66a6WomJbgwEuZ9Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcgWLq66a6WomJbgwEuZ9Z)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only dead CSS with no consumers; no auth, data, or live UI behavior changes.
> 
> **Overview**
> **P08 design-overhaul cleanup** in `styles/partials/motion-advanced.css`: removes four `@keyframes` blocks (`slide-in-start`, `fade-scale-in`, `gold-sweep`, `heading-reveal`) that were never referenced by any selector in styles, `src/`, or HTML.
> 
> A short tombstone comment documents the removal and notes that `gold-sweep` used `background-position`, which conflicts with the project’s transform/opacity-only motion rules. **No runtime animation behavior changes** — `card-lift-in` and all wired keyframes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b7f808aeab7887e68f75f21fc6b04a7d07c7b69. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->