### PR TITLE
refactor(tracker): tokenize the SVG fallback chart colours — zero visual change (P05)

### DIFF
--- a/src/tracker/chart.js
+++ b/src/tracker/chart.js
@@ -179,7 +179,8 @@ export function renderChart() {
     t.setAttribute('x', '50%');
     t.setAttribute('y', '50%');
     t.setAttribute('text-anchor', 'middle');
-    t.setAttribute('fill', '#9d8c72');
+    // SVG presentation attributes can't hold var(); the style attribute can.
+    t.setAttribute('style', 'fill: var(--chart-axis-text, #9d8c72)');
     t.setAttribute('font-size', '14');
     t.textContent = msg;
     _el.chart.replaceChildren(t);
@@ -224,10 +225,14 @@ export function renderChart() {
     // defs: gradient
     const defs = svgEl('defs', {});
     const grad = svgEl('linearGradient', { id: gradientId, x1: '0', y1: '0', x2: '0', y2: '1' });
-    const stop1 = svgEl('stop', { offset: '0%', 'stop-color': '#b08a3e', 'stop-opacity': '0.18' });
+    const stop1 = svgEl('stop', {
+      offset: '0%',
+      style: 'stop-color: var(--chart-line, #b08a3e)',
+      'stop-opacity': '0.18',
+    });
     const stop2 = svgEl('stop', {
       offset: '100%',
-      'stop-color': '#b08a3e',
+      style: 'stop-color: var(--chart-line, #b08a3e)',
       'stop-opacity': '0.01',
     });
     grad.append(stop1, stop2);
@@ -244,7 +249,7 @@ export function renderChart() {
           y1: yPos.toFixed(1),
           x2: String(W),
           y2: yPos.toFixed(1),
-          stroke: 'rgba(196,154,68,0.12)',
+          style: 'stroke: var(--chart-grid, rgba(196, 154, 68, 0.12))',
           'stroke-width': '1',
           'stroke-dasharray': '4 6',
         }),
@@ -253,7 +258,7 @@ export function renderChart() {
           {
             x: '6',
             y: (yPos - 4).toFixed(1),
-            fill: '#9d8c72',
+            style: 'fill: var(--chart-axis-text, #9d8c72)',
             'font-size': '10',
             'font-family': 'system-ui, sans-serif',
           },
@@ -277,7 +282,7 @@ export function renderChart() {
             x: x.toFixed(1),
             y: String(H - 4),
             'text-anchor': i === 0 ? 'start' : i === dateLabelCount - 1 ? 'end' : 'middle',
-            fill: '#9d8c72',
+            style: 'fill: var(--chart-axis-text, #9d8c72)',
             'font-size': '10',
             'font-family': 'system-ui, sans-serif',
           },
@@ -299,7 +304,7 @@ export function renderChart() {
       svgEl('polyline', {
         points: pts,
         fill: 'none',
-        stroke: '#b08a3e',
+        style: 'stroke: var(--chart-line, #b08a3e)',
         'stroke-width': '2.5',
         'stroke-linejoin': 'round',
         'stroke-linecap': 'round',
@@ -314,7 +319,7 @@ export function renderChart() {
           x: String(W - 6),
           y: String(H - 4),
           'text-anchor': 'end',
-          fill: '#9d8c72',
+          style: 'fill: var(--chart-axis-text, #9d8c72)',
           'font-size': '10',
           'font-family': 'system-ui, sans-serif',
           opacity: '0.7',

--- a/styles/partials/tokens.css
+++ b/styles/partials/tokens.css
@@ -395,6 +395,16 @@
 
   --font-numeric-features:
     'tnum' 1, 'lnum' 1, 'zero' 1; /* tabular + lining + slashed-zero — the data voice, zero new font bytes */
+
+  /* ── Chart tokens (P05, design overhaul) — the tracker SVG fallback chart ──
+     Values are IDENTICAL to the literals previously hardcoded in
+     src/tracker/chart.js, so this is zero visual change. Defined once in :root
+     (not re-declared per theme) because the chart intentionally rendered the
+     same in both themes before; per-theme tuning is a later, visual-gated
+     decision — change these only with before/after screenshots. */
+  --chart-line: #b08a3e; /* price polyline + gradient stop colour */
+  --chart-grid: rgb(196 154 68 / 12%); /* horizontal gridlines */
+  --chart-axis-text: #9d8c72; /* axis/date/source labels + collecting-data note */
 }
 
 /* ═══════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Design-overhaul phase **P05**: the tracker's first-paint SVG chart hardcoded **8 colour literals** in `src/tracker/chart.js` (`#b08a3e` price line + both gradient stops, `rgba(196,154,68,.12)` gridlines, `#9d8c72` on 4 text labels). That's debt #3 of the overhaul audit (raw hex outside `tokens.css`) and a blocker for any future chart theming.

This PR adds three tokens to `styles/partials/tokens.css` — `--chart-line`, `--chart-grid`, `--chart-axis-text` — with values **identical** to the old literals, and switches `chart.js` to consume them.

## Implementation notes

- SVG **presentation attributes can't hold `var()`**, so the colours move into the SVG `style` attribute: `style="stroke: var(--chart-line, #b08a3e)"`. The old literal remains as the `var()` fallback — even with no stylesheet the chart renders identically.
- Tokens are defined once in `:root` (not per-theme): the chart intentionally rendered the same in both themes before, and preserving that is the zero-change contract. Per-theme tuning stays a later, visual-gated decision (flagged in the token comment).
- No pricing, data, or freshness logic touched; attribute→style colour plumbing only.

## Verification

- **Browser (chromium vs built dist):** computed styles of SVG nodes built exactly as the new code builds them resolve to `rgb(176, 138, 62)` / `rgba(196, 154, 68, 0.12)` / `rgb(157, 140, 114)` — byte-identical to the old literals (tokens confirmed present in the built CSS: `--chart-line: #b08a3e`, `--chart-grid: #c49a441f`, `--chart-axis-text: #9d8c72`). **VALUE-IDENTITY: PASS.**
- Honest scope note: a full in-page tracker chart render wasn't reproducible in the headless sandbox this session (pre-existing environment limitation, consistent with the note in #672); the proof above tests the exact node/style shapes the code now emits, against the real built stylesheet.

## Checklist
- [x] `npm ci`, eslint + stylelint (pre-commit hook) clean
- [x] `npm run build` ✓
- [x] `npm test` → **1647 pass / 0 fail**
- [ ] Playwright smoke — CI runs the full matrix; no behavioral change expected (value-identical colours)

## Gold provider bakeoff checklist

N/A — presentation-layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcgWLq66a6WomJbgwEuZ9Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcgWLq66a6WomJbgwEuZ9Z)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only colour plumbing in the SVG chart renderer; no pricing, data, or freshness logic changes.
> 
> **Overview**
> Moves the tracker’s first-paint **SVG fallback chart** off eight hardcoded gold/axis colours and onto three design tokens in `tokens.css`: `--chart-line`, `--chart-grid`, and `--chart-axis-text`, with values matching the old literals so appearance stays the same.
> 
> Because SVG presentation attributes don’t resolve `var()`, `chart.js` now sets colours on the `style` attribute (e.g. `stroke` / `fill` / `stop-color`) with `var(--token, <old literal>)` fallbacks so the chart still looks correct if tokens are missing. Tokens live only on `:root` (not per dark theme) to preserve the prior “same chart in both themes” behaviour; per-theme chart tuning is explicitly deferred.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05551f961f9d8a2a62a69fa880c4faa217e7c1de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->